### PR TITLE
docs: add diff CLI output examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Full flags and behavior: [docs/CLI.md](docs/CLI.md).
 
 - Debug a **failed tool call** or thrown error in a support or ops agent.
 - See **which step dominated latency** in a multi-step planner or RAG pipeline.
-- **Diff two runs** after a prompt, model, or routing change.
+- **Diff two runs** after a prompt, model, or routing change (see [diff examples](docs/DIFF.md)).
 - Point **`logs`** / **`tail`** at existing job or service logs to get a **local execution view** without shipping data upstream.
 - **Export** a run to Markdown for a PR, postmortem, or internal thread — then review before sharing.
 - Keep traces **on disk** while still using enterprise observability elsewhere.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -196,6 +196,53 @@ Options:
 - `--focus <all|errors|structure|outputs>`
 - `--check <all|structure|outputs|errors|timing>`
 
+Fixture examples:
+
+```bash
+agent-inspect diff minimal-success minimal-error --dir fixtures/traces
+agent-inspect diff minimal-success long-running --dir fixtures/traces --check timing --duration-threshold 1ms
+agent-inspect diff minimal-success nested-3-levels --dir fixtures/traces --check structure --ignore-duration
+```
+
+**Simplified example output** (actual CLI formatting may differ slightly):
+
+```text
+Run diff
+Left:  minimal-success
+Right: minimal-error
+
+Summary:
+  Differences: 4
+  Errors: 0
+  Warnings: 3
+  Info: 1
+
+First divergence:
+  run-status at (run)
+    left: success
+    right: error
+
+Differences:
+  [warning] run-status
+    Run completion status differs
+    left: success
+    right: error
+  [info] duration
+    Run duration differs
+    left: 120
+    right: 70
+  [warning] step-removed plan
+    Step only in left run: plan
+    left: step_root
+    right: (undefined)
+  [warning] step-added failing-step
+    Step only in right run: failing-step
+    left: (undefined)
+    right: step_fail
+```
+
+More examples, including timing-only and structure-only diffs, are in `docs/DIFF.md`.
+
 ## 7. Optional TUI behavior
 
 `view --tui` delegates to `@agent-inspect/tui` and requires an interactive terminal. If the package is not installed, the CLI prints a short install hint.

--- a/docs/DIFF.md
+++ b/docs/DIFF.md
@@ -8,4 +8,131 @@ AgentInspect can compare two runs (manual traces) locally and render a diff summ
 Notes:
 - Programmatic diff APIs are documented as **experimental** in `docs/API.md`.
 - `diff` is read-only and does **not** rerun agents; “differences” do not necessarily imply failure (command errors do).
+- `diff` reads local trace files only. It is useful for local debugging, but it is not production APM or hosted observability.
 
+## CLI examples
+
+The examples below use the checked-in fixture traces, so they are safe to copy and run locally:
+
+```bash
+agent-inspect diff minimal-success minimal-error --dir fixtures/traces
+agent-inspect diff minimal-success long-running --dir fixtures/traces --check timing --duration-threshold 1ms
+agent-inspect diff minimal-success nested-3-levels --dir fixtures/traces --check structure --ignore-duration
+```
+
+If you are running from a source checkout before installing the package globally, use the built CLI path instead:
+
+```bash
+node packages/cli/dist/index.cjs diff minimal-success minimal-error --dir fixtures/traces
+```
+
+### Success run vs error run
+
+This compares a successful run with a run that ended in an error. It shows the run status change, a duration difference, and the step-level structure difference (`plan` removed, `failing-step` added).
+
+**Simplified example output** (actual CLI formatting may differ slightly):
+
+```text
+Run diff
+Left:  minimal-success
+Right: minimal-error
+
+Summary:
+  Differences: 4
+  Errors: 0
+  Warnings: 3
+  Info: 1
+
+First divergence:
+  run-status at (run)
+    left: success
+    right: error
+
+Differences:
+  [warning] run-status
+    Run completion status differs
+    left: success
+    right: error
+  [info] duration
+    Run duration differs
+    left: 120
+    right: 70
+  [warning] step-removed plan
+    Step only in left run: plan
+    left: step_root
+    right: (undefined)
+  [warning] step-added failing-step
+    Step only in right run: failing-step
+    left: (undefined)
+    right: step_fail
+```
+
+### Duration-only timing check
+
+Use `--check timing` when you only want timing differences. `--duration-threshold` can hide tiny deltas.
+
+```bash
+agent-inspect diff minimal-success long-running --dir fixtures/traces --check timing --duration-threshold 1ms
+```
+
+**Simplified example output**:
+
+```text
+Run diff
+Left:  minimal-success
+Right: long-running
+
+Summary:
+  Differences: 1
+  Errors: 0
+  Warnings: 0
+  Info: 1
+
+First divergence:
+  duration at (run)
+    left: 120
+    right: 45
+
+Differences:
+  [info] duration
+    Run duration differs
+    left: 120
+    right: 45
+```
+
+### Step structure / rename-style changes
+
+When a prompt, model, or routing change renames or restructures steps, the current diff output represents that as `step-removed` plus `step-added`. Use `--ignore-duration` if the structure is what matters.
+
+```bash
+agent-inspect diff minimal-success nested-3-levels --dir fixtures/traces --check structure --ignore-duration
+```
+
+**Simplified example output**:
+
+```text
+Run diff
+Left:  minimal-success
+Right: nested-3-levels
+
+Summary:
+  Differences: 2
+  Errors: 0
+  Warnings: 2
+  Info: 0
+
+First divergence:
+  step-removed at plan
+    left: step_root
+    right: (undefined)
+
+Differences:
+  [warning] step-removed plan
+    Step only in left run: plan
+    left: step_root
+    right: (undefined)
+  [warning] step-added outer
+    Step only in right run: outer
+    left: (undefined)
+    right: step_outer
+```


### PR DESCRIPTION
## Summary
- Add copy-pasteable `agent-inspect diff` fixture commands to `docs/DIFF.md` and `docs/CLI.md`
- Include simplified output blocks for success-vs-error, timing-only, and structure/rename-style diffs
- Link the README workflow bullet to the expanded diff examples

Closes #8.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `node packages/cli/dist/index.cjs diff minimal-success minimal-error --dir fixtures/traces`
- `node packages/cli/dist/index.cjs diff minimal-success long-running --dir fixtures/traces --check timing --duration-threshold 1ms`
- `node packages/cli/dist/index.cjs diff minimal-success nested-3-levels --dir fixtures/traces --check structure --ignore-duration`
- `pnpm run typecheck`
- `pnpm run test` (82 files / 674 tests passed)
