### PR TITLE
docs(examples): add Winston JSON logs recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage
 !fixtures/logs/*.log
 !examples/06-log-to-tree/*.log
 !examples/recipes/proactive-agent-logs/*.log
+!examples/recipes/winston-json-logs/*.log
 .DS_Store
 .turbo
 .pnpm-debug.log*

--- a/docs/LOGGING-PLAYBOOK.md
+++ b/docs/LOGGING-PLAYBOOK.md
@@ -56,7 +56,20 @@ Config highlights: `timestampKey: "time"`, `messageKey: "msg"`.
 - Fixture: `fixtures/logs/pino-agent-json.log`
 - Config: `fixtures/configs/pino-agent-inspect.logs.json`
 
-## 5. log4js JSON layout example
+## 5. Winston structured logging example
+
+Winston JSON lines commonly use string `level`, ISO `timestamp`, and `message`:
+
+```json
+{"level":"info","timestamp":"2026-05-08T10:00:18.130Z","message":"Agent run started","runId":"winston_run_01","event":"agent.run.started"}
+{"level":"info","timestamp":"2026-05-08T10:00:18.402Z","runId":"winston_run_01","event":"tool.search.completed","tool":"searchDocs","durationMs":270,"message":"Tool search completed"}
+```
+
+Config highlights: `timestampKey: "timestamp"`, `messageKey: "message"`, `levelKey: "level"`.
+
+- Recipe: `examples/recipes/winston-json-logs/`
+
+## 6. log4js JSON layout example
 
 Text prefix + **valid JSON** payload (one object per line):
 
@@ -70,7 +83,7 @@ Use `--format log4js`. Do not log JS object literals.
 - Fixture: `fixtures/logs/log4js-agent-json.log`
 - Config: `fixtures/configs/log4js-agent-inspect.logs.json`
 
-## 6. NestJS structured logging example
+## 7. NestJS structured logging example
 
 Nest JSON lines often use `message` and ISO `timestamp`:
 
@@ -84,7 +97,7 @@ Config highlights: `messageKey: "message"`, `timestampKey: "timestamp"`.
 - Fixture: `fixtures/logs/nestjs-agent-json.log`
 - Config: `fixtures/configs/nestjs-agent-inspect.logs.json`
 
-## 7. Run `agent-inspect logs`
+## 8. Run `agent-inspect logs`
 
 ```bash
 pnpm build
@@ -107,7 +120,7 @@ node packages/cli/dist/index.cjs logs fixtures/logs/nestjs-agent-json.log \
 
 Flags: `--run-id-key`, `--event-key`, `--warnings`, `--json` (see `docs/CLI.md`).
 
-## 8. Run `agent-inspect tail`
+## 9. Run `agent-inspect tail`
 
 Live local tail (developer machine only—not a production monitor):
 
@@ -121,7 +134,7 @@ node packages/cli/dist/index.cjs tail \
 
 Omit `--once` to follow append-only files; use stdin with `--file -` when piping.
 
-## 9. Redaction recommendations
+## 10. Redaction recommendations
 
 - Add `redact` rules in `agent-inspect.logs.json` for keys you may log (`authorization`, `token`, `apiKey`, `password`, `secret`, `email`).
 - Prefer **prefix** or **hash** strategies for correlation ids (`userUuid`, `tripUuid`) instead of full values in shared logs.
@@ -130,7 +143,7 @@ Omit `--once` to follow append-only files; use stdin with `--file -` when piping
 
 Default conservative keys ship in recipe configs; extend per your schema.
 
-## 10. Unsupported patterns
+## 11. Unsupported patterns
 
 Do **not** rely on AgentInspect for:
 
@@ -143,7 +156,7 @@ Do **not** rely on AgentInspect for:
 | Vendor live tail / upload sinks | Out of scope for core |
 | Full prompt/output in every line | Use `metadata-only` logging; previews opt-in |
 
-Runnable framework recipes live under `examples/recipes/` (pino JSON logs, log4js JSON layout, NestJS structured logging). See [examples/recipes/README.md](../examples/recipes/README.md).
+Runnable framework recipes live under `examples/recipes/` (pino JSON logs, Winston JSON logs, log4js JSON layout, NestJS structured logging). See [examples/recipes/README.md](../examples/recipes/README.md).
 
 ## See also
 

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -39,6 +39,7 @@ Use `AGENT_INSPECT_SILENT=true` to suppress live terminal tree output during scr
 | [multi-agent-handoff](multi-agent-handoff) | Coordinator + specialist steps | Nested steps, `metadata` for handoff | yes | no |
 | [proactive-agent-logs](proactive-agent-logs) | Log ingest + tail | `logs`, `tail`, config mapping, redaction | yes (CLI + samples) | no |
 | [pino-json-logs](pino-json-logs) | pino-shaped JSON logs | `logs`, `tail`, `time`/`msg` field mapping | yes (CLI + samples) | no |
+| [winston-json-logs](winston-json-logs) | Winston-shaped JSON logs | `logs`, `tail`, `timestamp`/`message` field mapping | yes (CLI + samples) | no |
 | [log4js-json-layout](log4js-json-layout) | log4js text + embedded JSON | `logs` with `--format log4js` | yes (CLI + samples) | no |
 | [nestjs-json-logging](nestjs-json-logging) | NestJS structured JSON | `logs`, `message`/`timestamp` mapping | yes (CLI + samples) | no |
 | [retry-fallback](retry-fallback) | Primary LLM fails, fallback OK | `step.llm`, error + recovery | yes | no |

--- a/examples/recipes/winston-json-logs/README.md
+++ b/examples/recipes/winston-json-logs/README.md
@@ -1,0 +1,47 @@
+# Recipe: winston-json-logs
+
+## What this demonstrates
+
+**Winston-shaped JSON logs → execution trees** without adding Winston to AgentInspect. Line-delimited JSON uses common Winston field names (`timestamp`, `message`, `level`) plus agent event keys (`runId`, `event`).
+
+## Why this matters
+
+Many Node.js agent services standardize on Winston for structured logs. You can inspect local log files with `agent-inspect logs` / `tail` using a small `agent-inspect.logs.json` mapping—no SaaS sink or core Winston adapter required.
+
+## How to run
+
+```bash
+pnpm build
+cd examples/recipes/winston-json-logs
+pnpm install
+pnpm start
+```
+
+From **repository root**:
+
+```bash
+node packages/cli/dist/index.cjs logs examples/recipes/winston-json-logs/sample-winston.log --format json --config examples/recipes/winston-json-logs/agent-inspect.logs.json
+
+node packages/cli/dist/index.cjs tail --file examples/recipes/winston-json-logs/sample-winston.log --format json --config examples/recipes/winston-json-logs/agent-inspect.logs.json --once
+```
+
+## Expected output
+
+See `expected-output.txt` for marker keywords (`Run winston_run_01`, `tool:search`, `llm:plan`, `confidence`).
+
+## What to look for
+
+- `timestampKey: "timestamp"` (ISO string from `format.timestamp()`).
+- `messageKey: "message"` — not pino's `msg`.
+- `levelKey: "level"` (string levels such as `info`, `warn`, `error`).
+- JSON lines only; no JavaScript object literal log payloads.
+
+## Notes and limitations
+
+- This recipe does **not** install or run Winston. It documents the **log shape** AgentInspect expects.
+- The sample is deterministic fake data only.
+- No vendor upload; local files only.
+
+## Version ownership
+
+Logging recipes pass (v1.x docs/examples).

--- a/examples/recipes/winston-json-logs/agent-inspect.logs.json
+++ b/examples/recipes/winston-json-logs/agent-inspect.logs.json
@@ -1,0 +1,64 @@
+{
+  "runIdKeys": ["runId", "decisionId", "requestId", "reqId"],
+  "eventKey": "event",
+  "timestampKey": "timestamp",
+  "messageKey": "message",
+  "levelKey": "level",
+  "mappings": {
+    "agent.run.started": {
+      "kind": "RUN",
+      "name": "agent:started",
+      "startsRun": true
+    },
+    "tool.search.started": {
+      "kind": "TOOL",
+      "name": "tool:search"
+    },
+    "tool.search.completed": {
+      "kind": "TOOL",
+      "name": "tool:search"
+    },
+    "tool.*.started": {
+      "kind": "TOOL"
+    },
+    "tool.*.completed": {
+      "kind": "TOOL"
+    },
+    "llm.plan.started": {
+      "kind": "LLM",
+      "name": "llm:plan"
+    },
+    "llm.plan.completed": {
+      "kind": "LLM",
+      "name": "llm:plan"
+    },
+    "llm.*.started": {
+      "kind": "LLM"
+    },
+    "llm.*.completed": {
+      "kind": "LLM"
+    },
+    "agent.run.completed": {
+      "kind": "RESULT",
+      "name": "agent:completed"
+    },
+    "*.failed": {
+      "kind": "ERROR",
+      "status": "error"
+    },
+    "*.error": {
+      "kind": "ERROR",
+      "status": "error"
+    }
+  },
+  "redact": [
+    "authorization",
+    "cookie",
+    "token",
+    "apiKey",
+    "password",
+    "secret",
+    "email"
+  ],
+  "heuristicWindowMs": 2000
+}

--- a/examples/recipes/winston-json-logs/expected-output.txt
+++ b/examples/recipes/winston-json-logs/expected-output.txt
@@ -1,0 +1,9 @@
+winston-json-logs recipe
+Run winston_run_01
+agent-inspect.logs.json
+sample-winston.log
+confidence
+tool:search
+llm:plan
+fixture-gpt
+agent:completed

--- a/examples/recipes/winston-json-logs/package.json
+++ b/examples/recipes/winston-json-logs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agent-inspect-recipe-winston-json-logs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "file:../../..",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/recipes/winston-json-logs/sample-winston.log
+++ b/examples/recipes/winston-json-logs/sample-winston.log
@@ -1,0 +1,6 @@
+{"level":"info","timestamp":"2026-05-08T10:00:18.130Z","service":"agent","message":"Agent run started","runId":"winston_run_01","event":"agent.run.started"}
+{"level":"info","timestamp":"2026-05-08T10:00:18.132Z","service":"agent","message":"Tool search started","runId":"winston_run_01","event":"tool.search.started","tool":"searchDocs"}
+{"level":"info","timestamp":"2026-05-08T10:00:18.402Z","service":"agent","message":"Tool search completed","runId":"winston_run_01","event":"tool.search.completed","tool":"searchDocs","durationMs":270}
+{"level":"info","timestamp":"2026-05-08T10:00:18.500Z","service":"agent","message":"LLM plan started","runId":"winston_run_01","event":"llm.plan.started","model":"fixture-gpt"}
+{"level":"info","timestamp":"2026-05-08T10:00:19.100Z","service":"agent","message":"LLM plan completed","runId":"winston_run_01","event":"llm.plan.completed","model":"fixture-gpt","durationMs":600,"tokens":{"input":820,"output":210}}
+{"level":"info","timestamp":"2026-05-08T10:00:19.150Z","service":"agent","message":"Agent run completed","runId":"winston_run_01","event":"agent.run.completed","status":"ok"}

--- a/examples/recipes/winston-json-logs/src/index.ts
+++ b/examples/recipes/winston-json-logs/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Prints CLI commands for bundled Winston JSON lines (no network, no winston dependency).
+ */
+import path from "node:path";
+
+const root = process.cwd();
+
+console.log("\n=== winston-json-logs recipe ===\n");
+console.log("Bundled deterministic Winston-shaped JSON lines:");
+console.log(`  ${path.join(root, "sample-winston.log")}`);
+console.log(`  ${path.join(root, "agent-inspect.logs.json")}`);
+console.log("\nFrom repository root, run:\n");
+console.log(
+  "  node packages/cli/dist/index.cjs logs examples/recipes/winston-json-logs/sample-winston.log --format json --config examples/recipes/winston-json-logs/agent-inspect.logs.json",
+);
+console.log(
+  "\n  node packages/cli/dist/index.cjs tail --file examples/recipes/winston-json-logs/sample-winston.log --format json --config examples/recipes/winston-json-logs/agent-inspect.logs.json --once",
+);
+console.log("\nExpect: Run winston_run_01, tool/llm lanes, confidence labels.");
+console.log("");

--- a/scripts/validate-recipes.mjs
+++ b/scripts/validate-recipes.mjs
@@ -15,6 +15,7 @@ const RECIPES = [
   "multi-agent-handoff",
   "proactive-agent-logs",
   "pino-json-logs",
+  "winston-json-logs",
   "log4js-json-layout",
   "nestjs-json-logging",
   "retry-fallback",
@@ -28,6 +29,7 @@ const LOG_RECIPE_FILES = {
     "sample-log4js.log",
   ],
   "pino-json-logs": ["agent-inspect.logs.json", "sample-pino.log"],
+  "winston-json-logs": ["agent-inspect.logs.json", "sample-winston.log"],
   "log4js-json-layout": ["agent-inspect.logs.json", "sample-log4js.log"],
   "nestjs-json-logging": ["agent-inspect.logs.json", "sample-nestjs.log"],
 };


### PR DESCRIPTION
## Summary
- Adds a deterministic `examples/recipes/winston-json-logs` recipe with sample Winston-shaped JSON logs, an ingest config, expected-output markers, and local run commands.
- Documents the Winston `timestamp`/`message`/`level` shape in `docs/LOGGING-PLAYBOOK.md`.
- Registers the recipe in `examples/recipes/README.md` and `scripts/validate-recipes.mjs`, and allowlists the recipe sample log so it is committed.

Per the issue and maintainer note, this is a recipe/example only — no Winston dependency is added to the root or `packages/core`, and the sample uses deterministic fake data with no secrets.

## Files
- `examples/recipes/winston-json-logs/` (README, package.json, src/index.ts, agent-inspect.logs.json, sample-winston.log, expected-output.txt)
- `docs/LOGGING-PLAYBOOK.md` (new "Winston structured logging example" section)
- `examples/recipes/README.md` (recipe index row)
- `scripts/validate-recipes.mjs` (recipe + required-files registration)
- `.gitignore` (allowlist `examples/recipes/winston-json-logs/*.log`)

## Validation
```
node packages/cli/dist/index.cjs logs examples/recipes/winston-json-logs/sample-winston.log \
  --format json --config examples/recipes/winston-json-logs/agent-inspect.logs.json
```
→ renders `Run winston_run_01` with 6 events (2 tools, 2 LLMs), 0 warnings.

- `pnpm recipes:check` → `OK — 10 recipes validated.`
- `pnpm typecheck` → passes
- `pnpm test` → 82 files / 674 tests passed

Closes #21.
