### PR TITLE
docs: add clean install smoke test guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ pnpm compat:smoke
 npm pack --dry-run
 ```
 
+For user-facing clean install verification, follow [docs/INSTALL-SMOKE-TEST.md](docs/INSTALL-SMOKE-TEST.md). It covers npm and pnpm temp-project checks, ESM import, CJS require, and CLI help without changing package exports.
+
 ## Development principles
 
 1. **Local-first** — features should work offline with files on disk; no hidden cloud dependencies.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Verify the CLI is available:
 npx agent-inspect --help
 ```
 
+For a clean npm/pnpm install checklist with ESM, CJS, and CLI checks, see [Clean install smoke test](docs/INSTALL-SMOKE-TEST.md).
+
 ## 60-second quickstart
 
 Create `demo.mjs`:
@@ -270,6 +272,7 @@ For a detailed comparison, see [Compare with other tools](docs/COMPARE.md).
 ## Documentation
 
 - [Getting started](docs/GETTING-STARTED.md)
+- [Clean install smoke test](docs/INSTALL-SMOKE-TEST.md)
 - [API stability & experimental surfaces](docs/API.md)
 - [CLI reference](docs/CLI.md)
 - [Schema (`schemaVersion: "0.1"`)](docs/SCHEMA.md)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -14,6 +14,8 @@ The `agent-inspect` package includes the CLI binary via its `bin` field:
 npx agent-inspect --help
 ```
 
+For a clean install verification path covering npm, pnpm, ESM import, CJS require, and CLI help, see [Clean install smoke test](./INSTALL-SMOKE-TEST.md).
+
 For local repo development (this monorepo), build and run the CLI from `packages/cli`:
 
 ```bash
@@ -155,4 +157,3 @@ agent-inspect view <runId> --tui
 - [docs/KNOWN-ISSUES.md](./KNOWN-ISSUES.md)
 - [docs/LIMITATIONS.md](./LIMITATIONS.md)
 - [ROADMAP.md](../ROADMAP.md)
-

--- a/docs/INSTALL-SMOKE-TEST.md
+++ b/docs/INSTALL-SMOKE-TEST.md
@@ -1,0 +1,145 @@
+# Clean Install Smoke Test
+
+Use this guide to check that the published `agent-inspect` package works from a clean consumer project. These steps are for users and contributors who want to verify npm or pnpm install behavior without reading the full monorepo development setup.
+
+AgentInspect targets Node.js `>=20`. TypeScript consumers should use TypeScript settings that support package exports, such as `module` and `moduleResolution` set to `NodeNext` or `Node16`.
+
+## npm Temp Project
+
+Start in an empty temporary directory:
+
+```bash
+mkdir /tmp/agent-inspect-npm-smoke
+cd /tmp/agent-inspect-npm-smoke
+npm init -y
+npm install agent-inspect
+```
+
+Check ESM import support:
+
+```bash
+node -e "import('agent-inspect').then((m) => { if (!m.inspectRun || !m.step || !m.maybeInspectRun) process.exit(1); console.log('esm ok'); })"
+```
+
+Check CJS require support:
+
+```bash
+node -e "const m = require('agent-inspect'); if (!m.inspectRun || !m.step || !m.maybeInspectRun) process.exit(1); console.log('cjs ok');"
+```
+
+Check the installed CLI:
+
+```bash
+npx --no-install agent-inspect --help
+```
+
+To check registry resolution without a local install, run this in a different empty directory:
+
+```bash
+npx agent-inspect --help
+```
+
+## pnpm Temp Project
+
+Start in a separate temporary directory:
+
+```bash
+mkdir /tmp/agent-inspect-pnpm-smoke
+cd /tmp/agent-inspect-pnpm-smoke
+npm init -y
+pnpm add agent-inspect
+```
+
+Check ESM import support:
+
+```bash
+node -e "import('agent-inspect').then((m) => { if (!m.inspectRun || !m.step || !m.maybeInspectRun) process.exit(1); console.log('esm ok'); })"
+```
+
+Check CJS require support:
+
+```bash
+node -e "const m = require('agent-inspect'); if (!m.inspectRun || !m.step || !m.maybeInspectRun) process.exit(1); console.log('cjs ok');"
+```
+
+Check the installed CLI:
+
+```bash
+pnpm exec agent-inspect --help
+```
+
+## TypeScript Consumer Notes
+
+For ESM TypeScript consumers, use a package with `"type": "module"` and Node-aware module settings:
+
+```json
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}
+```
+
+For CJS TypeScript consumers, use a CommonJS package or `.cts` files with Node-aware settings:
+
+```json
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}
+```
+
+These settings match the compatibility guidance in [Known issues](KNOWN-ISSUES.md#common-installruntime-compatibility-checks).
+
+## From a Repo Clone
+
+The temp-project checks above verify the published package. From a local repo clone, build first:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm compat:smoke
+```
+
+Maintainers can run the tarball smoke test when package contents or exports change:
+
+```bash
+pnpm pack:smoke
+```
+
+## Troubleshooting
+
+If `npm install agent-inspect` or `pnpm add agent-inspect` fails:
+
+- Confirm `node -v` is Node.js `20` or newer.
+- Confirm the package manager can reach the npm registry.
+- Retry in a new empty temp directory to rule out an existing lockfile or workspace override.
+
+If ESM import fails:
+
+- Confirm the consumer project uses `"type": "module"` or an `.mjs` entry file when testing static imports.
+- For TypeScript, use `module` and `moduleResolution` set to `NodeNext` or `Node16`.
+
+If CJS require fails:
+
+- Confirm the consumer project uses `"type": "commonjs"` or a `.cjs` entry file.
+- For TypeScript CJS, prefer `.cts` files with `module` and `moduleResolution` set to `Node16`.
+
+If the CLI is missing:
+
+- Check `node_modules/.bin/agent-inspect` after install.
+- Use `npx --no-install agent-inspect --help` or `pnpm exec agent-inspect --help` to ensure you are using the locally installed binary.
+
+## What to Report
+
+When opening an issue, include:
+
+- Node.js version from `node -v`.
+- Package manager and version from `npm -v` or `pnpm -v`.
+- Operating system and shell.
+- Whether the failing case is npm, pnpm, ESM import, CJS require, TypeScript compile, or CLI help.
+- The exact command and complete output or stack trace.
+- A minimal reproduction directory, repository, or file snippet when possible.


### PR DESCRIPTION
## Summary
- add `docs/INSTALL-SMOKE-TEST.md` for clean npm and pnpm temp-project checks
- cover ESM import, CJS require, installed CLI help, troubleshooting, and failure-reporting details
- link the guide from README, Getting started, and Contributing

Fixes #20

## Type of change
- [x] Documentation only

## Product boundaries
- [x] Local-first only; no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] No package export or runtime code changes

## Packages touched
- [x] Docs / community only

## Validation
- `git diff --check`
- `npx --yes pnpm@9.15.0 install --frozen-lockfile` completed; pnpm emitted pre-build bin-link warnings because dist files are absent before build
- `npx --yes pnpm@9.15.0 run typecheck`
- `npx --yes pnpm@9.15.0 run test` passed: 669 tests passed, 10 skipped
