### PR TITLE
docs: add extension submission template

### DIFF
--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -27,6 +27,11 @@ agent-inspect/
 5. Run validation (see root CONTRIBUTING.md).
 6. Use the [PR template](../../.github/PULL_REQUEST_TEMPLATE.md).
 
+For community extension or adapter registry proposals, start from the
+[extension submission template](EXTENSION-SUBMISSION-TEMPLATE.md). It captures
+package metadata, maintainer contact, privacy defaults, conformance evidence,
+and known gaps before a registry entry is reviewed.
+
 ## Package boundaries (detailed)
 
 ### Root `agent-inspect`

--- a/docs/community/EXTENSION-SUBMISSION-TEMPLATE.md
+++ b/docs/community/EXTENSION-SUBMISSION-TEMPLATE.md
@@ -1,0 +1,88 @@
+# Extension submission template
+
+Use this template when proposing a community AgentInspect extension for the
+extension registry. Keep the submission small, reviewable, and explicit about
+privacy and conformance status.
+
+## Package
+
+- **Package name:**
+- **npm package URL:**
+- **Source repository:**
+- **License:**
+- **Current version:**
+- **Extension type:** adapter / renderer / transform / reporter / other
+
+## Framework or runtime
+
+- **Framework, SDK, or runtime:**
+- **Supported versions:**
+- **Node.js versions tested:**
+- **Required peer dependencies:**
+- **Optional peer dependencies:**
+
+## Maintainer
+
+- **Primary maintainer:**
+- **GitHub handle:**
+- **Contact or discussion link:**
+- **Maintenance status:** active / experimental / looking for maintainer
+
+## Privacy and safety
+
+- **Default capture mode:** metadata-only / preview / custom
+- **Network behavior:** none by default / opt-in only / required
+- **Upload behavior:** none / opt-in / required
+- **Secret handling:**
+- **Redaction behavior:**
+- **Known sensitive fields:**
+- **Safe sharing notes:**
+
+## Conformance
+
+- **Conformance status:** passing / partial / not yet run
+- **Conformance command:**
+- **Conformance output or CI link:**
+- **Fixture coverage:**
+- **Known gaps:**
+
+## Usage
+
+```bash
+npm install <package-name> agent-inspect
+```
+
+```ts
+// Minimal setup example
+```
+
+## Registry entry
+
+```yaml
+name:
+package:
+repository:
+type:
+framework:
+status:
+maintainer:
+privacy:
+  defaultCapture:
+  networkByDefault:
+  uploadByDefault:
+conformance:
+  status:
+  command:
+  evidence:
+```
+
+## Review checklist
+
+- [ ] Package name and source repository are public.
+- [ ] Maintainer contact is present.
+- [ ] Privacy defaults are documented.
+- [ ] Network and upload behavior are explicit.
+- [ ] Conformance status includes evidence or known gaps.
+- [ ] Example uses synthetic data only.
+- [ ] No API keys, customer logs, prompts, outputs, or private trace data are included.
+

--- a/packages/adapter-sdk/README.md
+++ b/packages/adapter-sdk/README.md
@@ -43,6 +43,7 @@ export const registration = createAdapterRegistration({
 
 - [Adapter conformance](https://github.com/rajudandigam/agent-inspect/blob/main/docs/ADAPTER-CONFORMANCE.md)
 - [Adapters](https://github.com/rajudandigam/agent-inspect/blob/main/docs/ADAPTERS.md)
+- [Extension submission template](https://github.com/rajudandigam/agent-inspect/blob/main/docs/community/EXTENSION-SUBMISSION-TEMPLATE.md)
 
 ## Checklist for package authors
 
@@ -50,6 +51,7 @@ export const registration = createAdapterRegistration({
 2. Document peer dependencies
 3. No network in adapter code path
 4. Add conformance tests
+5. Use the extension submission template before proposing registry inclusion
 
 ## Version
 


### PR DESCRIPTION
## Summary

- add a community extension submission template for registry proposals
- capture package metadata, maintainer contact, privacy/safety defaults, conformance evidence, usage, and registry-entry shape
- link the template from the adapter SDK README and community contributing guide

Closes #64.

## Test plan

- pnpm typecheck
- git diff --check

Note: I also tried `pnpm test` locally, but it fails in this workspace because fixture paths are resolved through a URL-encoded non-ASCII path under `/Users/m/Documents/%E9%83%A8%E7%BD%B2mac/...`, causing ENOENT for existing fixtures. I kept this PR docs-only.