### PR TITLE
docs: add adapter SDK privacy checklist

### DIFF
--- a/docs/ADAPTER-SDK-PRIVACY.md
+++ b/docs/ADAPTER-SDK-PRIVACY.md
@@ -1,0 +1,73 @@
+# Adapter SDK privacy checklist
+
+Use this checklist when authoring or reviewing a third-party adapter built with
+`@agent-inspect/adapter-sdk`.
+
+Adapter packages should stay local-first, metadata-only by default, and explicit
+about any capture mode that can persist prompt, output, tool input, or tool
+result content.
+
+## Default capture
+
+- Default to `metadata-only` capture.
+- Do not persist full prompts, completions, tool inputs, tool outputs, request
+  bodies, response bodies, or raw logs unless the user opts in.
+- Keep preview or full capture modes explicit, documented, and easy to disable.
+- Treat framework-specific metadata as user-controlled data. Review it before
+  export or sharing.
+
+## Persistence
+
+- Write traces only to user-controlled local paths.
+- Do not upload traces, logs, exports, or adapter diagnostics by default.
+- Do not call external networks from adapter defaults or conformance examples.
+- Keep framework SDK dependencies inside the optional adapter package. Do not add
+  framework dependencies to the root `agent-inspect` package.
+- Preserve application behavior if trace writing, flushing, or closing fails.
+
+## Redaction and export review
+
+- Document capture and redaction behavior in the adapter README.
+- Use `redactionProfile: "share"` or `redactionProfile: "strict"` for artifacts
+  intended for issues, PRs, external posts, or support threads.
+- Review Markdown, HTML, JSON, JSONL, and screenshot outputs before sharing.
+- Search exported artifacts for secrets, tokens, session IDs, customer IDs,
+  internal hostnames, raw prompts, model outputs, tool payloads, and file paths.
+- Prefer small synthetic examples over production traces when demonstrating an
+  adapter.
+
+## Conformance helper
+
+`@agent-inspect/adapter-sdk` exposes `runPrivacyChecklist()` for adapter package
+tests or release checks.
+
+```ts
+import { runPrivacyChecklist } from "@agent-inspect/adapter-sdk";
+
+const result = runPrivacyChecklist({
+  captureMode: "metadata-only",
+  networkAllowed: false,
+  uploadAllowed: false,
+  redactionDocumented: true,
+  frameworkDepsPackageScoped: true,
+});
+
+if (!result.ok) {
+  throw new Error("Adapter privacy checklist failed");
+}
+```
+
+The helper is a contract check, not a compliance guarantee. Adapter authors still
+need to review the exact artifacts they share.
+
+## Before proposing registry inclusion
+
+- Confirm metadata-only is the default path.
+- Confirm no upload or network behavior is enabled by default.
+- Link the adapter README to this checklist and to
+  [Safe trace sharing](./SAFE-TRACE-SHARING.md).
+- Run conformance and privacy checks locally.
+- Use the
+  [extension submission template](./community/EXTENSION-SUBMISSION-TEMPLATE.md)
+  to describe capture, persistence, redaction, validation, and maintainer contact
+  details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Local-first TypeScript AI agent toolkit: **trace → check → redact** on your 
 | [DIFF.md](./DIFF.md) · [EXPORTS.md](./EXPORTS.md) | Compare and export |
 | [CI-ARTIFACTS.md](./CI-ARTIFACTS.md) | CI / test artifacts |
 | [PERFORMANCE.md](./PERFORMANCE.md) · [SCALE-LIMITS.md](./SCALE-LIMITS.md) · [STREAMING-LIMITATIONS.md](./STREAMING-LIMITATIONS.md) | Scale and streaming |
-| [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md) · [LIMITATIONS.md](./LIMITATIONS.md) · [KNOWN-ISSUES.md](./KNOWN-ISSUES.md) | Safety and limits |
+| [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md) · [ADAPTER-SDK-PRIVACY.md](./ADAPTER-SDK-PRIVACY.md) · [LIMITATIONS.md](./LIMITATIONS.md) · [KNOWN-ISSUES.md](./KNOWN-ISSUES.md) | Safety and limits |
 | [COMPARE.md](./COMPARE.md) · [MIGRATION.md](./MIGRATION.md) | Positioning and upgrades |
 | [VSCODE.md](./VSCODE.md) | In-repo VS Code extension |
 

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -55,6 +55,7 @@ Replace sensitive data with clear placeholders such as `example.test`, `user@exa
 - OpenInference / OTLP JSON exports: check attributes, span names, events, and resource metadata.
 - Structured log ingest configs: confirm mapped keys do not pull in full request bodies, headers, raw prompts, or unbounded output fields.
 - LangChain adapter traces: keep `capture: "metadata-only"` for shareable examples; review `capture: "preview"` traces carefully because previews can include prompt or output fragments.
+- Third-party adapter packages: follow the [Adapter SDK privacy checklist](./ADAPTER-SDK-PRIVACY.md) before sharing adapter traces, examples, or registry submissions.
 
 ## When to use each profile
 

--- a/packages/adapter-sdk/README.md
+++ b/packages/adapter-sdk/README.md
@@ -31,6 +31,9 @@ export const registration = createAdapterRegistration({
 ## Privacy
 
 - SDK helpers enforce local-first patterns; adapters must not upload by default
+- Use the Adapter SDK privacy checklist to document capture, persistence,
+  redaction, and export-review behavior before publishing or proposing registry
+  inclusion.
 
 ## API
 
@@ -42,6 +45,7 @@ export const registration = createAdapterRegistration({
 ## Docs
 
 - [Adapter conformance](https://github.com/rajudandigam/agent-inspect/blob/main/docs/ADAPTER-CONFORMANCE.md)
+- [Adapter SDK privacy checklist](https://github.com/rajudandigam/agent-inspect/blob/main/docs/ADAPTER-SDK-PRIVACY.md)
 - [Adapters](https://github.com/rajudandigam/agent-inspect/blob/main/docs/ADAPTERS.md)
 - [Extension submission template](https://github.com/rajudandigam/agent-inspect/blob/main/docs/community/EXTENSION-SUBMISSION-TEMPLATE.md)
 
@@ -51,7 +55,8 @@ export const registration = createAdapterRegistration({
 2. Document peer dependencies
 3. No network in adapter code path
 4. Add conformance tests
-5. Use the extension submission template before proposing registry inclusion
+5. Run the privacy checklist and review exported artifacts before sharing
+6. Use the extension submission template before proposing registry inclusion
 
 ## Version
 


### PR DESCRIPTION
## Summary

- add `docs/ADAPTER-SDK-PRIVACY.md` with a checklist for third-party adapter capture, persistence, redaction, and export review
- link the checklist from `packages/adapter-sdk/README.md`
- link the checklist from `docs/SAFE-TRACE-SHARING.md`

Closes #61.

## Scope

Docs-only Adapter SDK privacy checklist.

This PR only touches:

- `docs/ADAPTER-SDK-PRIVACY.md`
- `packages/adapter-sdk/README.md`
- `docs/SAFE-TRACE-SHARING.md`

No runtime, test, or redaction behavior changed.

## Validation

- `git diff --check` passed
- `pnpm typecheck` passed
- `pnpm test` failed locally because fixture paths resolve through a URL-encoded non-ASCII workspace path and hit fixture `ENOENT` errors, e.g. `/Users/m/Documents/%E9%83%A8%E7%BD%B2mac/...`. This is the existing local environment issue also seen on prior docs-only work; the patch is docs-only.
