### PR TITLE
feat(website): add AgentInspect landing page and docs shell

### DIFF
--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -1,0 +1,4 @@
+.next
+out
+node_modules
+*.tsbuildinfo

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -1,0 +1,72 @@
+# AgentInspect Website
+
+Private marketing site and docs shell for AgentInspect.
+
+## Local dev
+
+```bash
+pnpm --filter @agent-inspect/website dev
+```
+
+Or from the monorepo root:
+
+```bash
+pnpm website:dev
+```
+
+## Build
+
+```bash
+pnpm --filter @agent-inspect/website build
+```
+
+Static output is written to `apps/website/out`.
+
+## Typecheck
+
+```bash
+pnpm --filter @agent-inspect/website typecheck
+```
+
+## Vercel setup
+
+Project source:
+
+`rajudandigam/agent-inspect`
+
+Root Directory:
+
+`apps/website`
+
+Framework:
+
+Next.js
+
+Build Command:
+
+`pnpm build`
+
+Output Directory:
+
+`out`
+
+Install Command:
+
+`pnpm install --frozen-lockfile`
+
+Because this is a monorepo, configure Vercel with:
+
+- **Root Directory:** `apps/website`
+- **Install Command:** `cd ../.. && pnpm install --frozen-lockfile`
+- **Build Command:** `pnpm build`
+- **Output Directory:** `out`
+
+If Vercel monorepo install from the app directory fails to resolve the workspace, set the install command to run from the repository root as shown above.
+
+## Notes
+
+- The website package is private and is not published to npm.
+- The root package continues publishing only library artifacts (`files` allowlist excludes `apps/`).
+- Static export is enabled (`output: "export"`).
+- No analytics scripts, forms, auth, or backend routes in this first pass.
+- Canonical docs remain on GitHub during the docs migration.

--- a/apps/website/app/docs/[[...slug]]/page.tsx
+++ b/apps/website/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { DocsLayout } from "@/components/docs/DocsLayout";
+import { renderDocContent } from "@/lib/doc-content";
+import { docHref, getAllDocSlugs, getDocPage } from "@/lib/docs";
+import { createMetadata } from "@/lib/metadata";
+
+type DocsPageProps = {
+  params: Promise<{
+    slug?: string[];
+  }>;
+};
+
+export function generateStaticParams() {
+  return getAllDocSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: DocsPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const page = getDocPage(slug);
+  if (!page) {
+    return createMetadata({
+      title: "Docs not found · agent-inspect",
+      path: "/docs",
+    });
+  }
+
+  return createMetadata({
+    title: `${page.title} · agent-inspect docs`,
+    description: page.description,
+    path: docHref(page.slug),
+  });
+}
+
+export default async function DocsPage({ params }: DocsPageProps) {
+  const { slug } = await params;
+  const page = getDocPage(slug);
+  if (!page) {
+    notFound();
+  }
+
+  const currentPath = docHref(page.slug);
+
+  return (
+    <DocsLayout page={page} currentPath={currentPath}>
+      {renderDocContent(page.slug)}
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/globals.css
+++ b/apps/website/app/globals.css
@@ -1,0 +1,72 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-elevated: #ffffff;
+  --color-border: #e2e8f0;
+  --color-primary: #6366f1;
+  --color-secondary: #10b981;
+  --color-accent: #f59e0b;
+  --color-danger: #f43f5e;
+  --color-success: #22c55e;
+  --color-ink: #0f172a;
+  --color-muted: #64748b;
+}
+
+.dark {
+  --color-bg: #070a12;
+  --color-surface: #0f172a;
+  --color-elevated: #111827;
+  --color-border: #1e293b;
+  --color-primary: #6366f1;
+  --color-secondary: #10b981;
+  --color-accent: #f59e0b;
+  --color-danger: #f43f5e;
+  --color-success: #22c55e;
+  --color-ink: #e2e8f0;
+  --color-muted: #94a3b8;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  @apply bg-bg text-ink antialiased;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.prose-docs h2 {
+  @apply mt-10 scroll-mt-28 text-xl font-semibold tracking-tight text-ink;
+}
+
+.prose-docs h3 {
+  @apply mt-6 scroll-mt-28 text-lg font-semibold text-ink;
+}
+
+.prose-docs p {
+  @apply mt-3 text-base leading-7 text-muted;
+}
+
+.prose-docs ul {
+  @apply mt-3 list-disc space-y-2 pl-5 text-muted;
+}
+
+.prose-docs a {
+  @apply font-medium text-primary underline-offset-4 hover:underline;
+}
+
+.prose-docs code:not(pre code) {
+  @apply rounded bg-elevated px-1.5 py-0.5 font-mono text-[0.9em] text-ink;
+}

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { createMetadata, jsonLd } from "@/lib/metadata";
+
+import "./globals.css";
+
+export const metadata: Metadata = createMetadata();
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="dark" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("agent-inspect-theme");if(t==="light"){document.documentElement.classList.remove("dark");}else if(t==="dark"){document.documentElement.classList.add("dark");}else if(window.matchMedia("(prefers-color-scheme: light)").matches){document.documentElement.classList.remove("dark");}}catch(e){}})();`,
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -1,0 +1,37 @@
+import { ComparisonTable } from "@/components/marketing/ComparisonTable";
+import { CodeExamples } from "@/components/marketing/CodeExamples";
+import { FAQ } from "@/components/marketing/FAQ";
+import { FeatureGrid } from "@/components/marketing/FeatureGrid";
+import { FinalCTA } from "@/components/marketing/FinalCTA";
+import { FiveMinutePath } from "@/components/marketing/FiveMinutePath";
+import { Footer } from "@/components/marketing/Footer";
+import { Hero } from "@/components/marketing/Hero";
+import { NotAPlatform } from "@/components/marketing/NotAPlatform";
+import { OpenSourceTrust } from "@/components/marketing/OpenSourceTrust";
+import { ProblemSection } from "@/components/marketing/ProblemSection";
+import { ProductLoop } from "@/components/marketing/ProductLoop";
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { UseCases } from "@/components/marketing/UseCases";
+
+export default function HomePage() {
+  return (
+    <div className="min-h-screen">
+      <SiteHeader />
+      <main>
+        <Hero />
+        <ProblemSection />
+        <FiveMinutePath />
+        <ProductLoop />
+        <FeatureGrid />
+        <CodeExamples />
+        <UseCases />
+        <ComparisonTable />
+        <NotAPlatform />
+        <OpenSourceTrust />
+        <FAQ />
+        <FinalCTA />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsBreadcrumbs.tsx
+++ b/apps/website/components/docs/DocsBreadcrumbs.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+import type { DocPage } from "@/lib/docs";
+
+type DocsBreadcrumbsProps = {
+  page: DocPage;
+};
+
+export function DocsBreadcrumbs({ page }: DocsBreadcrumbsProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6 text-sm text-muted">
+      <ol className="flex flex-wrap items-center gap-2">
+        <li>
+          <Link href="/docs" className="hover:text-ink">
+            Docs
+          </Link>
+        </li>
+        {page.slug ? (
+          <>
+            <li aria-hidden>/</li>
+            <li>
+              <span className="text-muted">{page.section}</span>
+            </li>
+            <li aria-hidden>/</li>
+            <li className="text-ink">{page.title}</li>
+          </>
+        ) : (
+          <>
+            <li aria-hidden>/</li>
+            <li className="text-ink">Overview</li>
+          </>
+        )}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/website/components/docs/DocsCallout.tsx
+++ b/apps/website/components/docs/DocsCallout.tsx
@@ -1,0 +1,51 @@
+import { AlertTriangle, Info, Shield } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { clsx } from "clsx";
+
+type DocsCalloutProps = {
+  title?: string;
+  tone?: "info" | "warning" | "safety";
+  children: ReactNode;
+};
+
+const tones = {
+  info: {
+    icon: Info,
+    className: "border-primary/30 bg-primary/10 text-ink",
+  },
+  warning: {
+    icon: AlertTriangle,
+    className: "border-accent/30 bg-accent/10 text-ink",
+  },
+  safety: {
+    icon: Shield,
+    className: "border-secondary/30 bg-secondary/10 text-ink",
+  },
+} as const;
+
+export function DocsCallout({
+  title,
+  tone = "info",
+  children,
+}: DocsCalloutProps) {
+  const config = tones[tone];
+  const Icon = config.icon;
+
+  return (
+    <aside
+      className={clsx(
+        "my-6 rounded-xl border px-4 py-3 text-sm leading-6",
+        config.className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+        <div>
+          {title ? <p className="font-semibold">{title}</p> : null}
+          <div className={title ? "mt-1 text-muted" : "text-muted"}>{children}</div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/website/components/docs/DocsCardGrid.tsx
+++ b/apps/website/components/docs/DocsCardGrid.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+export type DocsCard = {
+  title: string;
+  description: string;
+  href: string;
+  external?: boolean;
+};
+
+type DocsCardGridProps = {
+  cards: DocsCard[];
+};
+
+export function DocsCardGrid({ cards }: DocsCardGridProps) {
+  return (
+    <div className="my-6 grid gap-4 sm:grid-cols-2">
+      {cards.map((card) =>
+        card.external ? (
+          <a
+            key={card.title}
+            href={card.href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="rounded-2xl border border-border bg-surface p-5 transition hover:border-primary/40"
+          >
+            <h3 className="font-semibold text-ink">{card.title}</h3>
+            <p className="mt-2 text-sm leading-6 text-muted">{card.description}</p>
+          </a>
+        ) : (
+          <Link
+            key={card.title}
+            href={card.href}
+            className="rounded-2xl border border-border bg-surface p-5 transition hover:border-primary/40"
+          >
+            <h3 className="font-semibold text-ink">{card.title}</h3>
+            <p className="mt-2 text-sm leading-6 text-muted">{card.description}</p>
+          </Link>
+        ),
+      )}
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsCodeBlock.tsx
+++ b/apps/website/components/docs/DocsCodeBlock.tsx
@@ -1,0 +1,19 @@
+import { CodeBlock } from "@/components/shared/CodeBlock";
+
+type DocsCodeBlockProps = {
+  code: string;
+  language?: string;
+  filename?: string;
+};
+
+export function DocsCodeBlock({
+  code,
+  language = "bash",
+  filename,
+}: DocsCodeBlockProps) {
+  return (
+    <div className="my-6">
+      <CodeBlock code={code} language={language} filename={filename} />
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsLayout.tsx
+++ b/apps/website/components/docs/DocsLayout.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+import type { DocPage } from "@/lib/docs";
+import { site } from "@/lib/site";
+
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { Footer } from "@/components/marketing/Footer";
+
+import { DocsBreadcrumbs } from "./DocsBreadcrumbs";
+import { DocsMobileNav } from "./DocsMobileNav";
+import { DocsPager } from "./DocsPager";
+import { DocsSearch } from "./DocsSearch";
+import { DocsSidebar } from "./DocsSidebar";
+import { DocsToc } from "./DocsToc";
+
+type DocsLayoutProps = {
+  page: DocPage;
+  currentPath: string;
+  children: ReactNode;
+};
+
+export function DocsLayout({ page, currentPath, children }: DocsLayoutProps) {
+  return (
+    <div className="min-h-screen">
+      <SiteHeader />
+      <div className="mx-auto grid max-w-6xl gap-8 px-4 py-8 sm:px-6 lg:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-[220px_minmax(0,1fr)_180px]">
+        <DocsSidebar currentPath={currentPath} />
+        <div className="min-w-0">
+          <div className="mb-6">
+            <DocsSearch />
+          </div>
+          <DocsMobileNav currentPath={currentPath} />
+          <DocsBreadcrumbs page={page} />
+          <article className="prose-docs">
+            <h1 className="text-3xl font-semibold tracking-tight text-ink">
+              {page.title}
+            </h1>
+            <p className="mt-3 text-lg leading-8 text-muted">{page.description}</p>
+            {children}
+          </article>
+          <DocsPager previous={page.previous} next={page.next} />
+          <p className="mt-8 text-sm text-muted">
+            Full reference remains in{" "}
+            <a
+              href={site.githubDocs}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-medium text-primary hover:underline"
+            >
+              GitHub docs
+            </a>{" "}
+            during the docs migration.
+          </p>
+        </div>
+        <DocsToc items={page.toc} />
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsMobileNav.tsx
+++ b/apps/website/components/docs/DocsMobileNav.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { docsNav } from "@/lib/docs";
+import { clsx } from "clsx";
+
+type DocsMobileNavProps = {
+  currentPath: string;
+};
+
+export function DocsMobileNav({ currentPath }: DocsMobileNavProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mb-6 lg:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between rounded-xl border border-border bg-surface px-4 py-3 text-sm font-medium"
+        aria-expanded={open}
+      >
+        <span>Docs navigation</span>
+        <span className="text-muted">{open ? "Hide" : "Show"}</span>
+      </button>
+      {open ? (
+        <div className="mt-2 space-y-4 rounded-xl border border-border bg-surface p-4">
+          {docsNav.map((section) => (
+            <div key={section.title}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">
+                {section.title}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {section.items.map((item) => {
+                  const active =
+                    currentPath === item.href ||
+                    currentPath === `${item.href}/`;
+                  return (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        onClick={() => setOpen(false)}
+                        className={clsx(
+                          "block rounded-lg px-3 py-2 text-sm",
+                          active
+                            ? "bg-primary/10 font-medium text-primary"
+                            : "text-muted hover:bg-elevated hover:text-ink",
+                        )}
+                      >
+                        {item.title}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsPager.tsx
+++ b/apps/website/components/docs/DocsPager.tsx
@@ -1,0 +1,57 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+import { docHref, docPages } from "@/lib/docs";
+
+type DocsPagerProps = {
+  previous?: string;
+  next?: string;
+};
+
+function resolve(slug?: string) {
+  if (slug === undefined) return undefined;
+  return docPages.find((page) => page.slug === slug);
+}
+
+export function DocsPager({ previous, next }: DocsPagerProps) {
+  const prevPage = resolve(previous);
+  const nextPage = resolve(next);
+
+  if (!prevPage && !nextPage) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Docs pagination"
+      className="mt-12 grid gap-4 border-t border-border pt-8 sm:grid-cols-2"
+    >
+      {prevPage ? (
+        <Link
+          href={docHref(prevPage.slug)}
+          className="rounded-2xl border border-border bg-surface p-4 transition hover:border-primary/40"
+        >
+          <p className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted">
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+            Previous
+          </p>
+          <p className="mt-2 font-semibold text-ink">{prevPage.title}</p>
+        </Link>
+      ) : (
+        <div />
+      )}
+      {nextPage ? (
+        <Link
+          href={docHref(nextPage.slug)}
+          className="rounded-2xl border border-border bg-surface p-4 text-right transition hover:border-primary/40"
+        >
+          <p className="flex items-center justify-end gap-2 text-xs uppercase tracking-wide text-muted">
+            Next
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+          </p>
+          <p className="mt-2 font-semibold text-ink">{nextPage.title}</p>
+        </Link>
+      ) : null}
+    </nav>
+  );
+}

--- a/apps/website/components/docs/DocsSearch.tsx
+++ b/apps/website/components/docs/DocsSearch.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { docHref, docPages } from "@/lib/docs";
+
+export function DocsSearch() {
+  const [query, setQuery] = useState("");
+
+  const results = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return [];
+    return docPages
+      .filter(
+        (page) =>
+          page.title.toLowerCase().includes(normalized) ||
+          page.description.toLowerCase().includes(normalized) ||
+          page.section.toLowerCase().includes(normalized),
+      )
+      .slice(0, 6);
+  }, [query]);
+
+  return (
+    <div className="relative">
+      <label className="sr-only" htmlFor="docs-search">
+        Search docs
+      </label>
+      <div className="flex items-center gap-2 rounded-xl border border-border bg-elevated px-3 py-2">
+        <Search className="h-4 w-4 text-muted" aria-hidden />
+        <input
+          id="docs-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search docs"
+          className="w-full bg-transparent text-sm text-ink outline-none placeholder:text-muted"
+          autoComplete="off"
+        />
+      </div>
+      {query.trim() ? (
+        <div className="absolute z-20 mt-2 w-full rounded-xl border border-border bg-surface p-2 shadow-lg">
+          {results.length ? (
+            <ul className="space-y-1">
+              {results.map((page) => (
+                <li key={page.slug || "home"}>
+                  <Link
+                    href={docHref(page.slug)}
+                    className="block rounded-lg px-3 py-2 hover:bg-elevated"
+                    onClick={() => setQuery("")}
+                  >
+                    <p className="text-sm font-medium text-ink">{page.title}</p>
+                    <p className="text-xs text-muted">{page.description}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="px-3 py-2 text-sm text-muted">No matching pages.</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/website/components/docs/DocsSidebar.tsx
+++ b/apps/website/components/docs/DocsSidebar.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+import { docsNav } from "@/lib/docs";
+import { clsx } from "clsx";
+
+type DocsSidebarProps = {
+  currentPath: string;
+};
+
+export function DocsSidebar({ currentPath }: DocsSidebarProps) {
+  return (
+    <nav aria-label="Docs" className="hidden lg:block">
+      <div className="sticky top-24 space-y-6">
+        {docsNav.map((section) => (
+          <div key={section.title}>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted">
+              {section.title}
+            </p>
+            <ul className="mt-2 space-y-1">
+              {section.items.map((item) => {
+                const active =
+                  currentPath === item.href ||
+                  currentPath === `${item.href}/`;
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={clsx(
+                        "block rounded-lg px-3 py-2 text-sm transition",
+                        active
+                          ? "bg-primary/10 font-medium text-primary"
+                          : "text-muted hover:bg-elevated hover:text-ink",
+                      )}
+                    >
+                      {item.title}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/apps/website/components/docs/DocsToc.tsx
+++ b/apps/website/components/docs/DocsToc.tsx
@@ -1,0 +1,33 @@
+import type { DocTocItem } from "@/lib/docs";
+
+type DocsTocProps = {
+  items?: DocTocItem[];
+};
+
+export function DocsToc({ items }: DocsTocProps) {
+  if (!items?.length) {
+    return null;
+  }
+
+  return (
+    <aside className="hidden xl:block">
+      <div className="sticky top-24">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted">
+          On this page
+        </p>
+        <ul className="mt-3 space-y-2 border-l border-border pl-3 text-sm">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className="text-muted transition hover:text-ink"
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/apps/website/components/marketing/CodeExamples.tsx
+++ b/apps/website/components/marketing/CodeExamples.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import { CodeBlock } from "@/components/shared/CodeBlock";
+
+const examples = [
+  {
+    id: "manual",
+    label: "Manual",
+    language: "ts",
+    code: `import { inspectRun, step } from "agent-inspect";
+
+await inspectRun("support-agent", async () => {
+  const intent = await step("classify intent", () =>
+    classifyIntent(ticket)
+  );
+
+  const docs = await step.tool("search knowledge base", () =>
+    searchKnowledgeBase(intent)
+  );
+
+  return step.llm("draft-model", () =>
+    generateResponse(docs)
+  );
+});`,
+  },
+  {
+    id: "ai-sdk",
+    label: "AI SDK",
+    language: "ts",
+    code: `import { generateText } from "ai";
+import { agentInspect } from "@agent-inspect/ai-sdk";
+
+await generateText({
+  model,
+  prompt,
+  experimental_telemetry: {
+    isEnabled: true,
+    recordInputs: false,
+    recordOutputs: false,
+    integrations: [
+      agentInspect({
+        traceDir: ".agent-inspect",
+        runName: "support-agent",
+        capture: "metadata-only"
+      })
+    ]
+  }
+});`,
+  },
+  {
+    id: "cli",
+    label: "CLI",
+    language: "bash",
+    code: `npx agent-inspect list --dir .agent-inspect
+npx agent-inspect view <run-id> --dir .agent-inspect
+npx agent-inspect report <run-id> --dir .agent-inspect
+npx agent-inspect check .agent-inspect/*.jsonl --require-completed
+npx agent-inspect verify-safe --dir .agent-inspect`,
+  },
+  {
+    id: "harness",
+    label: "Harness",
+    language: "ts",
+    code: `import {
+  createFixtureRunner,
+  defineTarget
+} from "@agent-inspect/harness";
+
+await createFixtureRunner({
+  name: "support-agent",
+  trace: {
+    traceDir: ".agent-inspect/support-agent"
+  },
+  targets: {
+    refund: defineTarget({
+      description: "Run refund policy agent",
+      resolve: (app) => app.get(RefundPolicyAgent),
+      invoke: (agent, input) => agent.run(input)
+    })
+  }
+}).runFromArgv();`,
+  },
+] as const;
+
+export function CodeExamples() {
+  const [active, setActive] = useState<(typeof examples)[number]["id"]>("manual");
+  const tablistId = useId();
+  const current = examples.find((example) => example.id === active) ?? examples[0];
+
+  return (
+    <section id="code-examples" className="scroll-mt-24 border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Code
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Start from the path you already use
+          </h2>
+        </div>
+
+        <div
+          role="tablist"
+          aria-label="Code examples"
+          id={tablistId}
+          className="mt-8 flex flex-wrap gap-2"
+        >
+          {examples.map((example) => {
+            const selected = example.id === active;
+            return (
+              <button
+                key={example.id}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`${example.id}-panel`}
+                id={`${example.id}-tab`}
+                onClick={() => setActive(example.id)}
+                className={
+                  selected
+                    ? "rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-medium text-primary"
+                    : "rounded-lg border border-border bg-elevated px-3 py-2 text-sm font-medium text-muted hover:text-ink"
+                }
+              >
+                {example.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          role="tabpanel"
+          id={`${current.id}-panel`}
+          aria-labelledby={`${current.id}-tab`}
+          className="mt-4"
+        >
+          <CodeBlock code={current.code} language={current.language} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/ComparisonTable.tsx
+++ b/apps/website/components/marketing/ComparisonTable.tsx
@@ -1,0 +1,114 @@
+const rows = [
+  {
+    label: "Local-first",
+    agentInspect: "Yes — traces on disk",
+    consoleLog: "Yes",
+    hosted: "Usually account + ingestion",
+    otel: "Depends on collector/backend",
+  },
+  {
+    label: "Account required",
+    agentInspect: "No",
+    consoleLog: "No",
+    hosted: "Usually yes",
+    otel: "No for SDK; yes for many backends",
+  },
+  {
+    label: "Upload required",
+    agentInspect: "No by default",
+    consoleLog: "No",
+    hosted: "Usually yes",
+    otel: "Exporter/collector dependent",
+  },
+  {
+    label: "Execution tree",
+    agentInspect: "Built-in",
+    consoleLog: "Flat stream",
+    hosted: "Often yes",
+    otel: "Spans/traces with setup",
+  },
+  {
+    label: "CI checks",
+    agentInspect: "Deterministic CLI checks",
+    consoleLog: "Manual",
+    hosted: "Platform-specific",
+    otel: "Custom pipelines",
+  },
+  {
+    label: "Safe redaction flow",
+    agentInspect: "Profiles + verify-safe",
+    consoleLog: "Manual",
+    hosted: "Varies",
+    otel: "Custom",
+  },
+  {
+    label: "Team dashboard",
+    agentInspect: "Not the goal",
+    consoleLog: "No",
+    hosted: "Yes",
+    otel: "Via backend/viewer",
+  },
+  {
+    label: "Production monitoring",
+    agentInspect: "Not the goal",
+    consoleLog: "No",
+    hosted: "Yes",
+    otel: "Yes, with platform setup",
+  },
+  {
+    label: "Best for",
+    agentInspect: "Local dev, CI artifacts, safe sharing",
+    consoleLog: "Tiny scripts",
+    hosted: "Production fleets and team collaboration",
+    otel: "Platform observability foundation",
+  },
+];
+
+export function ComparisonTable() {
+  return (
+    <section id="compare" className="scroll-mt-24 border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Compare
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Complementary, not a replacement
+          </h2>
+          <p className="mt-4 text-lg leading-8 text-muted">
+            Use AgentInspect for the local developer loop. Use hosted platforms or
+            OpenTelemetry for production observability. They can complement each
+            other.
+          </p>
+        </div>
+
+        <div className="mt-8 overflow-x-auto rounded-2xl border border-border">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead className="bg-elevated">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Capability</th>
+                <th className="px-4 py-3 font-semibold text-primary">agent-inspect</th>
+                <th className="px-4 py-3 font-semibold">console.log</th>
+                <th className="px-4 py-3 font-semibold">Hosted observability</th>
+                <th className="px-4 py-3 font-semibold">Raw OpenTelemetry</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.label} className="border-t border-border">
+                  <th className="px-4 py-3 align-top font-medium text-ink">
+                    {row.label}
+                  </th>
+                  <td className="px-4 py-3 align-top text-muted">{row.agentInspect}</td>
+                  <td className="px-4 py-3 align-top text-muted">{row.consoleLog}</td>
+                  <td className="px-4 py-3 align-top text-muted">{row.hosted}</td>
+                  <td className="px-4 py-3 align-top text-muted">{row.otel}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/FAQ.tsx
+++ b/apps/website/components/marketing/FAQ.tsx
@@ -1,0 +1,75 @@
+const faqs = [
+  {
+    q: "Is AgentInspect a replacement for LangSmith or Langfuse?",
+    a: "No. It complements hosted observability tools. AgentInspect focuses on the local developer loop: traces on disk, CLI checks, and safe sharing.",
+  },
+  {
+    q: "What does it capture by default?",
+    a: "Metadata-only by default. Prompts and outputs are not captured unless you explicitly opt into content capture settings.",
+  },
+  {
+    q: "Does it upload traces?",
+    a: "No upload by default. Traces are local files unless you explicitly export or share them.",
+  },
+  {
+    q: "Which frameworks does it support?",
+    a: "Manual instrumentation, Vercel AI SDK (`@agent-inspect/ai-sdk`), OpenAI Agents (`@agent-inspect/openai-agents`), LangChain (`@agent-inspect/langchain`), structured logs, harness, and CI/test reporters.",
+  },
+  {
+    q: "Can I use it in CI?",
+    a: "Yes. Run `check`, `eval`, `artifacts`, and `verify-safe` on local traces, then upload redacted artifacts with your CI platform.",
+  },
+  {
+    q: "Can I share traces safely?",
+    a: "Use `redact --profile share` (or `strict`) and `verify-safe` before attaching traces to PRs or issues. Profiles are best-effort safeguards, not compliance certifications.",
+  },
+  {
+    q: "Is it production monitoring?",
+    a: "No. Use hosted platforms or OpenTelemetry for production fleets and team dashboards.",
+  },
+  {
+    q: "Does it record chain-of-thought?",
+    a: "No. AgentInspect does not record chain-of-thought.",
+  },
+  {
+    q: "How much does it cost?",
+    a: "It is open source under the MIT license.",
+  },
+  {
+    q: "Where are the docs?",
+    a: "Starter docs live under /docs. Canonical GitHub docs remain the full reference during migration.",
+  },
+];
+
+export function FAQ() {
+  return (
+    <section id="faq" className="scroll-mt-24 border-b border-border bg-surface/50 py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            FAQ
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Straight answers
+          </h2>
+        </div>
+        <div className="mt-8 grid gap-3">
+          {faqs.map((item) => (
+            <details
+              key={item.q}
+              className="group rounded-2xl border border-border bg-bg px-5 py-4"
+            >
+              <summary className="cursor-pointer list-none font-medium marker:content-none">
+                <span className="flex items-center justify-between gap-4">
+                  {item.q}
+                  <span className="text-muted transition group-open:rotate-45">+</span>
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-6 text-muted">{item.a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/FeatureGrid.tsx
+++ b/apps/website/components/marketing/FeatureGrid.tsx
@@ -1,0 +1,85 @@
+import {
+  Boxes,
+  FileJson2,
+  GitCompare,
+  Monitor,
+  Network,
+  Shield,
+  TerminalSquare,
+  Workflow,
+} from "lucide-react";
+
+const features = [
+  {
+    title: "Local JSONL traces",
+    body: "Own your runs as files under `.agent-inspect/`. No account required.",
+    icon: FileJson2,
+  },
+  {
+    title: "Execution trees",
+    body: "Nested steps, tool/LLM types, durations, and status in a readable tree.",
+    icon: Workflow,
+  },
+  {
+    title: "Metadata-only by default",
+    body: "Safe defaults keep prompts and outputs out of traces unless you opt in.",
+    icon: Shield,
+  },
+  {
+    title: "Framework adapters",
+    body: "AI SDK, OpenAI Agents, LangChain, plus manual and log-ingest paths.",
+    icon: Boxes,
+  },
+  {
+    title: "CI checks and reporters",
+    body: "Deterministic `check`, `eval`, and Vitest/Jest reporters for PR evidence.",
+    icon: TerminalSquare,
+  },
+  {
+    title: "Redaction profiles",
+    body: "`local`, `share`, and `strict` profiles before issues, PRs, or partner threads.",
+    icon: GitCompare,
+  },
+  {
+    title: "Viewer, TUI, and VS Code surfaces",
+    body: "Inspect locally in terminal, localhost viewer, or the in-repo VS Code extension.",
+    icon: Monitor,
+  },
+  {
+    title: "OpenTelemetry and OpenInference export path",
+    body: "Compatibility-oriented local exports when you need a bridge to platform tooling.",
+    icon: Network,
+  },
+];
+
+export function FeatureGrid() {
+  return (
+    <section
+      id="features"
+      className="scroll-mt-24 border-b border-border bg-surface/50 py-16 sm:py-20"
+    >
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Features
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Built for the TypeScript agent inner loop
+          </h2>
+        </div>
+        <div className="mt-10 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {features.map((feature) => (
+            <article
+              key={feature.title}
+              className="rounded-2xl border border-border bg-bg p-5"
+            >
+              <feature.icon className="h-5 w-5 text-primary" aria-hidden />
+              <h3 className="mt-4 font-semibold">{feature.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{feature.body}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/FinalCTA.tsx
+++ b/apps/website/components/marketing/FinalCTA.tsx
@@ -1,0 +1,31 @@
+import { ButtonLink } from "@/components/shared/ButtonLink";
+import { CopyButton } from "@/components/shared/CopyButton";
+import { site } from "@/lib/site";
+
+export function FinalCTA() {
+  return (
+    <section className="border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="rounded-3xl border border-primary/30 bg-primary/10 px-6 py-10 sm:px-10">
+          <h2 className="text-3xl font-semibold tracking-tight">
+            Get your first local trace in five minutes
+          </h2>
+          <p className="mt-4 max-w-2xl text-lg leading-8 text-muted">
+            Install AgentInspect, run the deterministic demo, and keep traces on
+            your machine.
+          </p>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="flex min-w-0 flex-1 items-center justify-between gap-3 rounded-xl border border-border bg-bg px-4 py-3 font-mono text-sm">
+              <code className="truncate">{site.installCommand}</code>
+              <CopyButton value={site.installCommand} label="Copy" />
+            </div>
+            <ButtonLink href="/docs/getting-started">Read the docs</ButtonLink>
+            <ButtonLink href={site.github} variant="secondary" external>
+              Star on GitHub
+            </ButtonLink>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/FiveMinutePath.tsx
+++ b/apps/website/components/marketing/FiveMinutePath.tsx
@@ -1,0 +1,38 @@
+import { CodeBlock } from "@/components/shared/CodeBlock";
+
+const commands = `npm install agent-inspect
+npx agent-inspect init --yes
+node examples/agent-inspect-demo.mjs
+npx agent-inspect list --dir .agent-inspect
+npx agent-inspect view <run-id> --dir .agent-inspect
+npx agent-inspect check .agent-inspect/*.jsonl --require-completed --detect-stalls
+npx agent-inspect redact --profile share --dir .agent-inspect
+npx agent-inspect verify-safe --dir .agent-inspect`;
+
+export function FiveMinutePath() {
+  return (
+    <section
+      id="five-minute-path"
+      className="scroll-mt-24 border-b border-border bg-surface/50 py-16 sm:py-20"
+    >
+      <div className="mx-auto grid max-w-6xl gap-8 px-4 sm:px-6 lg:grid-cols-[0.9fr_1.1fr]">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Five-minute path
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            One trace, one check, one safe artifact
+          </h2>
+          <p className="mt-4 text-lg leading-8 text-muted">
+            Install, run the deterministic demo, inspect the tree, check
+            completion and stalls, then redact before you share.
+          </p>
+          <p className="mt-4 rounded-xl border border-secondary/30 bg-secondary/10 px-4 py-3 text-sm text-secondary">
+            The deterministic starter path works without API keys.
+          </p>
+        </div>
+        <CodeBlock code={commands} language="bash" />
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/Footer.tsx
+++ b/apps/website/components/marketing/Footer.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { site } from "@/lib/site";
+
+const columns = [
+  {
+    title: "Product",
+    links: [
+      { href: "/docs/getting-started", label: "Getting started" },
+      { href: "/docs/concepts/local-first", label: "Local-first" },
+      { href: "/docs/safe-sharing", label: "Safe sharing" },
+      { href: "/docs/ci", label: "CI artifacts" },
+    ],
+  },
+  {
+    title: "Integrations",
+    links: [
+      { href: "/docs/integrations/ai-sdk", label: "AI SDK" },
+      { href: "/docs/integrations/openai-agents", label: "OpenAI Agents" },
+      { href: "/docs/integrations/langchain", label: "LangChain" },
+      { href: "/docs/cli", label: "CLI" },
+    ],
+  },
+  {
+    title: "Community",
+    links: [
+      { href: site.github, label: "GitHub", external: true },
+      { href: site.npm, label: "npm", external: true },
+      { href: "/docs/contributing", label: "Contributing" },
+      { href: "/docs/compare", label: "Compare" },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border py-12">
+      <div className="mx-auto grid max-w-6xl gap-10 px-4 sm:px-6 md:grid-cols-[1.2fr_2fr]">
+        <div>
+          <p className="text-lg font-semibold">{site.name}</p>
+          <p className="mt-3 max-w-sm text-sm leading-6 text-muted">
+            Local-first trace + check + redact for TypeScript AI agents.
+          </p>
+        </div>
+        <div className="grid gap-8 sm:grid-cols-3">
+          {columns.map((column) => (
+            <div key={column.title}>
+              <p className="text-sm font-semibold">{column.title}</p>
+              <ul className="mt-3 space-y-2 text-sm text-muted">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    {"external" in link && link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="hover:text-ink"
+                      >
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link href={link.href} className="hover:text-ink">
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="mx-auto mt-10 flex max-w-6xl flex-col gap-2 border-t border-border px-4 pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <p>MIT license. No account. No upload by default.</p>
+        <p>Not a hosted SaaS product or production APM.</p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/website/components/marketing/Hero.tsx
+++ b/apps/website/components/marketing/Hero.tsx
@@ -1,0 +1,87 @@
+import { ArrowRight } from "lucide-react";
+
+import { Badge } from "@/components/shared/Badge";
+import { ButtonLink } from "@/components/shared/ButtonLink";
+import { CopyButton } from "@/components/shared/CopyButton";
+import { site } from "@/lib/site";
+
+import { TerminalDemo } from "./TerminalDemo";
+
+export function Hero() {
+  return (
+    <section className="relative overflow-hidden border-b border-border">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.18),transparent_45%)]" />
+      <div className="relative mx-auto grid max-w-6xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:py-20">
+        <div>
+          <Badge tone="primary">{site.name} · Local-first trace + check + redact</Badge>
+          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+            Debug TypeScript AI agents locally
+          </h1>
+          <p className="mt-5 max-w-xl text-lg leading-8 text-muted">
+            Trace what happened, check what should have happened, and redact what
+            must not leave your machine. No account. No upload. Metadata-only by
+            default.
+          </p>
+
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="flex min-w-0 flex-1 items-center justify-between gap-3 rounded-xl border border-border bg-elevated px-4 py-3 font-mono text-sm">
+              <code className="truncate">{site.installCommand}</code>
+              <CopyButton value={site.installCommand} label="Copy install command" />
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-3">
+            <ButtonLink href="/docs/getting-started">
+              First trace in 5 minutes
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </ButtonLink>
+            <ButtonLink href={site.github} variant="secondary" external>
+              View on GitHub
+            </ButtonLink>
+          </div>
+
+          <div className="mt-8 flex flex-wrap gap-2">
+            {["Open source", "MIT license", "TypeScript", "Local-first"].map(
+              (item) => (
+                <Badge key={item}>{item}</Badge>
+              ),
+            )}
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <a href={site.npm} target="_blank" rel="noreferrer noopener">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={site.badges.npmVersion} alt="npm version" height={20} />
+            </a>
+            <a href={site.npm} target="_blank" rel="noreferrer noopener">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={site.badges.npmDownloads}
+                alt="npm downloads per month"
+                height={20}
+              />
+            </a>
+            <a href={site.github} target="_blank" rel="noreferrer noopener">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={site.badges.githubStars}
+                alt="GitHub stars"
+                height={20}
+              />
+            </a>
+            <a href={site.github} target="_blank" rel="noreferrer noopener">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={site.badges.githubLicense}
+                alt="MIT license"
+                height={20}
+              />
+            </a>
+          </div>
+        </div>
+
+        <TerminalDemo />
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/NotAPlatform.tsx
+++ b/apps/website/components/marketing/NotAPlatform.tsx
@@ -1,0 +1,39 @@
+import { X } from "lucide-react";
+
+const items = [
+  "Not a hosted SaaS dashboard",
+  "Not a production APM replacement",
+  "Not an eval dataset platform",
+  "Not a prompt registry",
+  "Not a hidden uploader",
+  "Not a chain-of-thought recorder",
+  "Not a replay engine",
+];
+
+export function NotAPlatform() {
+  return (
+    <section className="border-b border-border bg-surface/50 py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Boundaries
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Local-first by design. Not a hidden platform.
+          </h2>
+        </div>
+        <ul className="mt-8 grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 rounded-xl border border-border bg-bg px-4 py-3 text-sm text-muted"
+            >
+              <X className="mt-0.5 h-4 w-4 shrink-0 text-danger" aria-hidden />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/OpenSourceTrust.tsx
+++ b/apps/website/components/marketing/OpenSourceTrust.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+import { site } from "@/lib/site";
+
+const links = [
+  { href: site.github, label: "MIT license", external: true },
+  { href: "/docs/concepts/local-first", label: "Local JSONL files" },
+  { href: "/docs/concepts/trace-check-redact", label: "Metadata-only default" },
+  { href: "/docs/safe-sharing", label: "Redaction profiles" },
+  { href: "/docs/safe-sharing", label: "verify-safe before sharing" },
+  { href: `${site.github}/issues`, label: "GitHub issues and discussions", external: true },
+  { href: site.npm, label: "npm package", external: true },
+  {
+    href: `${site.github}/blob/main/docs/TECHNICAL-GUIDE.md`,
+    label: "Technical guide",
+    external: true,
+  },
+  {
+    href: `${site.github}/blob/main/docs/SAFE-TRACE-SHARING.md`,
+    label: "Safe trace sharing docs",
+    external: true,
+  },
+];
+
+export function OpenSourceTrust() {
+  return (
+    <section className="border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Open source trust
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Transparent defaults you can audit
+          </h2>
+          <p className="mt-4 text-lg leading-8 text-muted">
+            AgentInspect is MIT-licensed, dependency-light at the root, and explicit
+            about network behavior: no upload by default.
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <a href={site.npm} target="_blank" rel="noreferrer noopener">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={site.badges.npmVersion} alt="npm version" height={20} />
+          </a>
+          <a href={site.github} target="_blank" rel="noreferrer noopener">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={site.badges.githubStars} alt="GitHub stars" height={20} />
+          </a>
+          <a href={site.github} target="_blank" rel="noreferrer noopener">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={site.badges.githubLicense} alt="MIT license" height={20} />
+          </a>
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-2">
+          {links.map((link) =>
+            link.external ? (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="rounded-full border border-border bg-elevated px-3 py-1.5 text-sm text-muted transition hover:text-ink"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.label}
+                href={link.href}
+                className="rounded-full border border-border bg-elevated px-3 py-1.5 text-sm text-muted transition hover:text-ink"
+              >
+                {link.label}
+              </Link>
+            ),
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/ProblemSection.tsx
+++ b/apps/website/components/marketing/ProblemSection.tsx
@@ -1,0 +1,59 @@
+import { GitBranch, Layers, ShieldAlert, Timer } from "lucide-react";
+
+const cards = [
+  {
+    title: "Flat logs hide nested decisions",
+    body: "You see a tool name, not the parent run, siblings, or where the branch went wrong.",
+    icon: Layers,
+  },
+  {
+    title: "Parallel tool calls get interleaved",
+    body: "Concurrent work collapses into a stream of lines without step boundaries.",
+    icon: GitBranch,
+  },
+  {
+    title: "Hosted dashboards slow the local loop",
+    body: "Accounts, ingestion, and dashboards are great for fleets — not for the first failing run on your laptop.",
+    icon: Timer,
+  },
+  {
+    title: "Raw traces can leak customer data",
+    body: "Without redaction and verify-safe, PR and issue attachments can expose more than you intended.",
+    icon: ShieldAlert,
+  },
+];
+
+export function ProblemSection() {
+  return (
+    <section id="problem" className="scroll-mt-24 border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            The problem
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            console.log was not built for agents
+          </h2>
+          <p className="mt-4 text-lg leading-8 text-muted">
+            Agent runs are nested, parallel, tool-heavy, and privacy-sensitive.
+            Flat logs tell you something happened. They rarely show what happened
+            in order, where it branched, or what is safe to share.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-2">
+          {cards.map((card) => (
+            <article
+              key={card.title}
+              className="rounded-2xl border border-border bg-surface p-5"
+            >
+              <card.icon className="h-5 w-5 text-primary" aria-hidden />
+              <h3 className="mt-4 text-lg font-semibold">{card.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{card.body}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/ProductLoop.tsx
+++ b/apps/website/components/marketing/ProductLoop.tsx
@@ -1,0 +1,58 @@
+import { Eye, ScanSearch, ShieldCheck, TreePine } from "lucide-react";
+
+const steps = [
+  {
+    title: "Capture",
+    body: "Capture manual steps, AI SDK telemetry, OpenAI Agents traces, LangChain callbacks, logs, harness runs, and CI/test artifacts.",
+    icon: TreePine,
+  },
+  {
+    title: "Inspect",
+    body: "Read local JSONL as trees, timelines, reports, terminal output, viewer artifacts, or editor-friendly traces.",
+    icon: Eye,
+  },
+  {
+    title: "Check",
+    body: "Turn expectations into deterministic checks for completion, stalls, failures, regressions, and CI review.",
+    icon: ScanSearch,
+  },
+  {
+    title: "Redact",
+    body: "Create share-safe artifacts before opening issues, reviewing PRs, or talking with design partners.",
+    icon: ShieldCheck,
+  },
+];
+
+export function ProductLoop() {
+  return (
+    <section id="product-loop" className="scroll-mt-24 border-b border-border py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Product loop
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            The local agent debugging loop
+          </h2>
+        </div>
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {steps.map((step, index) => (
+            <article
+              key={step.title}
+              className="rounded-2xl border border-border bg-surface p-5"
+            >
+              <div className="flex items-center justify-between">
+                <step.icon className="h-5 w-5 text-primary" aria-hidden />
+                <span className="font-mono text-xs text-muted">
+                  0{index + 1}
+                </span>
+              </div>
+              <h3 className="mt-4 text-lg font-semibold">{step.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{step.body}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/marketing/SiteHeader.tsx
+++ b/apps/website/components/marketing/SiteHeader.tsx
@@ -1,0 +1,69 @@
+import { Github, Menu, Package } from "lucide-react";
+import Link from "next/link";
+
+import { ThemeToggle } from "@/components/shared/ThemeToggle";
+import { site } from "@/lib/site";
+
+const nav = [
+  { href: "/#five-minute-path", label: "Quickstart" },
+  { href: "/#features", label: "Features" },
+  { href: "/#compare", label: "Compare" },
+  { href: "/docs", label: "Docs" },
+];
+
+export function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-40 border-b border-border/80 bg-bg/90 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+        <Link href="/" className="flex items-center gap-2 font-semibold tracking-tight">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 text-primary">
+            <Package className="h-4 w-4" aria-hidden />
+          </span>
+          <span>{site.name}</span>
+        </Link>
+
+        <nav className="hidden items-center gap-6 text-sm text-muted md:flex" aria-label="Primary">
+          {nav.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="transition hover:text-ink"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <a
+            href={site.github}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-3 text-sm font-medium text-ink transition hover:border-primary/40"
+          >
+            <Github className="h-4 w-4" aria-hidden />
+            <span className="hidden sm:inline">GitHub</span>
+          </a>
+          <details className="relative md:hidden">
+            <summary className="flex h-9 w-9 list-none items-center justify-center rounded-lg border border-border bg-elevated text-muted marker:content-none">
+              <Menu className="h-4 w-4" aria-hidden />
+              <span className="sr-only">Open menu</span>
+            </summary>
+            <div className="absolute right-0 mt-2 w-48 rounded-xl border border-border bg-surface p-2 shadow-lg">
+              {nav.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="block rounded-lg px-3 py-2 text-sm text-ink hover:bg-elevated"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </details>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/website/components/marketing/TerminalDemo.tsx
+++ b/apps/website/components/marketing/TerminalDemo.tsx
@@ -1,0 +1,49 @@
+export function TerminalDemo() {
+  return (
+    <div className="rounded-2xl border border-border bg-[#0b1220] p-1 shadow-2xl shadow-primary/10">
+      <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
+        <span className="h-2.5 w-2.5 rounded-full bg-rose-500/80" />
+        <span className="h-2.5 w-2.5 rounded-full bg-amber-400/80" />
+        <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/80" />
+        <span className="ml-2 font-mono text-xs text-slate-400">
+          agent-inspect · local terminal
+        </span>
+      </div>
+      <pre className="overflow-x-auto p-5 font-mono text-[13px] leading-6 text-slate-200 sm:text-sm">
+        <code>
+          <span className="text-slate-500">$ </span>
+          <span>npx agent-inspect init --framework ai-sdk</span>
+          {"\n"}
+          <span className="text-success">✓</span>
+          <span> created agent-inspect.config.ts</span>
+          {"\n"}
+          <span className="text-success">✓</span>
+          <span> wrote .agent-inspect/demo-support-agent.jsonl</span>
+          {"\n\n"}
+          <span className="text-slate-500">$ </span>
+          <span>npx agent-inspect view demo-support-agent</span>
+          {"\n"}
+          <span className="text-indigo-300">support-agent</span>
+          <span> 1.8s </span>
+          <span className="text-success">✓</span>
+          {"\n"}
+          <span className="text-slate-500">├─ </span>
+          <span>classify intent 120ms </span>
+          <span className="text-success">✓</span>
+          {"\n"}
+          <span className="text-slate-500">├─ </span>
+          <span>search knowledge base 740ms </span>
+          <span className="text-success">✓</span>
+          {"\n"}
+          <span className="text-slate-500">├─ </span>
+          <span>draft response 890ms </span>
+          <span className="text-success">✓</span>
+          {"\n"}
+          <span className="text-slate-500">└─ </span>
+          <span>verify-safe 40ms </span>
+          <span className="text-success">✓</span>
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/website/components/marketing/UseCases.tsx
+++ b/apps/website/components/marketing/UseCases.tsx
@@ -1,0 +1,73 @@
+import {
+  Bug,
+  GitPullRequest,
+  LineChart,
+  Puzzle,
+  SquareTerminal,
+  TimerOff,
+} from "lucide-react";
+
+const cases = [
+  {
+    title: "Debug a wrong tool call locally",
+    body: "See the tool step, siblings, and parent run without leaving your terminal.",
+    icon: Bug,
+  },
+  {
+    title: "Attach a safe trace to a PR",
+    body: "Redact with the share profile, verify-safe, then attach the local artifact.",
+    icon: GitPullRequest,
+  },
+  {
+    title: "Catch stalled agent runs in CI",
+    body: "Use deterministic checks for completion and stalls on fixture traces.",
+    icon: TimerOff,
+  },
+  {
+    title: "Compare before/after agent behavior",
+    body: "Diff two local runs when a prompt, tool, or model change lands.",
+    icon: LineChart,
+  },
+  {
+    title: "Build a community adapter",
+    body: "Use the adapter SDK and conformance guidance for third-party frameworks.",
+    icon: Puzzle,
+  },
+  {
+    title: "Review traces in VS Code without a hosted dashboard",
+    body: "Open local JSONL in the in-repo extension while you stay on disk.",
+    icon: SquareTerminal,
+  },
+];
+
+export function UseCases() {
+  return (
+    <section
+      id="use-cases"
+      className="scroll-mt-24 border-b border-border bg-surface/50 py-16 sm:py-20"
+    >
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Use cases
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight">
+            Where teams use AgentInspect today
+          </h2>
+        </div>
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {cases.map((item) => (
+            <article
+              key={item.title}
+              className="rounded-2xl border border-border bg-bg p-5"
+            >
+              <item.icon className="h-5 w-5 text-primary" aria-hidden />
+              <h3 className="mt-4 font-semibold">{item.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/components/shared/Badge.tsx
+++ b/apps/website/components/shared/Badge.tsx
@@ -1,0 +1,33 @@
+import { clsx } from "clsx";
+import type { ReactNode } from "react";
+
+type BadgeProps = {
+  children: ReactNode;
+  tone?: "default" | "primary" | "success" | "accent";
+  className?: string;
+};
+
+const tones = {
+  default: "border-border bg-elevated text-muted",
+  primary: "border-primary/30 bg-primary/10 text-primary",
+  success: "border-secondary/30 bg-secondary/10 text-secondary",
+  accent: "border-accent/30 bg-accent/10 text-accent",
+} as const;
+
+export function Badge({
+  children,
+  tone = "default",
+  className,
+}: BadgeProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium",
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/website/components/shared/ButtonLink.tsx
+++ b/apps/website/components/shared/ButtonLink.tsx
@@ -1,0 +1,52 @@
+import { clsx } from "clsx";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type ButtonLinkProps = {
+  href: string;
+  children: ReactNode;
+  variant?: "primary" | "secondary" | "ghost";
+  className?: string;
+  external?: boolean;
+};
+
+const variants = {
+  primary:
+    "bg-primary text-white hover:bg-primary/90 border-transparent shadow-sm",
+  secondary:
+    "bg-elevated text-ink border-border hover:border-primary/40 hover:text-primary",
+  ghost: "bg-transparent text-muted border-transparent hover:text-ink",
+} as const;
+
+export function ButtonLink({
+  href,
+  children,
+  variant = "primary",
+  className,
+  external = false,
+}: ButtonLinkProps) {
+  const classes = clsx(
+    "inline-flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    variants[variant],
+    className,
+  );
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        className={classes}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={classes}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/website/components/shared/CodeBlock.tsx
+++ b/apps/website/components/shared/CodeBlock.tsx
@@ -1,0 +1,37 @@
+import { clsx } from "clsx";
+
+import { CopyButton } from "./CopyButton";
+
+type CodeBlockProps = {
+  code: string;
+  language?: string;
+  filename?: string;
+  className?: string;
+};
+
+export function CodeBlock({
+  code,
+  language = "bash",
+  filename,
+  className,
+}: CodeBlockProps) {
+  return (
+    <div
+      className={clsx(
+        "overflow-hidden rounded-xl border border-border bg-[#0b1220] shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-white/10 px-4 py-2">
+        <div className="flex items-center gap-2 text-xs text-slate-400">
+          <span className="font-mono uppercase tracking-wide">{language}</span>
+          {filename ? <span className="text-slate-500">· {filename}</span> : null}
+        </div>
+        <CopyButton value={code} className="border-white/10 bg-white/5 text-slate-200" />
+      </div>
+      <pre className="overflow-x-auto p-4 text-sm leading-6 text-slate-100">
+        <code className="font-mono">{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/website/components/shared/CopyButton.tsx
+++ b/apps/website/components/shared/CopyButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+import { clsx } from "clsx";
+
+type CopyButtonProps = {
+  value: string;
+  label?: string;
+  className?: string;
+};
+
+export function CopyButton({
+  value,
+  label = "Copy",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={clsx(
+        "inline-flex items-center gap-1.5 rounded-md border border-border bg-elevated px-2.5 py-1.5 text-xs font-medium text-ink transition hover:border-primary/50 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+        className,
+      )}
+      aria-label={copied ? "Copied" : label}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-success" aria-hidden />
+      ) : (
+        <Copy className="h-3.5 w-3.5" aria-hidden />
+      )}
+      <span>{copied ? "Copied" : label}</span>
+    </button>
+  );
+}

--- a/apps/website/components/shared/ThemeToggle.tsx
+++ b/apps/website/components/shared/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  window.localStorage.setItem("agent-inspect-theme", theme);
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("dark");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("agent-inspect-theme");
+    const preferred: Theme =
+      stored === "light" || stored === "dark"
+        ? stored
+        : window.matchMedia("(prefers-color-scheme: light)").matches
+          ? "light"
+          : "dark";
+    setTheme(preferred);
+    applyTheme(preferred);
+  }, []);
+
+  function toggle() {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    applyTheme(next);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-elevated text-muted transition hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {theme === "dark" ? (
+        <Sun className="h-4 w-4" aria-hidden />
+      ) : (
+        <Moon className="h-4 w-4" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/apps/website/lib/doc-content.tsx
+++ b/apps/website/lib/doc-content.tsx
@@ -1,0 +1,550 @@
+import type { ReactNode } from "react";
+
+import { DocsCallout } from "@/components/docs/DocsCallout";
+import { DocsCardGrid } from "@/components/docs/DocsCardGrid";
+import { DocsCodeBlock } from "@/components/docs/DocsCodeBlock";
+import { githubDoc, site } from "@/lib/site";
+
+export function renderDocContent(slug: string): ReactNode {
+  switch (slug) {
+    case "":
+      return <DocsHomeContent />;
+    case "getting-started":
+      return <GettingStartedContent />;
+    case "concepts/local-first":
+      return <LocalFirstContent />;
+    case "concepts/trace-check-redact":
+      return <TraceCheckRedactContent />;
+    case "integrations":
+      return <IntegrationsContent />;
+    case "integrations/ai-sdk":
+      return <AiSdkContent />;
+    case "integrations/openai-agents":
+      return <OpenAiAgentsContent />;
+    case "integrations/langchain":
+      return <LangChainContent />;
+    case "cli":
+      return <CliContent />;
+    case "safe-sharing":
+      return <SafeSharingContent />;
+    case "ci":
+      return <CiContent />;
+    case "compare":
+      return <CompareContent />;
+    case "contributing":
+      return <ContributingContent />;
+    default:
+      return null;
+  }
+}
+
+function DocsHomeContent() {
+  return (
+    <>
+      <h2 id="start-here">Start here</h2>
+      <p>
+        AgentInspect is local-first trace + check + redact for TypeScript AI
+        agents. These pages are a starter shell. Canonical detail still lives in
+        the repository docs on GitHub.
+      </p>
+      <DocsCardGrid
+        cards={[
+          {
+            title: "First trace in 5 minutes",
+            description: "Install, demo, inspect, check, and share-safe artifact.",
+            href: "/docs/getting-started",
+          },
+          {
+            title: "Concepts",
+            description: "Local-first defaults and the trace/check/redact loop.",
+            href: "/docs/concepts/local-first",
+          },
+        ]}
+      />
+
+      <h2 id="browse">Browse by topic</h2>
+      <DocsCardGrid
+        cards={[
+          {
+            title: "Integrations",
+            description: "Manual, AI SDK, OpenAI Agents, LangChain, and more.",
+            href: "/docs/integrations",
+          },
+          {
+            title: "CLI",
+            description: "High-level command groups for local workflows.",
+            href: "/docs/cli",
+          },
+          {
+            title: "Safe trace sharing",
+            description: "Redact and verify before PRs and issues.",
+            href: "/docs/safe-sharing",
+          },
+          {
+            title: "CI",
+            description: "Deterministic checks and redacted CI artifacts.",
+            href: "/docs/ci",
+          },
+          {
+            title: "Compare",
+            description: "How AgentInspect relates to logs, hosted tools, and OTel.",
+            href: "/docs/compare",
+          },
+          {
+            title: "Contributing",
+            description: "Good first contribution surfaces.",
+            href: "/docs/contributing",
+          },
+        ]}
+      />
+    </>
+  );
+}
+
+function GettingStartedContent() {
+  return (
+    <>
+      <h2 id="install">Install</h2>
+      <DocsCodeBlock code="npm install agent-inspect" />
+
+      <h2 id="init">Init</h2>
+      <DocsCodeBlock code="npx agent-inspect init --yes" />
+      <p>
+        Creates `agent-inspect.config.ts`, `.agent-inspect/`, and
+        `examples/agent-inspect-demo.mjs`.
+      </p>
+
+      <h2 id="demo">Run deterministic demo</h2>
+      <DocsCodeBlock code="node examples/agent-inspect-demo.mjs" />
+      <DocsCallout tone="info" title="No API keys">
+        The init demo is deterministic and works without provider credentials.
+      </DocsCallout>
+
+      <h2 id="inspect">List and view traces</h2>
+      <DocsCodeBlock
+        code={`npx agent-inspect list --dir .agent-inspect
+npx agent-inspect view <run-id> --dir .agent-inspect
+npx agent-inspect report <run-id> --dir .agent-inspect`}
+      />
+
+      <h2 id="check">Check traces</h2>
+      <DocsCodeBlock
+        code="npx agent-inspect check .agent-inspect/*.jsonl --require-completed --detect-stalls"
+      />
+
+      <h2 id="share">Redact and verify safe</h2>
+      <DocsCodeBlock
+        code={`npx agent-inspect redact --profile share --dir .agent-inspect
+npx agent-inspect verify-safe --dir .agent-inspect`}
+      />
+
+      <h2 id="next-steps">Next steps</h2>
+      <ul>
+        <li>
+          <a href={githubDoc("FIRST-TRACE-IN-5-MINUTES.md")}>
+            Full reference in GitHub docs
+          </a>
+        </li>
+        <li>
+          <a href="/docs/integrations">Pick an integration path</a>
+        </li>
+        <li>
+          <a href="/docs/safe-sharing">Read the safe sharing guide</a>
+        </li>
+      </ul>
+    </>
+  );
+}
+
+function LocalFirstContent() {
+  return (
+    <>
+      <h2 id="what-local-first-means">What local-first means</h2>
+      <ul>
+        <li>Traces stay local by default</li>
+        <li>No account required</li>
+        <li>No upload by default</li>
+        <li>No hosted dashboard required for the core loop</li>
+      </ul>
+
+      <h2 id="jsonl-on-disk">JSONL on disk</h2>
+      <p>
+        Runs are persisted as JSONL files you own, typically under
+        `.agent-inspect/` or `AGENT_INSPECT_TRACE_DIR`. You can inspect, check,
+        redact, and attach them like any other local artifact.
+      </p>
+
+      <h2 id="where-it-fits">Where it fits</h2>
+      <p>
+        Local debugging, CI artifacts, safe trace sharing, and adapter
+        development. For production fleets and team dashboards, use hosted
+        observability or OpenTelemetry — AgentInspect is complementary.
+      </p>
+      <p>
+        <a href={githubDoc("ADOPTION.md")}>Full reference in GitHub docs</a>
+      </p>
+    </>
+  );
+}
+
+function TraceCheckRedactContent() {
+  return (
+    <>
+      <h2 id="trace">Trace what happened</h2>
+      <p>
+        Capture manual steps, framework adapters, logs, harness runs, and
+        CI/test artifacts as an execution tree.
+      </p>
+
+      <h2 id="check">Check what should have happened</h2>
+      <p>
+        Run deterministic checks for completion, stalls, failures, and
+        regressions in local or CI environments.
+      </p>
+
+      <h2 id="redact">Redact what must not leave your machine</h2>
+      <p>
+        Use redaction profiles and `verify-safe` before opening issues, reviewing
+        PRs, or talking with design partners.
+      </p>
+      <DocsCallout tone="safety" title="Metadata-only by default">
+        AgentInspect defaults to metadata-only capture. Do not assume prompts or
+        outputs are present unless you opted into content capture.
+      </DocsCallout>
+      <p>
+        <a href={githubDoc("TECHNICAL-GUIDE.md")}>
+          Full reference in GitHub docs
+        </a>
+      </p>
+    </>
+  );
+}
+
+function IntegrationsContent() {
+  return (
+    <>
+      <h2 id="paths">Integration paths</h2>
+      <DocsCardGrid
+        cards={[
+          {
+            title: "Manual instrumentation",
+            description: "`inspectRun`, `step`, `step.tool`, `step.llm`, `observe`.",
+            href: githubDoc("API.md"),
+            external: true,
+          },
+          {
+            title: "AI SDK",
+            description: "Vercel AI SDK telemetry integration.",
+            href: "/docs/integrations/ai-sdk",
+          },
+          {
+            title: "OpenAI Agents",
+            description: "Local processor for OpenAI Agents JS.",
+            href: "/docs/integrations/openai-agents",
+          },
+          {
+            title: "LangChain",
+            description: "Callback handler with persisted local traces.",
+            href: "/docs/integrations/langchain",
+          },
+          {
+            title: "Logs",
+            description: "Structured log ingest into local trees.",
+            href: githubDoc("LOG-TO-TREE-QUICKSTART.md"),
+            external: true,
+          },
+          {
+            title: "Harness",
+            description: "Fixture runner for real project integrations.",
+            href: `${site.github}/tree/main/packages/harness`,
+            external: true,
+          },
+          {
+            title: "CI / tests",
+            description: "Vitest/Jest reporters and CLI checks.",
+            href: "/docs/ci",
+          },
+          {
+            title: "Adapter SDK",
+            description: "Build community adapters with conformance guidance.",
+            href: `${site.github}/tree/main/packages/adapter-sdk`,
+            external: true,
+          },
+        ]}
+      />
+    </>
+  );
+}
+
+function AiSdkContent() {
+  return (
+    <>
+      <h2 id="install">Install</h2>
+      <DocsCodeBlock code="npm install agent-inspect @agent-inspect/ai-sdk ai" />
+
+      <h2 id="example">Example</h2>
+      <DocsCodeBlock
+        language="ts"
+        code={`import { generateText } from "ai";
+import { agentInspect } from "@agent-inspect/ai-sdk";
+
+await generateText({
+  model: yourModel,
+  prompt: "Hello",
+  experimental_telemetry: {
+    isEnabled: true,
+    recordInputs: false,
+    recordOutputs: false,
+    integrations: [
+      agentInspect({
+        traceDir: ".agent-inspect",
+        runName: "support-agent",
+        capture: "metadata-only",
+      }),
+    ],
+  },
+});`}
+      />
+
+      <h2 id="privacy">Privacy</h2>
+      <ul>
+        <li>Keep `recordInputs: false` and `recordOutputs: false` unless you accept content capture risk</li>
+        <li>Default capture is `metadata-only`</li>
+        <li>Traces write locally to `traceDir`</li>
+      </ul>
+      <p>
+        <a href={githubDoc("AI-SDK-ADOPTION.md")}>
+          Full reference in GitHub docs
+        </a>
+      </p>
+    </>
+  );
+}
+
+function OpenAiAgentsContent() {
+  return (
+    <>
+      <h2 id="local-only">Local-only mode</h2>
+      <p>
+        Prefer `setTraceProcessors([agentInspect(...)])` when you want AgentInspect
+        traces without OpenAI&apos;s default export pipeline. Using
+        `addTraceProcessor` may leave the default export enabled.
+      </p>
+
+      <h2 id="example">Example</h2>
+      <DocsCodeBlock
+        language="ts"
+        code={`import { setTraceProcessors } from "@openai/agents";
+import { agentInspect } from "@agent-inspect/openai-agents";
+
+setTraceProcessors([
+  agentInspect({
+    traceDir: ".agent-inspect",
+    capture: "metadata-only",
+  }),
+]);`}
+      />
+
+      <h2 id="privacy">Privacy notes</h2>
+      <DocsCallout tone="warning" title="Processor replacement is not full network isolation">
+        Replacing processors does not by itself redact OpenAI SDK network traffic.
+        Review OpenAI SDK settings separately.
+      </DocsCallout>
+      <p>
+        <a href={githubDoc("OPENAI-AGENTS-LOCAL.md")}>
+          Full reference in GitHub docs
+        </a>
+      </p>
+    </>
+  );
+}
+
+function LangChainContent() {
+  return (
+    <>
+      <h2 id="install">Install</h2>
+      <DocsCodeBlock code="npm install agent-inspect @agent-inspect/langchain @langchain/core" />
+
+      <h2 id="example">Example</h2>
+      <DocsCodeBlock
+        language="ts"
+        code={`import { AgentInspectCallback } from "@agent-inspect/langchain";
+
+const handler = new AgentInspectCallback({
+  traceDir: ".agent-inspect",
+  runName: "my-chain",
+  persist: true,
+});
+
+// Pass handler to your chain / runnable callbacks`}
+      />
+
+      <h2 id="privacy">Privacy</h2>
+      <p>
+        Keep `capture: &quot;metadata-only&quot;` for shareable examples. Review
+        `preview` traces carefully because previews can include prompt or output
+        fragments.
+      </p>
+      <p>
+        <a href={githubDoc("ADAPTERS.md")}>Full reference in GitHub docs</a>
+      </p>
+    </>
+  );
+}
+
+function CliContent() {
+  return (
+    <>
+      <h2 id="overview">Overview</h2>
+      <p>
+        The CLI is local-first and read-only by default where possible. Exports
+        write local files only. There is no upload and no vendor sink.
+      </p>
+
+      <h2 id="command-groups">Command groups</h2>
+      <ul>
+        <li>`init`, `doctor` — scaffold and diagnose local setup</li>
+        <li>`list`, `view`, `report`, `what`, `timeline`, `stats`, `search` — inspect</li>
+        <li>`check`, `eval` — deterministic quality gates</li>
+        <li>`redact`, `scan`, `verify-safe` — safe sharing</li>
+        <li>`export`, `artifacts`, `ci-summary` — local artifacts</li>
+        <li>`diff`, `sessions`, `session` — compare and multi-run workflows</li>
+        <li>`logs`, `tail`, `open`, `migrate` — ingest and compatibility</li>
+      </ul>
+      <p>
+        <a href={githubDoc("CLI.md")}>Full reference in GitHub docs</a>
+      </p>
+    </>
+  );
+}
+
+function SafeSharingContent() {
+  return (
+    <>
+      <h2 id="why">Why it matters</h2>
+      <p>
+        Traces are local files, but they may still contain sensitive metadata you
+        attached, collected from logs, or included through optional preview
+        settings. Do not share raw traces by default.
+      </p>
+
+      <h2 id="workflow">Workflow</h2>
+      <DocsCodeBlock
+        code={`npx agent-inspect redact --profile share --dir .agent-inspect
+npx agent-inspect verify-safe --dir .agent-inspect`}
+      />
+      <ul>
+        <li>Use `--profile share` for PR/issue attachments</li>
+        <li>Use `--profile strict` for wider or public sharing</li>
+        <li>Review the output file before attaching it</li>
+      </ul>
+
+      <h2 id="limits">Limits</h2>
+      <DocsCallout tone="safety" title="Best-effort, not certification">
+        Redaction profiles are key-based safeguards, not compliance-grade DLP or
+        regulatory certifications.
+      </DocsCallout>
+      <p>
+        <a href={githubDoc("SAFE-TRACE-SHARING.md")}>
+          Full reference in GitHub docs
+        </a>
+      </p>
+    </>
+  );
+}
+
+function CiContent() {
+  return (
+    <>
+      <h2 id="pattern">CI pattern</h2>
+      <ol className="mt-3 list-decimal space-y-2 pl-5 text-muted">
+        <li>Install `agent-inspect` in CI</li>
+        <li>Write traces locally during tests or fixtures</li>
+        <li>Run deterministic checks</li>
+        <li>Create redacted artifacts</li>
+        <li>Upload with your CI platform (AgentInspect does not upload)</li>
+      </ol>
+
+      <h2 id="checks">Checks</h2>
+      <DocsCodeBlock
+        code="npx agent-inspect check .agent-inspect/*.jsonl --require-completed --detect-stalls"
+      />
+
+      <h2 id="artifacts">Artifacts</h2>
+      <DocsCodeBlock
+        code={`npx agent-inspect artifacts <run-id> --dir ./.agent-inspect \\
+  --output-dir ./artifacts --github-summary "$GITHUB_STEP_SUMMARY"`}
+      />
+      <p>
+        Prefer deterministic fixtures and redacted outputs for PR review.
+      </p>
+      <p>
+        <a href={githubDoc("CI-ARTIFACTS.md")}>Full reference in GitHub docs</a>
+      </p>
+    </>
+  );
+}
+
+function CompareContent() {
+  return (
+    <>
+      <h2 id="positioning">Positioning</h2>
+      <p>
+        AgentInspect is for the local developer loop. Hosted observability
+        platforms are for production fleets, team dashboards, and longer-lived
+        eval workflows. OpenTelemetry is a platform observability foundation.
+        They can complement each other.
+      </p>
+
+      <h2 id="table">Comparison</h2>
+      <ul>
+        <li>
+          <strong>agent-inspect:</strong> local-first, no account, no upload by
+          default, execution trees, CLI checks, safe redaction
+        </li>
+        <li>
+          <strong>console.log:</strong> local and simple, but flat and manual
+        </li>
+        <li>
+          <strong>Hosted observability:</strong> great for production monitoring
+          and team collaboration; usually requires account/ingestion
+        </li>
+        <li>
+          <strong>Raw OpenTelemetry:</strong> vendor-neutral and powerful;
+          requires collector/backend/viewer decisions
+        </li>
+      </ul>
+      <p>
+        <a href={githubDoc("COMPARE.md")}>Full reference in GitHub docs</a>
+      </p>
+    </>
+  );
+}
+
+function ContributingContent() {
+  return (
+    <>
+      <h2 id="good-first">Good first contributions</h2>
+      <ul>
+        <li>Docs and examples</li>
+        <li>Fixtures and recipes</li>
+        <li>Community adapters</li>
+        <li>VS Code / viewer polish</li>
+        <li>Safe-sharing and CI guidance improvements</li>
+      </ul>
+
+      <h2 id="boundaries">Boundaries</h2>
+      <p>
+        Avoid core schema changes, new root/core dependencies, or network
+        behavior changes unless a maintainer explicitly approves them.
+      </p>
+      <p>
+        <a href={`${site.github}/issues`}>Browse GitHub issues</a>
+        {" · "}
+        <a href={githubDoc("community/CONTRIBUTING.md")}>
+          Full reference in GitHub docs
+        </a>
+      </p>
+    </>
+  );
+}

--- a/apps/website/lib/docs.ts
+++ b/apps/website/lib/docs.ts
@@ -1,0 +1,253 @@
+export type DocTocItem = {
+  id: string;
+  title: string;
+};
+
+export type DocPage = {
+  slug: string;
+  title: string;
+  description: string;
+  section: string;
+  toc?: DocTocItem[];
+  previous?: string;
+  next?: string;
+};
+
+export const docPages: DocPage[] = [
+  {
+    slug: "",
+    title: "Documentation",
+    description:
+      "Local-first docs for tracing, checking, and redacting TypeScript AI agent runs.",
+    section: "Start",
+    toc: [
+      { id: "start-here", title: "Start here" },
+      { id: "browse", title: "Browse by topic" },
+    ],
+    next: "getting-started",
+  },
+  {
+    slug: "getting-started",
+    title: "Getting started",
+    description:
+      "Install AgentInspect, run the deterministic demo, inspect a trace, check it, and create a share-safe artifact.",
+    section: "Start",
+    toc: [
+      { id: "install", title: "Install" },
+      { id: "init", title: "Init" },
+      { id: "demo", title: "Run demo" },
+      { id: "inspect", title: "Inspect" },
+      { id: "check", title: "Check" },
+      { id: "share", title: "Redact and verify" },
+      { id: "next-steps", title: "Next steps" },
+    ],
+    previous: "",
+    next: "concepts/local-first",
+  },
+  {
+    slug: "concepts/local-first",
+    title: "Local-first",
+    description:
+      "Traces stay on disk by default. No account, no upload, and no hosted dashboard required.",
+    section: "Concepts",
+    toc: [
+      { id: "what-local-first-means", title: "What local-first means" },
+      { id: "jsonl-on-disk", title: "JSONL on disk" },
+      { id: "where-it-fits", title: "Where it fits" },
+    ],
+    previous: "getting-started",
+    next: "concepts/trace-check-redact",
+  },
+  {
+    slug: "concepts/trace-check-redact",
+    title: "Trace, check, redact",
+    description:
+      "The AgentInspect product loop: capture what happened, check expectations, and redact before sharing.",
+    section: "Concepts",
+    toc: [
+      { id: "trace", title: "Trace" },
+      { id: "check", title: "Check" },
+      { id: "redact", title: "Redact" },
+    ],
+    previous: "concepts/local-first",
+    next: "integrations",
+  },
+  {
+    slug: "integrations",
+    title: "Integrations",
+    description:
+      "Manual instrumentation, framework adapters, logs, harness, CI reporters, and adapter SDK paths.",
+    section: "Integrations",
+    toc: [{ id: "paths", title: "Integration paths" }],
+    previous: "concepts/trace-check-redact",
+    next: "integrations/ai-sdk",
+  },
+  {
+    slug: "integrations/ai-sdk",
+    title: "AI SDK",
+    description:
+      "Use @agent-inspect/ai-sdk with Vercel AI SDK telemetry. Metadata-only by default.",
+    section: "Integrations",
+    toc: [
+      { id: "install", title: "Install" },
+      { id: "example", title: "Example" },
+      { id: "privacy", title: "Privacy" },
+    ],
+    previous: "integrations",
+    next: "integrations/openai-agents",
+  },
+  {
+    slug: "integrations/openai-agents",
+    title: "OpenAI Agents",
+    description:
+      "Local AgentInspect processor for OpenAI Agents JS. Prefer setTraceProcessors for local-only traces.",
+    section: "Integrations",
+    toc: [
+      { id: "local-only", title: "Local-only mode" },
+      { id: "example", title: "Example" },
+      { id: "privacy", title: "Privacy notes" },
+    ],
+    previous: "integrations/ai-sdk",
+    next: "integrations/langchain",
+  },
+  {
+    slug: "integrations/langchain",
+    title: "LangChain",
+    description:
+      "LangChain callback handler that writes local AgentInspect JSONL traces.",
+    section: "Integrations",
+    toc: [
+      { id: "install", title: "Install" },
+      { id: "example", title: "Example" },
+      { id: "privacy", title: "Privacy" },
+    ],
+    previous: "integrations/openai-agents",
+    next: "cli",
+  },
+  {
+    slug: "cli",
+    title: "CLI",
+    description:
+      "High-level AgentInspect CLI command groups for local inspect, check, redact, and export workflows.",
+    section: "Reference",
+    toc: [
+      { id: "overview", title: "Overview" },
+      { id: "command-groups", title: "Command groups" },
+    ],
+    previous: "integrations/langchain",
+    next: "safe-sharing",
+  },
+  {
+    slug: "safe-sharing",
+    title: "Safe trace sharing",
+    description:
+      "Redact and verify traces before attaching them to PRs, issues, or design-partner threads.",
+    section: "Guides",
+    toc: [
+      { id: "why", title: "Why it matters" },
+      { id: "workflow", title: "Workflow" },
+      { id: "limits", title: "Limits" },
+    ],
+    previous: "cli",
+    next: "ci",
+  },
+  {
+    slug: "ci",
+    title: "CI artifacts",
+    description:
+      "Run deterministic checks in CI and upload redacted local artifacts with your CI platform.",
+    section: "Guides",
+    toc: [
+      { id: "pattern", title: "CI pattern" },
+      { id: "checks", title: "Checks" },
+      { id: "artifacts", title: "Artifacts" },
+    ],
+    previous: "safe-sharing",
+    next: "compare",
+  },
+  {
+    slug: "compare",
+    title: "Compare",
+    description:
+      "How AgentInspect relates to console.log, hosted observability platforms, and OpenTelemetry.",
+    section: "Guides",
+    toc: [
+      { id: "positioning", title: "Positioning" },
+      { id: "table", title: "Comparison" },
+    ],
+    previous: "ci",
+    next: "contributing",
+  },
+  {
+    slug: "contributing",
+    title: "Contributing",
+    description:
+      "Good first contribution surfaces for docs, examples, fixtures, adapters, and editor polish.",
+    section: "Community",
+    toc: [
+      { id: "good-first", title: "Good first contributions" },
+      { id: "boundaries", title: "Boundaries" },
+    ],
+    previous: "compare",
+  },
+];
+
+export type DocsNavSection = {
+  title: string;
+  items: Array<{ title: string; href: string }>;
+};
+
+export const docsNav: DocsNavSection[] = [
+  {
+    title: "Start",
+    items: [
+      { title: "Overview", href: "/docs" },
+      { title: "Getting started", href: "/docs/getting-started" },
+    ],
+  },
+  {
+    title: "Concepts",
+    items: [
+      { title: "Local-first", href: "/docs/concepts/local-first" },
+      {
+        title: "Trace, check, redact",
+        href: "/docs/concepts/trace-check-redact",
+      },
+    ],
+  },
+  {
+    title: "Integrations",
+    items: [
+      { title: "Overview", href: "/docs/integrations" },
+      { title: "AI SDK", href: "/docs/integrations/ai-sdk" },
+      { title: "OpenAI Agents", href: "/docs/integrations/openai-agents" },
+      { title: "LangChain", href: "/docs/integrations/langchain" },
+    ],
+  },
+  {
+    title: "Guides",
+    items: [
+      { title: "CLI", href: "/docs/cli" },
+      { title: "Safe sharing", href: "/docs/safe-sharing" },
+      { title: "CI artifacts", href: "/docs/ci" },
+      { title: "Compare", href: "/docs/compare" },
+    ],
+  },
+  {
+    title: "Community",
+    items: [{ title: "Contributing", href: "/docs/contributing" }],
+  },
+];
+
+export function docHref(slug: string): string {
+  return slug ? `/docs/${slug}` : "/docs";
+}
+
+export function getDocPage(slugParts: string[] | undefined): DocPage | undefined {
+  const slug = (slugParts ?? []).join("/");
+  return docPages.find((page) => page.slug === slug);
+}
+
+export function getAllDocSlugs(): string[][] {
+  return docPages.map((page) => (page.slug ? page.slug.split("/") : []));
+}

--- a/apps/website/lib/metadata.ts
+++ b/apps/website/lib/metadata.ts
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+
+import { site } from "./site";
+
+export function createMetadata(overrides?: {
+  title?: string;
+  description?: string;
+  path?: string;
+}): Metadata {
+  const title = overrides?.title ?? site.title;
+  const description = overrides?.description ?? site.description;
+  const path = overrides?.path ?? "/";
+  const url = `${site.url}${path === "/" ? "" : path}`;
+
+  return {
+    title,
+    description,
+    keywords: [...site.keywords],
+    authors: [{ name: "AgentInspect contributors" }],
+    metadataBase: new URL(site.url),
+    icons: {
+      icon: "/favicon.svg",
+    },
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      type: "website",
+      url,
+      title,
+      description,
+      siteName: site.name,
+      images: [
+        {
+          url: "/og.svg",
+          width: 1200,
+          height: 630,
+          alt: "agent-inspect — local-first AI agent tracing",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["/og.svg"],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+export const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "agent-inspect",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Node.js",
+  license: "https://opensource.org/licenses/MIT",
+  description: site.description,
+  url: site.url,
+  downloadUrl: site.npm,
+  codeRepository: site.github,
+  programmingLanguage: "TypeScript",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};

--- a/apps/website/lib/routes.ts
+++ b/apps/website/lib/routes.ts
@@ -1,0 +1,26 @@
+export const marketingAnchors = {
+  problem: "#problem",
+  path: "#five-minute-path",
+  loop: "#product-loop",
+  features: "#features",
+  examples: "#code-examples",
+  useCases: "#use-cases",
+  compare: "#compare",
+  faq: "#faq",
+} as const;
+
+export const docsRoutes = {
+  home: "/docs",
+  gettingStarted: "/docs/getting-started",
+  localFirst: "/docs/concepts/local-first",
+  traceCheckRedact: "/docs/concepts/trace-check-redact",
+  integrations: "/docs/integrations",
+  aiSdk: "/docs/integrations/ai-sdk",
+  openaiAgents: "/docs/integrations/openai-agents",
+  langchain: "/docs/integrations/langchain",
+  cli: "/docs/cli",
+  safeSharing: "/docs/safe-sharing",
+  ci: "/docs/ci",
+  compare: "/docs/compare",
+  contributing: "/docs/contributing",
+} as const;

--- a/apps/website/lib/site.ts
+++ b/apps/website/lib/site.ts
@@ -1,0 +1,33 @@
+export const site = {
+  name: "agent-inspect",
+  title: "agent-inspect — Local-first AI agent tracing for TypeScript",
+  description:
+    "Trace, check, and redact TypeScript AI agent runs locally. No account, no upload, metadata-only by default. CLI-first debugging for AI SDK, OpenAI Agents, LangChain, CI, and real projects.",
+  keywords: [
+    "TypeScript AI agents",
+    "AI agent tracing",
+    "local-first observability",
+    "agent debugging",
+    "AI SDK tracing",
+    "OpenAI Agents tracing",
+    "LangChain tracing",
+    "AI agent CI checks",
+    "safe trace sharing",
+  ],
+  url: "https://agent-inspect.dev",
+  github: "https://github.com/rajudandigam/agent-inspect",
+  githubDocs: "https://github.com/rajudandigam/agent-inspect/blob/main/docs",
+  npm: "https://www.npmjs.com/package/agent-inspect",
+  license: "MIT",
+  installCommand: "npm install agent-inspect",
+  badges: {
+    npmVersion: "https://img.shields.io/npm/v/agent-inspect",
+    npmDownloads: "https://img.shields.io/npm/dm/agent-inspect",
+    githubStars: "https://img.shields.io/github/stars/rajudandigam/agent-inspect",
+    githubLicense: "https://img.shields.io/github/license/rajudandigam/agent-inspect",
+  },
+} as const;
+
+export function githubDoc(path: string): string {
+  return `${site.githubDocs}/${path}`;
+}

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
+};
+
+export default nextConfig;

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agent-inspect/website",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "next": "^15.1.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/website/postcss.config.mjs
+++ b/apps/website/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/apps/website/public/favicon.svg
+++ b/apps/website/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#070A12"/>
+  <rect x="10" y="12" width="44" height="40" rx="8" fill="#0F172A" stroke="#6366F1" stroke-width="2"/>
+  <path d="M20 24h24M20 32h16M20 40h20" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="46" cy="40" r="5" fill="#6366F1"/>
+</svg>

--- a/apps/website/public/og.svg
+++ b/apps/website/public/og.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#070A12"/>
+  <rect x="72" y="72" width="1056" height="486" rx="28" fill="#0F172A" stroke="#1E293B" stroke-width="2"/>
+  <text x="110" y="190" fill="#6366F1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="600">agent-inspect</text>
+  <text x="110" y="270" fill="#E2E8F0" font-family="ui-sans-serif, system-ui, sans-serif" font-size="58" font-weight="700">Debug TypeScript AI agents locally</text>
+  <text x="110" y="340" fill="#94A3B8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="30">Trace · Check · Redact · No account · No upload</text>
+  <rect x="110" y="400" width="420" height="64" rx="12" fill="#111827" stroke="#1E293B"/>
+  <text x="132" y="440" fill="#E2E8F0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">npm install agent-inspect</text>
+</svg>

--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://agent-inspect.dev/sitemap.xml

--- a/apps/website/public/sitemap.xml
+++ b/apps/website/public/sitemap.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://agent-inspect.dev/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/getting-started/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/concepts/local-first/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/concepts/trace-check-redact/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/integrations/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/integrations/ai-sdk/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/integrations/openai-agents/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/integrations/langchain/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/cli/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/safe-sharing/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/ci/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/compare/</loc></url>
+  <url><loc>https://agent-inspect.dev/docs/contributing/</loc></url>
+</urlset>

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -1,0 +1,55 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--color-bg)",
+        surface: "var(--color-surface)",
+        elevated: "var(--color-elevated)",
+        border: "var(--color-border)",
+        primary: "var(--color-primary)",
+        secondary: "var(--color-secondary)",
+        accent: "var(--color-accent)",
+        danger: "var(--color-danger)",
+        success: "var(--color-success)",
+        ink: "var(--color-ink)",
+        muted: "var(--color-muted)",
+      },
+      fontFamily: {
+        sans: [
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif",
+        ],
+        mono: [
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "Liberation Mono",
+          "Courier New",
+          "monospace",
+        ],
+      },
+      boxShadow: {
+        focus: "0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-primary)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/marketing/DOCS-SITE-PLAN.md
+++ b/docs/marketing/DOCS-SITE-PLAN.md
@@ -1,0 +1,39 @@
+# AgentInspect Docs Site Plan
+
+## Goal
+
+Provide a rich docs interface under /docs inside the same website app.
+
+## First pass
+
+Create a polished docs shell and a small set of starter docs pages.
+Do not migrate the entire docs folder yet.
+Link to GitHub docs as canonical source where needed.
+
+## Future docs capabilities
+
+- Sidebar navigation
+- Mobile docs navigation
+- Right-side table of contents
+- Search
+- Code copy buttons
+- Callouts
+- Tabs
+- Prev/next navigation
+- Version awareness
+- Integration guides
+- API reference
+- CLI reference
+- Safe sharing guide
+- CI guide
+- Adapter SDK guide
+
+## Possible future search
+
+Start with simple local static search over title/description.
+Later consider Pagefind or Algolia DocSearch if adoption grows.
+
+## Possible future content system
+
+Start with typed TS content for simplicity.
+Later consider MDX if the docs become large.

--- a/docs/marketing/WEBSITE-BRIEF.md
+++ b/docs/marketing/WEBSITE-BRIEF.md
@@ -1,0 +1,49 @@
+# AgentInspect Website Brief
+
+## Goal
+
+Create a low-cost adoption website for AgentInspect.
+
+## Audience
+
+TypeScript/Node.js developers building AI agents.
+
+## Primary message
+
+Debug TypeScript AI agents locally. Trace what happened, check what should have happened, and redact what must not leave your machine.
+
+## Product boundary
+
+AgentInspect is local-first trace + check + redact for TypeScript AI agents.
+
+## What the website should drive
+
+- npm install
+- GitHub visit/star
+- first trace docs
+- safe trace sharing docs
+- docs route exploration
+- contributor interest
+
+## Non-goals
+
+- hosted dashboard
+- SaaS signup
+- production APM
+- hidden telemetry
+- database
+- auth
+- full docs migration in this first pass
+- separate website repo
+
+## Hosting
+
+- Vercel first
+- Root Directory: apps/website
+- Static export preferred
+- Cloudflare Pages/Netlify/GitHub Pages compatible later
+
+## Deployment model
+
+The library stays published from the root/package workspace.
+The website is private and deployed from apps/website.

--- a/docs/marketing/WEBSITE-COPY.md
+++ b/docs/marketing/WEBSITE-COPY.md
@@ -1,0 +1,114 @@
+# AgentInspect Website Copy
+
+Exact copy used by the marketing site (aligned with repo docs as of v3.5.x).
+
+## Hero
+
+**Eyebrow:** Local-first trace + check + redact
+
+**Headline:** Debug TypeScript AI agents locally
+
+**Subheadline:** Trace what happened, check what should have happened, and redact what must not leave your machine. No account. No upload. Metadata-only by default.
+
+**Primary command:** `npm install agent-inspect`
+
+**Primary CTA:** Copy install command
+
+**Secondary CTAs:** First trace in 5 minutes · View on GitHub
+
+**Trust badges:** Open source · MIT license · TypeScript · Local-first
+
+## Problem
+
+**Headline:** console.log was not built for agents
+
+**Intro:** Agent runs are nested, parallel, tool-heavy, and privacy-sensitive. Flat logs tell you something happened. They rarely show what happened in order, where it branched, or what is safe to share.
+
+**Cards:**
+
+- Flat logs hide nested decisions
+- Parallel tool calls get interleaved
+- Hosted dashboards slow the local loop
+- Raw traces can leak customer data
+
+## Five-minute path
+
+**Headline:** One trace, one check, one safe artifact
+
+```bash
+npm install agent-inspect
+npx agent-inspect init --yes
+node examples/agent-inspect-demo.mjs
+npx agent-inspect list --dir .agent-inspect
+npx agent-inspect view <run-id> --dir .agent-inspect
+npx agent-inspect check .agent-inspect/*.jsonl --require-completed --detect-stalls
+npx agent-inspect redact --profile share --dir .agent-inspect
+npx agent-inspect verify-safe --dir .agent-inspect
+```
+
+**Note:** The deterministic starter path should work without API keys.
+
+## Product loop
+
+**Headline:** The local agent debugging loop
+
+- **Capture** — Capture manual steps, AI SDK telemetry, OpenAI Agents traces, LangChain callbacks, logs, harness runs, and CI/test artifacts.
+- **Inspect** — Read local JSONL as trees, timelines, reports, terminal output, viewer artifacts, or editor-friendly traces.
+- **Check** — Turn expectations into deterministic checks for completion, stalls, failures, regressions, and CI review.
+- **Redact** — Create share-safe artifacts before opening issues, reviewing PRs, or talking with design partners.
+
+## Features
+
+1. Local JSONL traces
+2. Execution trees
+3. Metadata-only by default
+4. Framework adapters
+5. CI checks and reporters
+6. Redaction profiles
+7. Viewer, TUI, and VS Code surfaces
+8. OpenTelemetry and OpenInference export path
+
+## Code examples
+
+Tabs: Manual · AI SDK · CLI · Harness
+
+(See site components for full snippets; APIs verified against repo docs.)
+
+## Use cases
+
+- Debug a wrong tool call locally
+- Attach a safe trace to a PR
+- Catch stalled agent runs in CI
+- Compare before/after agent behavior
+- Build a community adapter
+- Review traces in VS Code without a hosted dashboard
+
+## Comparison
+
+Columns: agent-inspect · console.log · Hosted observability platforms · Raw OpenTelemetry
+
+Caption: Use AgentInspect for the local developer loop. Use hosted platforms or OpenTelemetry for production observability. They can complement each other.
+
+## What it is not
+
+**Headline:** Local-first by design. Not a hidden platform.
+
+- Not a hosted SaaS dashboard
+- Not a production APM replacement
+- Not an eval dataset platform
+- Not a prompt registry
+- Not a hidden uploader
+- Not a chain-of-thought recorder
+- Not a replay engine
+
+## Open-source trust
+
+MIT license · Local JSONL files · Metadata-only default · Redaction profiles · verify-safe before sharing · GitHub issues and discussions · npm package · Technical guide · Safe trace sharing docs
+
+## FAQ
+
+See site FAQ component for full Q&A.
+
+## Footer
+
+Links to docs, GitHub, npm, MIT license, and safe-sharing guidance.

--- a/package.json
+++ b/package.json
@@ -193,7 +193,10 @@
     "perf:baseline": "node scripts/performance-baseline.mjs",
     "examples:check": "pnpm install && pnpm --filter agent-inspect-example-01-basic run start",
     "changeset": "changeset",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "website:dev": "pnpm --filter @agent-inspect/website dev",
+    "website:build": "pnpm --filter @agent-inspect/website build",
+    "website:typecheck": "pnpm --filter @agent-inspect/website typecheck"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,46 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)
 
+  apps/website:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.469.0
+        version: 0.469.0(react@19.2.7)
+      next:
+        specifier: ^15.1.3
+        version: 15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.2
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.17)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.2(postcss@8.5.13)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.13
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.21.0)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   examples/08-langchain-adapter:
     dependencies:
       '@agent-inspect/langchain':
@@ -527,6 +567,10 @@ packages:
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1241,6 +1285,143 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -1385,6 +1566,57 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@next/env@15.5.20':
+    resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
+
+  '@next/swc-darwin-arm64@15.5.20':
+    resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.20':
+    resolution: {integrity: sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    resolution: {integrity: sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.5.20':
+    resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.20':
+    resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.5.20':
+    resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.20':
+    resolution: {integrity: sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1587,6 +1819,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1623,8 +1858,16 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1861,6 +2104,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1878,6 +2124,13 @@ packages:
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  autoprefixer@10.5.2:
+    resolution: {integrity: sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
 
   babel-jest@30.4.1:
     resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
@@ -1922,6 +2175,10 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -1982,6 +2239,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -2016,6 +2277,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -2039,9 +2304,16 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2114,6 +2386,11 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2154,13 +2431,23 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2350,6 +2637,9 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -2407,6 +2697,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -2510,6 +2804,14 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2713,6 +3015,10 @@ packages:
       node-notifier:
         optional: true
 
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2817,6 +3123,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.469.0:
+    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2923,6 +3234,27 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next@15.5.20:
+    resolution: {integrity: sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -2941,6 +3273,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3046,6 +3382,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -3078,6 +3417,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -3097,6 +3440,18 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -3114,6 +3469,23 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
@@ -3153,6 +3525,11 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -3169,9 +3546,20 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -3195,6 +3583,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
@@ -3222,6 +3615,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3241,6 +3637,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3368,6 +3768,19 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3381,9 +3794,18 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -3514,6 +3936,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -3698,6 +4123,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -4299,6 +4726,103 @@ snapshots:
       hono: 4.12.27
     optional: true
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
     dependencies:
       chardet: 2.1.1
@@ -4589,6 +5113,32 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@next/env@15.5.20': {}
+
+  '@next/swc-darwin-arm64@15.5.20':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.20':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.20':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.20':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.20':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.20':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4774,6 +5324,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -4820,9 +5374,17 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/react@19.2.17':
+    dependencies:
       csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
@@ -5029,6 +5591,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  arg@5.0.2: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -5040,6 +5604,15 @@ snapshots:
   assertion-error@2.0.1: {}
 
   auto-bind@5.0.1: {}
+
+  autoprefixer@10.5.2(postcss@8.5.13):
+    dependencies:
+      browserslist: 4.28.4
+      caniuse-lite: 1.0.30001799
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.13
+      postcss-value-parser: 4.2.0
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -5104,6 +5677,8 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  binary-extensions@2.3.0: {}
 
   body-parser@2.3.0:
     dependencies:
@@ -5177,6 +5752,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-css@2.0.1: {}
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -5204,6 +5781,18 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -5223,11 +5812,15 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  client-only@0.0.1: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   co@4.6.0: {}
 
@@ -5284,6 +5877,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -5303,11 +5898,18 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
+  detect-libc@2.1.2:
+    optional: true
+
   detect-newline@3.1.0: {}
+
+  didyoumean@1.2.2: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dlv@1.1.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5348,8 +5950,7 @@ snapshots:
   es-define-property@1.0.1:
     optional: true
 
-  es-errors@1.3.0:
-    optional: true
+  es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -5599,6 +6200,8 @@ snapshots:
   forwarded@0.2.0:
     optional: true
 
+  fraction.js@5.3.4: {}
+
   fresh@2.0.0:
     optional: true
 
@@ -5619,8 +6222,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2:
-    optional: true
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -5657,6 +6259,10 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
@@ -5700,7 +6306,6 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   hono@4.12.27:
     optional: true
@@ -5782,6 +6387,14 @@ snapshots:
     optional: true
 
   is-arrayish@0.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -6164,6 +6777,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  jiti@1.21.7: {}
+
   jiti@2.6.1: {}
 
   jose@6.2.3:
@@ -6237,6 +6852,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.469.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   magic-string@0.30.21:
     dependencies:
@@ -6332,6 +6951,30 @@ snapshots:
   negotiator@1.0.0:
     optional: true
 
+  next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 15.5.20
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.20
+      '@next/swc-darwin-x64': 15.5.20
+      '@next/swc-linux-arm64-gnu': 15.5.20
+      '@next/swc-linux-arm64-musl': 15.5.20
+      '@next/swc-linux-x64-gnu': 15.5.20
+      '@next/swc-linux-x64-musl': 15.5.20
+      '@next/swc-win32-arm64-msvc': 15.5.20
+      '@next/swc-win32-x64-msvc': 15.5.20
+      '@opentelemetry/api': 1.9.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.50: {}
@@ -6343,6 +6986,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4:
     optional: true
@@ -6422,6 +7067,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
@@ -6444,6 +7091,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pify@2.3.0: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
@@ -6461,6 +7110,26 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  postcss-import@15.1.0(postcss@8.5.13):
+    dependencies:
+      postcss: 8.5.13
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.13):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.13
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.13)(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.13
+      tsx: 4.21.0
+
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
@@ -6468,6 +7137,24 @@ snapshots:
       jiti: 2.6.1
       postcss: 8.5.13
       tsx: 4.21.0
+
+  postcss-nested@6.2.0(postcss@8.5.13):
+    dependencies:
+      postcss: 8.5.13
+      postcss-selector-parser: 6.1.4
+
+  postcss-selector-parser@6.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.13:
     dependencies:
@@ -6513,6 +7200,11 @@ snapshots:
       unpipe: 1.0.0
     optional: true
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
 
   react-is@19.2.7: {}
@@ -6527,12 +7219,22 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  react@19.2.7: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -6548,6 +7250,13 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@4.0.0:
     dependencies:
@@ -6608,6 +7317,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.27.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -6640,6 +7351,38 @@ snapshots:
     optional: true
 
   setprototypeof@1.2.0:
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:
@@ -6776,6 +7519,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -6794,9 +7542,39 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  tailwindcss@3.4.19(tsx@4.21.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.13
+      postcss-import: 15.1.0(postcss@8.5.13)
+      postcss-js: 4.1.0(postcss@8.5.13)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.13)(tsx@4.21.0)
+      postcss-nested: 6.2.0(postcss@8.5.13)
+      postcss-selector-parser: 6.1.4
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
 
   term-size@2.2.1: {}
 
@@ -6848,8 +7626,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
@@ -6942,6 +7719,8 @@ snapshots:
       browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "."
   - "packages/*"
+  - "apps/*"
   - "examples/08-langchain-adapter"
   - "examples/recipes/*"
 allowBuilds:


### PR DESCRIPTION
Add a private Next.js static marketing site under apps/website with adoption-focused landing copy, a /docs shell, and Vercel-ready export.

## Summary

<!-- What does this PR change and why? Link issue: # -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [ ] Local-first only — no network upload added
- [ ] No new vendor sinks
- [ ] No SaaS / dashboard scope added
- [ ] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [ ] No `step_failed` event introduced
- [ ] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

<!-- Paste commands run and results -->

```bash
# Docs-only minimum:
pnpm typecheck
pnpm test

# Runtime / export changes:
pnpm test:all
pnpm pack:smoke
# npm pack --dry-run  # if package files/exports changed
```

## Screenshots / sample output

<!-- CLI output, trace snippets, or doc previews if relevant -->

## Checklist

- [ ] Tests added or updated (if behavior changed)
- [ ] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [ ] No new runtime dependencies without approval
- [ ] No version bump in this PR (Changesets used for releases)
- [ ] No secrets, production logs, or real PII in commits
