### PR TITLE
docs: link streaming limitations to recipes

### DIFF
--- a/docs/STREAMING-LIMITATIONS.md
+++ b/docs/STREAMING-LIMITATIONS.md
@@ -19,6 +19,20 @@ AgentInspect records **execution trees** from framework callbacks and manual `st
 | **Long-running streams** | No live “typing” view in traces; use terminal/TUI while running, inspect JSONL after completion. |
 | **Silent hangs** | Without completion events, checks flag `running` / stall rules (`--detect-stalls`); not a live watchdog. |
 
+## Framework recipe map
+
+Use the local recipes to verify which streaming signals are emitted and which
+payloads stay unavailable in metadata-only mode:
+
+| Framework path | Recipe | Emitted in local traces | Unavailable by default |
+| -------------- | ------ | ----------------------- | ---------------------- |
+| **Vercel AI SDK** | [`ai-sdk-local-telemetry`](../examples/recipes/ai-sdk-local-telemetry/README.md) | Model IDs, finish reasons, token usage when exposed, timing, and bounded counts/summaries from AI SDK telemetry callbacks. | Raw prompts, generated text, stream chunks, tool inputs/outputs, headers, request bodies, and response bodies. Callers still own `recordInputs: false` and `recordOutputs: false`. |
+| **OpenAI Agents JS** | [`openai-agents-local-tracing`](../examples/recipes/openai-agents-local-tracing/README.md) | Trace/span IDs, parentage, safe names, timing, status, token usage, and bounded span summaries from the processor interface. | Raw prompts, generated text, tool inputs/outputs, custom data, trace metadata, exporter credentials, and provider execution details. |
+| **LangGraph via LangChain** | [`langgraph-callback-local`](../examples/recipes/langgraph-callback-local/README.md) | Graph, node, subgraph, task, branch, checkpoint, handoff, thread, and stream-mode metadata through the LangChain callback boundary. With `stream: true`, chunk counts and timing metadata are stored on the LLM step. | Full graph state, prompts, tool payloads, outputs, raw stream tokens, checkpoint state, and framework edges not present in callback metadata. |
+
+The recipes use deterministic local fixtures. They do not run provider calls,
+hosted tracing, LangSmith, OpenAI exporters, API keys, or network uploads.
+
 ## Recommended workarounds
 
 1. Wrap long tools with explicit `step` boundaries and timeouts in application code.


### PR DESCRIPTION
## Summary

Fixes #69.

This adds a concise framework recipe map to `docs/STREAMING-LIMITATIONS.md` so readers can jump from the limitations page to the local AI SDK, OpenAI Agents, and LangGraph/LangChain recipes. The table calls out which streaming signals are emitted in local traces and which payloads remain unavailable by default in metadata-only mode.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only

## Validation

```bash
pnpm typecheck
pnpm test
git diff --check
```

Results:
- `pnpm typecheck` -> passed
- `pnpm test` -> 147 files passed, 1 skipped; 1208 tests passed, 21 skipped
- `git diff --check` -> clean

## Screenshots / sample output

Not applicable; docs-only markdown update.

## Checklist

- [ ] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits