### PR TITLE
fix(core): stop duplicating attributes section in HTML run reports

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -138,8 +138,16 @@ export function buildRunReport(
     '<section class="tree">',
     "</section>",
   );
+  // The exporter emits Errors before Attributes, so the errors fragment must
+  // stop at the attributes heading when both sections are present; ending at
+  // <footer> would swallow the attributes section and duplicate it below.
+  const errorsSectionEnd = treeHtml.content.includes(
+    "<h2>Attributes (bounded)</h2>",
+  )
+    ? "<h2>Attributes (bounded)</h2>"
+    : "<footer>";
   const errorsSection = treeHtml.content.includes("<h2>Errors</h2>")
-    ? extractHtmlFragment(treeHtml.content, "<h2>Errors</h2>", "<footer>")
+    ? extractHtmlFragment(treeHtml.content, "<h2>Errors</h2>", errorsSectionEnd)
     : "";
   const attrsSection = treeHtml.content.includes("<h2>Attributes (bounded)</h2>")
     ? extractHtmlFragment(

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -109,6 +109,23 @@ describe("buildRunReport", () => {
     expect(report.content).toContain("## Errors");
   });
 
+  it("html report renders errors and attributes sections exactly once", () => {
+    const report = buildRunReport(sensitiveTrace(), {
+      format: "html",
+      includeAttributes: true,
+    });
+
+    const errorHeadings =
+      report.content.match(/<h2>Errors<\/h2>/g) ?? [];
+    const attrHeadings =
+      report.content.match(/<h2>Attributes \(bounded\)<\/h2>/g) ?? [];
+    expect(errorHeadings).toHaveLength(1);
+    expect(attrHeadings).toHaveLength(1);
+    expect(report.content.indexOf("<h2>Errors</h2>")).toBeLessThan(
+      report.content.indexOf("<h2>Attributes (bounded)</h2>"),
+    );
+  });
+
   it("markdown report includes token line in what section when present", async () => {
     const events = await loadFixtureTrace("llm-with-tokens");
     const report = buildRunReport(events as any, { format: "markdown" });


### PR DESCRIPTION
## Summary

Fixes the duplicated "Attributes (bounded)" section in HTML run reports. `buildRunReport` extracts the Errors and Attributes fragments from the `exportHtml` output and both extractions ended at `<footer>`. Because the exporter emits Errors before Attributes, the Errors fragment also captured the entire Attributes section, which was then appended a second time on its own. Any HTML report built with `includeAttributes: true` for a run containing errors (for example `agent-inspect report <run-id> --attributes` on a failed run) rendered the attributes block twice, with the first copy sitting under the Errors heading.

The fix ends the Errors fragment at the `<h2>Attributes (bounded)</h2>` heading when that section is present, and keeps `<footer>` as the end marker otherwise. Markdown reports were never affected. No public API, schema, or export surface changes.

Closes #77

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm build          # pass
pnpm typecheck      # pass
pnpm exec vitest run packages/core/test/report.test.ts   # 11/11 pass, includes new regression test
pnpm size           # pass, 11.31 kB of 120 kB limit
pnpm fixtures:check # pass
```

Full `pnpm test` on my machine (Windows 11) reports 64 failures in 20 files, but they are identical on a clean `main` checkout without this change and come from path handling in the test environment (for example doubled drive prefixes like `C:\C:\...`). They are unrelated to this diff; all report tests pass locally and CI runs on ubuntu-latest where these do not occur.

Verified end to end against the built package: before the fix a synthetic failed run with `includeAttributes: true` produced two `<h2>Attributes (bounded)</h2>` headings, after the fix exactly one, with Errors rendered before Attributes.

## Screenshots / sample output

Before (built dist, repro script from #77):

```text
Attributes headings: 2
Errors headings: 1
```

After:

```text
Attributes headings: 1
Errors headings: 1
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, no documented behavior change
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits

@rajudandigam this only touches the report composition path in core, the exporter itself is unchanged. If you would rather have `exportHtml` emit explicit section boundary markers so the report does not depend on heading strings, I am happy to rework it that way instead.
