### PR TITLE
docs: add log ingest config cookbook

### DIFF
--- a/docs/LOG-INGEST-COOKBOOK.md
+++ b/docs/LOG-INGEST-COOKBOOK.md
@@ -1,0 +1,186 @@
+# Log ingest config cookbook
+
+Copy-pasteable `agent-inspect.logs.json` patterns for turning structured logs into local execution trees, in one place. This documents current `LogIngestConfig` behavior only; for concept background see [LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md), and for the full config type see [SCHEMA.md](./SCHEMA.md).
+
+No vendor sinks. No network upload. JSON logs are first-class; log4js-style lines are best-effort.
+
+## Format boundaries
+
+| Input | Support | Notes |
+|-------|---------|-------|
+| Line-delimited JSON | **First-class** (`--format json`) | Deterministic parse; field mapping is explicit |
+| log4js text + embedded JSON | **Best-effort** (`--format log4js`) | Parses the last balanced `{...}` per line; prefix text is ignored |
+| Plain printf / prose lines | Unsupported | No reliable `runId` / `event` / `timestamp` extraction |
+| JS object literal strings | Unsupported (unsafe) | No `eval`; not valid JSON |
+
+## Required and default fields
+
+Three fields drive grouping. Everything else refines the tree.
+
+| Field | Purpose | Default |
+|-------|---------|---------|
+| `runIdKeys` | Which log fields group lines into a run (first match wins) | `["runId", "traceId", "requestId", "decisionId", "jobId"]` |
+| `eventKey` | Which field names the event for mapping | `"event"` |
+| `timestampKey` | Which field orders events | `"timestamp"` |
+| `messageKey` | Human message for tree labels | `"message"` |
+| `levelKey` | Log level passthrough | `"level"` |
+| `heuristicWindowMs` | Grouping window for lines without an explicit parent | `2000` |
+
+Your config is merged over these defaults: top-level fields you set replace the default, and `mappings` are merged key by key, so custom mappings add to the built-in wildcard mappings (`*.error`, `*.failed`, `*.tool.*`, `*.llm.*`, `*.agent.*`, `*.retriever.*`, `*.result.*`) instead of replacing them.
+
+## Minimal starter
+
+The smallest useful config (also shipped as [`fixtures/configs/minimal-agent-inspect.logs.json`](../fixtures/configs/minimal-agent-inspect.logs.json)):
+
+```json
+{
+  "runIdKeys": ["runId", "decisionId", "requestId"],
+  "eventKey": "event",
+  "timestampKey": "timestamp",
+  "mappings": {
+    "*.started": { "status": "running" },
+    "*.completed": { "status": "ok" },
+    "*.failed": { "kind": "ERROR", "status": "error" },
+    "*.error": { "kind": "ERROR", "status": "error" },
+    "*.tool.*": { "kind": "TOOL" },
+    "*.llm.*": { "kind": "LLM" },
+    "*.agent.*": { "kind": "AGENT" }
+  },
+  "redact": [
+    "authorization",
+    "cookie",
+    "token",
+    "apiKey",
+    "password",
+    "secret",
+    "email"
+  ]
+}
+```
+
+Run it:
+
+```bash
+npx agent-inspect logs app.log --format json --config agent-inspect.logs.json
+```
+
+## Framework field names at a glance
+
+The shipped recipes differ mostly in which JSON fields the logger emits. Point the `*Key` options at your logger's names:
+
+| Recipe | `timestampKey` | `messageKey` | `runIdKeys` | Format |
+|--------|----------------|--------------|-------------|--------|
+| [pino-json-logs](../examples/recipes/pino-json-logs/README.md) | `time` | `msg` | `runId`, `decisionId`, `requestId`, `reqId` | `json` |
+| [winston-json-logs](../examples/recipes/winston-json-logs/README.md) | `timestamp` | `message` | `runId`, `decisionId`, `requestId`, `reqId` | `json` |
+| [nestjs-json-logging](../examples/recipes/nestjs-json-logging/README.md) | `timestamp` | `message` | `runId`, `decisionId`, `requestId`, `traceId` | `json` |
+| [log4js-json-layout](../examples/recipes/log4js-json-layout/README.md) | `timestamp` | `msg` | `runId`, `decisionId`, `requestId` | `log4js` |
+| [proactive-agent-logs](../examples/recipes/proactive-agent-logs/README.md) | `timestamp` | `message` | `decisionId`, `requestId`, `jobId` | `json` or `log4js` |
+
+Each recipe directory contains the full `agent-inspect.logs.json` plus a sample log file, so you can run them as-is.
+
+## pino
+
+pino emits `time` (epoch millis) and `msg` by default. Only the key names change relative to the starter:
+
+```json
+{
+  "runIdKeys": ["runId", "decisionId", "requestId", "reqId"],
+  "eventKey": "event",
+  "timestampKey": "time",
+  "messageKey": "msg",
+  "levelKey": "level"
+}
+```
+
+Full config with event mappings: [`examples/recipes/pino-json-logs/agent-inspect.logs.json`](../examples/recipes/pino-json-logs/agent-inspect.logs.json).
+
+## Winston and NestJS
+
+Both emit `timestamp` and `message`; NestJS setups commonly carry `traceId`, so it joins `runIdKeys`:
+
+```json
+{
+  "runIdKeys": ["runId", "decisionId", "requestId", "traceId"],
+  "eventKey": "event",
+  "timestampKey": "timestamp",
+  "messageKey": "message",
+  "levelKey": "level"
+}
+```
+
+Full configs: [`examples/recipes/winston-json-logs/agent-inspect.logs.json`](../examples/recipes/winston-json-logs/agent-inspect.logs.json) and [`examples/recipes/nestjs-json-logging/agent-inspect.logs.json`](../examples/recipes/nestjs-json-logging/agent-inspect.logs.json).
+
+## log4js (embedded JSON)
+
+Same config shape as the starter (with `messageKey: "msg"`), but the file is parsed with `--format log4js`: the parser takes the last balanced `{...}` on each line and ignores the text prefix. Parsing is best-effort; prefer line-delimited JSON when you control the logger.
+
+```bash
+npx agent-inspect logs app.log --format log4js --config agent-inspect.logs.json
+```
+
+Full config: [`examples/recipes/log4js-json-layout/agent-inspect.logs.json`](../examples/recipes/log4js-json-layout/agent-inspect.logs.json).
+
+## Named event mappings
+
+Wildcard mappings classify by convention; named mappings pin specific events to a kind, display name, and run boundary. From the proactive-agent recipe:
+
+```json
+{
+  "mappings": {
+    "proactive.job.started": { "kind": "RUN", "name": "job:started", "startsRun": true },
+    "proactive.agent.started": { "kind": "AGENT", "name": "agent:started" },
+    "proactive.tool.conversation_history_fetched": { "kind": "TOOL", "name": "tool:get_conversation_history" },
+    "proactive.tool.*": { "kind": "TOOL" },
+    "proactive.llm.*": { "kind": "LLM" },
+    "proactive.result.*": { "kind": "RESULT" }
+  }
+}
+```
+
+More specific patterns win over wildcards. `startsRun: true` marks the event that opens a run; without it, grouping falls back to `runIdKeys` plus the `heuristicWindowMs` window.
+
+## Redaction
+
+The conservative default keys (`authorization`, `cookie`, `token`, `apiKey`, `password`, `secret`, `email`) are always redacted for log-derived paths, case-insensitively and recursively, with values replaced by `[REDACTED]`. A `redact` array in your config adds rules; strings mean full redaction, and object rules choose a strategy:
+
+```json
+{
+  "redact": [
+    "sessionKey",
+    { "key": "userUuid", "strategy": "prefix", "keep": 8 },
+    { "key": "accountRef", "strategy": "hash" }
+  ]
+}
+```
+
+- `full` replaces the value with `[REDACTED]` (default for string rules)
+- `prefix` keeps the first `keep` characters (default 8)
+- `hash` replaces the value with a short SHA-256 tag like `[HASH:1a2b3c4d]`
+
+Redaction is a key-based safeguard, not DLP. Review output before sharing; see [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md).
+
+## CLI quick reference
+
+```bash
+# One-shot parse to trees
+npx agent-inspect logs app.log --format json --config agent-inspect.logs.json
+
+# JSON payload for scripting (events, trees, warnings, summary)
+npx agent-inspect logs app.log --format json --config agent-inspect.logs.json --json
+
+# Follow a growing file locally (not a production monitor)
+npx agent-inspect tail --file app.log --format json --config agent-inspect.logs.json
+
+# Read once and exit (CI-friendly)
+npx agent-inspect tail --file app.log --format json --config agent-inspect.logs.json --once
+```
+
+Per-key overrides (`--run-id-key`, `--event-key`, `--timestamp-key`, and friends) work without a config file for quick experiments; move to a config once the mapping stabilizes. Full flag list: [CLI.md](./CLI.md).
+
+## See also
+
+- [LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md) for logger setup and field recommendations
+- [LOG-TO-TREE-QUICKSTART.md](./LOG-TO-TREE-QUICKSTART.md) for the five-minute path
+- [LOGS.md](./LOGS.md) for ingest internals and warnings
+- [`fixtures/configs/`](../fixtures/configs/) for validated sample configs
+- [`examples/recipes/README.md`](../examples/recipes/README.md) for the runnable recipes

--- a/docs/LOGGING-PLAYBOOK.md
+++ b/docs/LOGGING-PLAYBOOK.md
@@ -160,6 +160,7 @@ Runnable framework recipes live under `examples/recipes/` (pino JSON logs, Winst
 
 ## See also
 
+- `docs/LOG-INGEST-COOKBOOK.md` (copy-pasteable config patterns per framework)
 - `docs/LOGS.md`
 - `docs/LOG-TO-TREE-QUICKSTART.md`
 - `docs/CLI.md` (`logs`, `tail`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This folder is the full canonical reference. The marketing site and root README 
 | [SCHEMA.md](./SCHEMA.md) · [ARCHITECTURE.md](./ARCHITECTURE.md) | Data model and boundaries |
 | [ADAPTERS.md](./ADAPTERS.md) · [ADAPTER-CONFORMANCE.md](./ADAPTER-CONFORMANCE.md) | Framework integrations |
 | [AI-SDK-ADOPTION.md](./AI-SDK-ADOPTION.md) · [OPENAI-AGENTS-LOCAL.md](./OPENAI-AGENTS-LOCAL.md) · [NESTJS.md](./NESTJS.md) | Framework guides |
-| [LOGS.md](./LOGS.md) · [LOG-TO-TREE-QUICKSTART.md](./LOG-TO-TREE-QUICKSTART.md) · [LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md) | Log ingest |
+| [LOGS.md](./LOGS.md) · [LOG-TO-TREE-QUICKSTART.md](./LOG-TO-TREE-QUICKSTART.md) · [LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md) · [LOG-INGEST-COOKBOOK.md](./LOG-INGEST-COOKBOOK.md) | Log ingest |
 | [DIFF.md](./DIFF.md) · [EXPORTS.md](./EXPORTS.md) | Compare and export |
 | [CI-ARTIFACTS.md](./CI-ARTIFACTS.md) | CI / test artifacts |
 | [PERFORMANCE.md](./PERFORMANCE.md) · [SCALE-LIMITS.md](./SCALE-LIMITS.md) · [STREAMING-LIMITATIONS.md](./STREAMING-LIMITATIONS.md) | Scale and streaming |


### PR DESCRIPTION
## Summary

Adds `docs/LOG-INGEST-COOKBOOK.md` from #27: one place for copy-pasteable `agent-inspect.logs.json` patterns instead of reading five recipe directories.

- Format boundaries up front: JSON first-class, log4js best-effort (last balanced `{...}` per line), printf and JS object literals unsupported
- Required fields (`runIdKeys`, `eventKey`, `timestampKey`) with the actual defaults from `DEFAULT_LOG_INGEST_CONFIG` and how user configs merge over them (mappings merge key by key)
- A minimal starter config mirroring `fixtures/configs/minimal-agent-inspect.logs.json`
- A per-framework field-name table plus short sections for the pino, Winston, NestJS, log4js, and proactive-agent recipes, each linking to the full shipped config
- Named event mappings (`startsRun`, specificity over wildcards) using the proactive recipe as the example
- Redaction: the always-on conservative key list and the `full` / `prefix` / `hash` strategies
- `logs` and `tail` CLI quick reference

Documents current `LogIngestConfig` behavior only, per the maintainer note; no parser or normalizer changes, no new event names. All snippets are taken from or reduced from the shipped recipe and fixture configs. Linked from `LOGGING-PLAYBOOK.md` (See also) and the `docs/README.md` index row for log ingest. I did not add the new file to the npm `files` array since `LOGGING-PLAYBOOK.md` is repo-only too; happy to add it if you want it shipped in the tarball.

Closes #27

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only

## Validation

```bash
pnpm typecheck     # pass
pnpm recipes:check # pass, 28 recipes validated
```

Also verified the documented commands against the built CLI: `logs` and `tail --once` with the pino recipe sample and config both parse the expected tree and exit 0. All relative links in the new doc point at files that exist.

## Checklist

- [ ] Tests added or updated (if behavior changed) - docs only, no behavior change
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
