### PR TITLE
docs: refresh COMPARE.md for the v3.5 package map

### DIFF
--- a/docs/COMPARE.md
+++ b/docs/COMPARE.md
@@ -1,15 +1,29 @@
-## Compare AgentInspect
+# Compare AgentInspect
 
-AgentInspect is a local-first execution-tree debugger for TypeScript AI agents. It’s designed for inner-loop debugging, deterministic local eval heuristics, redaction, and quick inspection — not as a replacement for hosted observability, dataset evaluation, or production monitoring platforms.
+AgentInspect is a local-first trace workbench for TypeScript AI agents: capture runs as local JSONL, inspect and diff them from the CLI, gate them in CI, and redact before sharing. It is designed for the inner loop, not as a replacement for hosted observability, dataset evaluation, or production monitoring platforms. Those tools complement AgentInspect; this page maps where each fits.
 
 **Docs site:** [https://agentinspect.vercel.app/docs/compare/](https://agentinspect.vercel.app/docs/compare/)
+
+## Category comparison
+
+| Dimension | AgentInspect | Hosted dashboards (LangSmith, Langfuse) | Eval platforms (Braintrust) | Production APM / OTel pipelines |
+| --------- | ------------ | --------------------------------------- | --------------------------- | ------------------------------- |
+| Where traces live | Local JSONL on your disk | Vendor or self-hosted backend | Vendor backend | Your collector + backend |
+| Account / setup | None; `npm install` + CLI | Account or deployment | Account | SDK + collector + backend |
+| Primary surface | CLI (`view`, `report`, `diff`, `check`), local viewer, in-repo VS Code extension | Web dashboards | Web dashboards, eval UI | Dashboards, alerting |
+| Evals | Deterministic local heuristics and CI gates (`check`, `eval`, `circuit`, `guardrails`) | Platform evals | Datasets, scoring, regressions at scale | Not the focus |
+| Retention / fleet view | Not the goal | Strong | Strong | Strong |
+| Data sharing | Explicit `redact` + `scan` / `verify-safe` before you share a file | Team access controls | Team access controls | Org pipelines |
+| Network behavior | No upload; everything stays local unless you share a file | Uploads traces by design | Uploads by design | Ships telemetry by design |
+
+If you need hosted retention, fleet dashboards, dataset management, or org-wide pipelines, use one of those platforms alongside AgentInspect. Boundaries are listed in [LIMITATIONS.md](./LIMITATIONS.md); concrete inner-loop workflows in [USE-CASES.md](./USE-CASES.md).
 
 ## AgentInspect vs console.log
 
 - **console.log is flat**: logs are a stream of lines without run grouping or step boundaries.
 - **AgentInspect adds structure**: runs, nested steps, step types (tool/LLM), durations, status summaries, and local trace files you can inspect later.
 - **console.log still matters**: use it for quick values or ad-hoc debugging inside a step.
-- **AgentInspect helps you understand flow**: especially when your agent fans out, retries, or has nested tool/LLM calls.
+- **Existing structured logs work too**: the log ingest path parses JSON logs into trees without instrumentation ([LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md)).
 
 ## AgentInspect vs LangSmith
 
@@ -17,7 +31,7 @@ LangSmith is a hosted/platform workflow for tracing, evaluation, and observabili
 
 AgentInspect is local-first CLI debugging:
 
-- Use AgentInspect to debug locally before/alongside LangSmith when iterating on agent logic.
+- Use AgentInspect to debug locally before or alongside LangSmith when iterating on agent logic; `@agent-inspect/langchain` captures LangChain callbacks locally.
 - AgentInspect does not provide hosted dashboards, dataset/eval management workflows, or production tracing pipelines.
 
 ## AgentInspect vs Langfuse
@@ -26,7 +40,7 @@ Langfuse provides broader LLM observability (tracing, prompt management, dataset
 
 AgentInspect focuses on local execution trees and CLI workflows:
 
-- Complementary: use AgentInspect for quick local run understanding; use Langfuse for dashboards and longer-lived observability workflows.
+- Complementary: use AgentInspect for quick local run understanding and PR/debug artifacts; use Langfuse for dashboards and longer-lived observability workflows.
 - Not a replacement.
 
 ## AgentInspect vs Braintrust
@@ -35,7 +49,7 @@ Braintrust is strong for evals, regressions, datasets, and production AI quality
 
 AgentInspect is lighter and local-first:
 
-- Use AgentInspect to understand a single run locally and run deterministic trace checks/eval heuristics before sharing artifacts.
+- Use AgentInspect to understand a single run locally and run deterministic trace checks (`check`, `@agent-inspect/eval` heuristics, `@agent-inspect/guardrails`, `@agent-inspect/circuit`) before sharing artifacts.
 - Use Braintrust when you want repeatable evals, comparisons at scale, and production quality workflows.
 
 ## AgentInspect vs Phoenix / OpenInference
@@ -44,7 +58,7 @@ Phoenix and the OpenInference ecosystem are standards-oriented and useful for tr
 
 AgentInspect can export **OpenInference-compatible JSON** and **OTLP JSON** as local files:
 
-- Exports are **compatibility-oriented** and should be validated against your target backend/collector.
+- Exports are **compatibility-oriented** and experimental; validate them against your target backend or collector.
 - AgentInspect does not claim that every backend will accept these exports without configuration.
 
 ## AgentInspect vs OpenTelemetry setup
@@ -53,9 +67,9 @@ OpenTelemetry is powerful, but setup can be heavier (SDK configuration, exporter
 
 AgentInspect avoids SDK/collector setup for local debugging:
 
-- Use AgentInspect when you want quick, local execution trees with no collector required.
+- Use AgentInspect when you want quick, local execution trees with no collector required; no OTel SDK is added to the root package.
 - Use OpenTelemetry when you need organization-wide production telemetry pipelines.
-- Exports can help bridge later, but AgentInspect is not an OpenTelemetry SDK replacement.
+- Local OTLP JSON export can help bridge later, but AgentInspect is not an OpenTelemetry SDK replacement.
 
 ## Quick decision table
 
@@ -63,9 +77,12 @@ AgentInspect avoids SDK/collector setup for local debugging:
 | --- | --- |
 | Local agent debugging | Strong fit |
 | No-account CLI tracing | Strong fit |
-| Deterministic local eval heuristics | Good fit |
+| Framework-native capture (AI SDK, OpenAI Agents, LangChain, MCP) | Good fit (optional adapter packages) |
+| Deterministic local eval heuristics and CI gates | Good fit |
+| Loop / retry / timeout analysis (`circuit`) | Good fit |
 | Share-safe local redaction copy | Good fit |
-| VS Code trace sidebar (in-repo / dev host) | Good fit — Marketplace listing separate |
+| Existing structured logs to trees | Good fit |
+| VS Code trace review (in-repo extension) | Good fit; Marketplace listing separate |
 | Production dashboards | Not the goal |
 | Hosted eval datasets | Not the goal |
 | Prompt management | Not the goal |
@@ -74,12 +91,16 @@ AgentInspect avoids SDK/collector setup for local debugging:
 
 ## v3.5 positioning (local inner loop)
 
-AgentInspect v3.5 is the **adoption release** — not new runtime surface. Use it when:
+AgentInspect v3.5 is the **adoption release**. The npm map is one core package (`agent-inspect`: APIs + CLI) plus optional packages that stay out of the root dependency graph: framework adapters (`ai-sdk`, `openai-agents`, `langchain`, `mcp`, `adapter-sdk`), CI and quality gates (`vitest`, `jest`, `eval`, `guardrails`, `circuit`, `harness`), and inspection surfaces (`viewer`, `tui`, `mcp-server`, `redact`). See the [package map](../README.md#package-map).
 
-- You want **traces on disk** before/alongside hosted tools
+Use it when:
+
+- You want **traces on disk** before or alongside hosted tools
 - You need **CI gates** (`check`, `eval`, `circuit`) without a vendor account
 - You want **metadata-only** defaults and explicit `redact` before sharing
 
 Keep using LangSmith, Langfuse, Braintrust, Phoenix, or OTel when you need hosted retention, fleet dashboards, dataset management, or org-wide production pipelines. AgentInspect is complementary.
 
-**Full adoption path:** [ADOPTION.md](./ADOPTION.md)
+Before posting any exported trace to an issue, PR, or chat, follow [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md) and [SECURITY.md](../SECURITY.md): redaction is a key-based safeguard, and exports deserve a human review.
+
+**Full adoption path:** [ADOPTION.md](./ADOPTION.md) · **Boundaries:** [LIMITATIONS.md](./LIMITATIONS.md) · **Scenarios:** [USE-CASES.md](./USE-CASES.md)


### PR DESCRIPTION
## Summary

Refreshes `docs/COMPARE.md` for the v3.5 package map, from #9.

- Adds a category comparison table up front: AgentInspect as a local-first trace workbench vs hosted dashboards (LangSmith, Langfuse), eval platforms (Braintrust), and production APM / OTel pipelines, across trace location, setup, surface, evals, retention, sharing, and network behavior
- Updates the positioning section to describe the v3.5 npm map (core package plus optional adapters, CI/quality gates, and inspection surfaces) with a link to the README package map
- Extends the quick decision table with framework-native capture, circuit analysis, and log-ingest rows
- Links USE-CASES.md and LIMITATIONS.md for scenarios and boundaries, and SAFE-TRACE-SHARING.md plus SECURITY.md for redaction guidance before posting exported traces
- Fixes the document title from `##` to a proper `#` h1, matching the other docs

The framing stays complement, not compete, per the maintainer note: vendors are described by capability, every "not the goal" row points at using a dedicated platform, and no SaaS or dashboard scope is claimed for AgentInspect. The existing per-vendor sections are kept and lightly updated (LangChain adapter mention, OpenInference/OTLP exports called compatibility-oriented and experimental, no OTel SDK in root).

No README changes: it already links COMPARE.md from the documentation table.

Closes #9

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
```

All relative links in the updated doc verified against files that exist (`USE-CASES.md`, `LIMITATIONS.md`, `SAFE-TRACE-SHARING.md`, `ADOPTION.md`, `LOGGING-PLAYBOOK.md`, root `SECURITY.md`, README `#package-map` anchor).

## Checklist

- [ ] Tests added or updated (if behavior changed) - docs only, no behavior change
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
