### PR TITLE
fix(cli): report true match count in list summary

### DIFF
--- a/packages/cli/src/list.ts
+++ b/packages/cli/src/list.ts
@@ -105,11 +105,12 @@ export async function list(options: ListOptions = {}): Promise<void> {
     }
 
     const limit = parseLimit(options.limit);
+    // Filter without a limit so the summary reports how many runs matched;
+    // the limit only bounds the rows shown.
     const filtered = filterTraces(metas, {
       status: options.status,
       name: options.name,
       since: options.since,
-      limit,
     });
     const shown = filtered.slice(0, limit);
 

--- a/packages/cli/test/list.test.ts
+++ b/packages/cli/test/list.test.ts
@@ -340,6 +340,28 @@ describe("list", () => {
     logSpy.mockRestore();
   });
 
+  it("summary reports total matching runs when limit truncates", async () => {
+    const ids = ["run_t3", "run_t2", "run_t1"];
+    const times = [3000, 2000, 1000];
+    for (let i = 0; i < 3; i++) {
+      const id = ids[i]!;
+      const t = times[i]!;
+      await writeFile(
+        path.join(traceDir, `${id}.jsonl`),
+        jsonl(
+          runStarted(id, `name-${id}`, t, t),
+          runCompleted(id, "success", t + 1, 1),
+        ),
+        "utf-8",
+      );
+    }
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await list({ dir: traceDir, limit: "2" });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Showing 2 of 3 runs");
+    logSpy.mockRestore();
+  });
+
   it("sets exit code when listTraceFiles fails unexpectedly", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(core.TraceDirectory.prototype, "list").mockRejectedValueOnce(


### PR DESCRIPTION
## Summary

Fixes the `list` summary line always printing `Showing N of N runs`. The command passed the parsed `--limit` into `filterTraces`, which truncates its result, so the summary compared the shown rows against an already-limited set; the redundant `filtered.slice(0, limit)` right after shows the total was meant to be the unlimited match count. The fix filters without the limit and applies it only when slicing the rows to show, so `Showing X of Y runs` now reports how many runs actually matched.

Rows shown, newest-first ordering, and `--json` output are unchanged: the JSON path still emits the limited `shown` array, and `filterTraces` itself is untouched, so no other caller is affected.

Closes #82

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [x] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/cli/test/list.test.ts
# 17/18 pass including the new regression test asserting "Showing 2 of 3 runs";
# the 1 failure ("lists v0.2 metadata from the embedded run") is pre-existing on
# clean main on my Windows machine (test env path issue, same as noted on #78)
# and is unrelated to this change. CI runs on ubuntu-latest where it passes.
```

Verified end to end against the rebuilt CLI with three fixture traces in a temp directory:

- Before: `list --limit 2` printed `Showing 2 of 2 runs`
- After: `list --limit 2` prints `Showing 2 of 3 runs`, and `list --name minimal --limit 1` prints `Showing 1 of 2 runs`

## Screenshots / sample output

```text
$ agent-inspect list --dir demo-traces --limit 2
...
Showing 2 of 3 runs
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, output format unchanged
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
