### PR TITLE
examples: add minimal adapter SDK source

### DIFF
--- a/examples/adapter-sdk/minimal-source-adapter/README.md
+++ b/examples/adapter-sdk/minimal-source-adapter/README.md
@@ -1,0 +1,35 @@
+# Minimal Adapter SDK source adapter
+
+This example shows the smallest shape of a third-party adapter package that uses
+`@agent-inspect/adapter-sdk` without adding a vendor SDK, network access, or
+secrets.
+
+It demonstrates how an adapter author can:
+
+1. register adapter metadata with `createAdapterRegistration`;
+2. keep the default capture mode metadata-only;
+3. capture a deterministic fake framework run with local AgentInspect traces;
+4. run `runAdapterConformance` against the captured events.
+
+## Run it
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter agent-inspect-example-minimal-source-adapter start
+```
+
+The example writes a local `.agent-inspect-minimal-adapter/` trace directory and
+prints the adapter registration, privacy checklist, and conformance result.
+
+## Privacy defaults
+
+- No API keys or credentials are required.
+- No network calls are made by the fake framework source.
+- The adapter checklist uses `captureMode: "metadata-only"`.
+- The conformance run checks that a forbidden raw string does not appear in the
+  persisted events.
+
+Use this as a copy-paste starting point for real adapter packages, then add your
+framework-specific event mapping and fixtures.

--- a/examples/adapter-sdk/minimal-source-adapter/package.json
+++ b/examples/adapter-sdk/minimal-source-adapter/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-inspect-example-minimal-source-adapter",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prestart": "pnpm --workspace-root run build && pnpm --filter @agent-inspect/adapter-sdk run build",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@agent-inspect/adapter-sdk": "workspace:*",
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/adapter-sdk/minimal-source-adapter/src/index.ts
+++ b/examples/adapter-sdk/minimal-source-adapter/src/index.ts
@@ -1,0 +1,78 @@
+import { inspectRun, step } from "agent-inspect";
+import { openTrace } from "agent-inspect/readers";
+import { TraceDirectory } from "agent-inspect/advanced";
+import {
+  createAdapterRegistration,
+  runAdapterConformance,
+  runPrivacyChecklist,
+} from "@agent-inspect/adapter-sdk";
+
+class FakeFrameworkSource {
+  async run(prompt: string): Promise<string> {
+    const lookup = await step.tool("lookup-policy", async () => ({
+      source: "fixture-policy",
+      matched: true,
+    }));
+
+    if (!lookup.matched) {
+      throw new Error("fixture policy lookup failed");
+    }
+
+    return `metadata-only reply for: ${prompt}`;
+  }
+}
+
+async function main(): Promise<void> {
+  const registration = createAdapterRegistration({
+    id: "fake-framework-source",
+    name: "Fake Framework Source",
+    version: "0.1.0",
+    framework: "fake-framework",
+    docsUrl: "https://github.com/rajudandigam/agent-inspect/tree/main/examples/adapter-sdk/minimal-source-adapter",
+  });
+
+  const privacy = runPrivacyChecklist({
+    captureMode: "metadata-only",
+    redactionDocumented: true,
+  });
+
+  if (!privacy.ok) {
+    throw new Error(`privacy checklist failed: ${JSON.stringify(privacy.items)}`);
+  }
+
+  const traceDir = ".agent-inspect-minimal-adapter";
+  const source = new FakeFrameworkSource();
+
+  await inspectRun(
+    "minimal-source-adapter",
+    async () => {
+      await step("fake-framework.run", async () => source.run("summarize local trace"));
+    },
+    { traceDir },
+  );
+
+  const traces = new TraceDirectory({ dir: traceDir });
+  const files = await traces.list();
+  if (files.length === 0) {
+    throw new Error("expected at least one captured trace file");
+  }
+
+  const read = await openTrace({ type: "file", path: traces.getPath(files[0]!) });
+  const result = await runAdapterConformance({
+    adapterId: registration.id,
+    events: read.events,
+    expectedKinds: ["RUN", "LOGIC", "TOOL", "LOGIC", "LOGIC", "RUN"],
+    forbiddenRawStrings: ["super-secret-token"],
+  });
+
+  console.log(JSON.stringify({ registration, privacy, conformance: result }, null, 2));
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/adapter-sdk/README.md
+++ b/packages/adapter-sdk/README.md
@@ -28,6 +28,12 @@ export const registration = createAdapterRegistration({
 });
 ```
 
+## Minimal third-party adapter example
+
+See [`examples/adapter-sdk/minimal-source-adapter`](../../examples/adapter-sdk/minimal-source-adapter)
+for a dependency-free fake framework source that registers adapter metadata,
+captures a local metadata-only trace, and runs `runAdapterConformance`.
+
 ## Privacy
 
 - SDK helpers enforce local-first patterns; adapters must not upload by default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,18 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/adapter-sdk/minimal-source-adapter:
+    dependencies:
+      '@agent-inspect/adapter-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/adapter-sdk
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/recipes/ai-sdk-local-telemetry:
     dependencies:
       '@agent-inspect/ai-sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "packages/*"
   - "apps/*"
   - "examples/08-langchain-adapter"
+  - "examples/adapter-sdk/*"
   - "examples/recipes/*"
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Summary

Fixes #60 by adding a dependency-free minimal Adapter SDK example for third-party adapter authors.

## Changes

- Add `examples/adapter-sdk/minimal-source-adapter/` with:
  - a fake framework source;
  - adapter metadata registration via `createAdapterRegistration`;
  - metadata-only privacy checklist validation;
  - a local trace capture with `inspectRun`/`step`;
  - `runAdapterConformance` against the captured events.
- Add the adapter SDK examples path to `pnpm-workspace.yaml`.
- Link the example from `packages/adapter-sdk/README.md`.

## Verification

- `pnpm --filter agent-inspect-example-minimal-source-adapter start`
  - builds the workspace packages;
  - runs the example;
  - prints a passing privacy checklist and conformance result.
- `pnpm typecheck`
- `pnpm exec vitest run packages/adapter-sdk/test/index.test.ts`
  - 4 tests passed.
- `pnpm test`
  - 152 test files passed;
  - 1274 tests passed.
- `git diff --check`

## Notes

The example is deterministic and local-only: no API keys, vendor SDKs, external services, network calls, or uploads.