### PR TITLE
examples: add adapter SDK custom renderer example

### DIFF
--- a/examples/adapter-sdk/custom-renderer/README.md
+++ b/examples/adapter-sdk/custom-renderer/README.md
@@ -1,0 +1,51 @@
+# Custom renderer example (adapter SDK)
+
+This example implements the `TraceRenderer` contract from
+`@agent-inspect/adapter-sdk` as a standalone markdown summary renderer over a
+persisted run tree, with no changes to the core renderer contract.
+
+It demonstrates how a renderer author can:
+
+1. define a renderer with `defineRenderer` (`src/renderer.ts`);
+2. keep output metadata-only: names, kinds, statuses, and durations, never
+   attribute values or step return values;
+3. compose the renderer with `renderWithSafety` for truncation bounds and
+   forbidden-string leak checks;
+4. render a tree built from locally captured events via
+   `persistedInspectEventsToRunTrees`.
+
+## Run it
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter agent-inspect-example-custom-renderer start
+```
+
+The example captures a deterministic local run into
+`.agent-inspect-custom-renderer/`, renders it, and prints the markdown followed
+by the content type and safety warnings. It exits non-zero if any expected
+output marker is missing.
+
+## Expected output markers
+
+```text
+# Run summary: custom-renderer-demo
+| runId |
+## Steps
+contentType: text/markdown
+```
+
+## Tests
+
+Renderer output shape is covered by
+[`packages/adapter-sdk/test/example-custom-renderer.test.ts`](../../../packages/adapter-sdk/test/example-custom-renderer.test.ts):
+markers present, `text/markdown` content type, no step return values in the
+output, deterministic rendering, and `renderWithSafety` truncation.
+
+## Privacy defaults
+
+- No API keys, no network calls; the traced run is a deterministic fake.
+- The renderer never serializes attributes, so prompts and outputs stay out of
+  the summary even when the trace contains them.

--- a/examples/adapter-sdk/custom-renderer/package.json
+++ b/examples/adapter-sdk/custom-renderer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-inspect-example-custom-renderer",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prestart": "pnpm --workspace-root run build && pnpm --filter @agent-inspect/adapter-sdk run build",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@agent-inspect/adapter-sdk": "workspace:*",
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/adapter-sdk/custom-renderer/src/index.ts
+++ b/examples/adapter-sdk/custom-renderer/src/index.ts
@@ -1,0 +1,59 @@
+import { inspectRun, step } from "agent-inspect";
+import { persistedInspectEventsToRunTrees } from "agent-inspect/persisted";
+import { openTrace } from "agent-inspect/readers";
+import { TraceDirectory } from "agent-inspect/advanced";
+import { renderWithSafety } from "@agent-inspect/adapter-sdk";
+
+import { markdownSummaryRenderer } from "./renderer.js";
+
+async function main(): Promise<void> {
+  const traceDir = ".agent-inspect-custom-renderer";
+
+  await inspectRun(
+    "custom-renderer-demo",
+    async () => {
+      await step.tool("lookup-inventory", async () => ({ matched: true }));
+      await step("summarize-result", async () => "metadata-only summary");
+    },
+    { traceDir },
+  );
+
+  const traces = new TraceDirectory({ dir: traceDir });
+  const files = await traces.list();
+  if (files.length === 0) {
+    throw new Error("expected at least one captured trace file");
+  }
+
+  const read = await openTrace({ type: "file", path: traces.getPath(files[0]!) });
+  const tree = persistedInspectEventsToRunTrees(read.events)[0];
+  if (!tree) {
+    throw new Error("expected a run tree from the captured events");
+  }
+
+  const result = renderWithSafety(markdownSummaryRenderer, tree, {
+    maxContentLength: 10_000,
+    forbiddenRawStrings: ["metadata-only summary"],
+  });
+
+  console.log(result.content);
+  console.log("");
+  console.log(`contentType: ${result.contentType}`);
+  console.log(`warnings: ${JSON.stringify(result.warnings)}`);
+
+  const expectedMarkers = [
+    "# Run summary: custom-renderer-demo",
+    "## Steps",
+    "tool:lookup-inventory",
+  ];
+  for (const marker of expectedMarkers) {
+    if (!result.content.includes(marker)) {
+      console.error(`missing expected output marker: ${marker}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/adapter-sdk/custom-renderer/src/renderer.ts
+++ b/examples/adapter-sdk/custom-renderer/src/renderer.ts
@@ -1,0 +1,73 @@
+import type { InspectNode, InspectRunTree } from "agent-inspect/advanced";
+import { defineRenderer, type TraceRenderer } from "@agent-inspect/adapter-sdk";
+
+function formatDuration(durationMs: number | undefined): string {
+  if (durationMs === undefined || !Number.isFinite(durationMs)) return "-";
+  return `${durationMs}ms`;
+}
+
+function renderNodes(nodes: readonly InspectNode[], depth: number, lines: string[]): void {
+  for (const node of nodes) {
+    const ev = node.event;
+    const indent = "  ".repeat(depth);
+    const status = ev.status ?? "unknown";
+    lines.push(
+      `${indent}- **${ev.name}** [${ev.kind}] ${status} (${formatDuration(ev.durationMs)})`,
+    );
+    if (node.children.length > 0) {
+      renderNodes(node.children, depth + 1, lines);
+    }
+  }
+}
+
+function collectErrors(nodes: readonly InspectNode[], out: InspectNode[]): void {
+  for (const node of nodes) {
+    if (node.event.status === "error") out.push(node);
+    collectErrors(node.children, out);
+  }
+}
+
+/**
+ * Example TraceRenderer that turns an InspectRunTree into a compact markdown
+ * summary. Metadata-only: it renders names, kinds, statuses, and durations,
+ * never attribute values, so nothing sensitive is copied into the output.
+ */
+export const markdownSummaryRenderer: TraceRenderer = defineRenderer({
+  format: "markdown-summary",
+  render(tree: InspectRunTree) {
+    const lines: string[] = [];
+    lines.push(`# Run summary: ${tree.name ?? tree.runId}`);
+    lines.push("");
+    lines.push("| Field | Value |");
+    lines.push("| ----- | ----- |");
+    lines.push(`| runId | \`${tree.runId}\` |`);
+    lines.push(`| status | ${tree.status ?? "unknown"} |`);
+    lines.push(`| duration | ${formatDuration(tree.durationMs)} |`);
+    lines.push(`| events | ${tree.metadata.totalEvents} |`);
+    lines.push("");
+    lines.push("## Steps");
+    lines.push("");
+    if (tree.children.length > 0) {
+      renderNodes(tree.children, 0, lines);
+    } else {
+      lines.push("(no steps recorded)");
+    }
+
+    const errors: InspectNode[] = [];
+    collectErrors(tree.children, errors);
+    if (errors.length > 0) {
+      lines.push("");
+      lines.push("## Errors");
+      lines.push("");
+      for (const node of errors) {
+        lines.push(`- **${node.event.name}** (\`${node.event.eventId}\`)`);
+      }
+    }
+
+    return {
+      content: lines.join("\n"),
+      contentType: "text/markdown",
+      warnings: [],
+    };
+  },
+});

--- a/packages/adapter-sdk/README.md
+++ b/packages/adapter-sdk/README.md
@@ -37,6 +37,12 @@ See [`examples/adapter-sdk/minimal-source-adapter`](../../examples/adapter-sdk/m
 for a dependency-free fake framework source that registers adapter metadata,
 captures a local metadata-only trace, and runs `runAdapterConformance`.
 
+## Custom renderer example
+
+See [`examples/adapter-sdk/custom-renderer`](../../examples/adapter-sdk/custom-renderer)
+for a standalone `TraceRenderer` that renders a metadata-only markdown summary
+from a persisted run tree and composes with `renderWithSafety`.
+
 ## Privacy
 
 - SDK helpers enforce local-first patterns; adapters must not upload by default

--- a/packages/adapter-sdk/test/example-custom-renderer.test.ts
+++ b/packages/adapter-sdk/test/example-custom-renderer.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inspectRun, step } from "agent-inspect";
+import { persistedInspectEventsToRunTrees } from "agent-inspect/persisted";
+import { openTrace } from "agent-inspect/readers";
+import { TraceDirectory } from "agent-inspect/advanced";
+
+import { renderWithSafety } from "../src/index.js";
+import { markdownSummaryRenderer } from "../../../examples/adapter-sdk/custom-renderer/src/renderer.js";
+
+describe("custom renderer example", () => {
+  let traceDir: string;
+  let tree: ReturnType<typeof persistedInspectEventsToRunTrees>[number];
+
+  beforeEach(async () => {
+    traceDir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-custom-renderer-"));
+    await inspectRun(
+      "custom-renderer-demo",
+      async () => {
+        await step.tool("lookup-inventory", async () => ({ matched: true }));
+        await step("summarize-result", async () => "metadata-only summary");
+      },
+      { traceDir },
+    );
+    const td = new TraceDirectory({ dir: traceDir });
+    const files = await td.list();
+    const read = await openTrace({ type: "file", path: td.getPath(files[0]!) });
+    tree = persistedInspectEventsToRunTrees(read.events)[0]!;
+    expect(tree).toBeDefined();
+  });
+
+  afterEach(async () => {
+    await rm(traceDir, { recursive: true, force: true });
+  });
+
+  it("renders a markdown summary with expected markers", () => {
+    const result = markdownSummaryRenderer.render(tree);
+    expect(result.contentType).toBe("text/markdown");
+    expect(result.warnings).toEqual([]);
+    expect(result.content).toContain("# Run summary: custom-renderer-demo");
+    expect(result.content).toContain("| runId |");
+    expect(result.content).toContain("## Steps");
+    expect(result.content).toContain("lookup-inventory");
+  });
+
+  it("renders metadata only, never step return values", () => {
+    const result = markdownSummaryRenderer.render(tree);
+    expect(result.content).not.toContain("metadata-only summary");
+  });
+
+  it("composes with renderWithSafety truncation bounds", () => {
+    const safe = renderWithSafety(markdownSummaryRenderer, tree, {
+      maxContentLength: 40,
+    });
+    expect(safe.content.length).toBe(40);
+    expect(safe.warnings.some((warning) => warning.includes("renderer.truncated"))).toBe(true);
+  });
+
+  it("is deterministic for the same tree", () => {
+    const a = markdownSummaryRenderer.render(tree).content;
+    const b = markdownSummaryRenderer.render(tree).content;
+    expect(a).toBe(b);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,18 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/adapter-sdk/custom-renderer:
+    dependencies:
+      '@agent-inspect/adapter-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/adapter-sdk
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/adapter-sdk/minimal-source-adapter:
     dependencies:
       '@agent-inspect/adapter-sdk':


### PR DESCRIPTION
## Summary

Adds the custom renderer example from #62: `examples/adapter-sdk/custom-renderer/` implements the `TraceRenderer` contract as a standalone markdown summary renderer, with no changes to the contract in core or the adapter SDK.

- `src/renderer.ts` defines `markdownSummaryRenderer` via `defineRenderer`: a run summary table, a nested step list, and an errors section, all metadata-only (names, kinds, statuses, durations; attribute values and step return values never appear in the output)
- `src/index.ts` captures a deterministic fake run locally, builds the tree with `persistedInspectEventsToRunTrees`, renders through `renderWithSafety` (truncation bound plus a forbidden-string check), prints the markdown with sample markers, and exits non-zero if any expected marker is missing
- Tests live in `packages/adapter-sdk/test/example-custom-renderer.test.ts` so the root suite runs them (the root vitest config excludes `examples/**`): output markers and content type, the metadata-only guarantee (step return value absent from output), determinism, and `renderWithSafety` truncation with its warning
- README documents run steps, expected output markers, and privacy defaults; the adapter-sdk README links the example next to `minimal-source-adapter`
- `pnpm-lock.yaml` gains only the new workspace importer entry

Closes #62

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only (example package plus a test file under packages/adapter-sdk/test; no src changes)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/adapter-sdk/test/example-custom-renderer.test.ts  # 4/4 pass
```

Ran the example end to end with the workspace tsx binary: it captures the trace, prints the markdown summary with all expected markers, reports `contentType: text/markdown` with no warnings, and exits 0.

## Screenshots / sample output

```text
# Run summary: custom-renderer-demo

| Field | Value |
| ----- | ----- |
| runId | `run_...` |
| status | ok |
...
## Steps

- **custom-renderer-demo** [RUN] running (-)
- **tool:lookup-inventory** [TOOL] running (-)
...
contentType: text/markdown
warnings: []
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval (example package uses tsx like the existing example)
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
