### PR TITLE
examples: add adapter SDK custom transform example

### DIFF
--- a/examples/adapter-sdk/custom-transform/README.md
+++ b/examples/adapter-sdk/custom-transform/README.md
@@ -1,0 +1,48 @@
+# Custom transform example (adapter SDK)
+
+This example implements the `TraceTransform` contract from
+`@agent-inspect/adapter-sdk` to normalize one custom event shape into standard
+persisted-event conventions, with no schema changes.
+
+The fake input (`src/events.ts`) looks like what a third-party framework might
+persist: generic `LOGIC` events named `fakefw.call` carrying vendor-specific
+attributes (`fakefw.op`, `fakefw.channel`, `fakefw.duration_us`). The transform
+(`src/transform.ts`) maps them into AgentInspect conventions:
+
+| fakefw convention | Normalized to |
+| ----------------- | ------------- |
+| `fakefw.channel: "tool"` / `"llm"` | event `kind` `TOOL` / `LLM` |
+| `fakefw.op` | `tool:<op>` / `llm:<op>` name plus `toolName` / `operation` attribute |
+| `fakefw.duration_us` (microseconds) | `durationMs` |
+| `fakefw.model` | `model` attribute |
+| unknown channel | event left unchanged plus a `transform.fakefw.unknown-channel` warning |
+
+Events without `fakefw.*` attributes pass through untouched, and the input
+array is never mutated.
+
+## Run it
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter agent-inspect-example-custom-transform start
+```
+
+The example runs the transform through `runTransformPipeline`, prints the
+normalized events and warnings, runs `runAdapterConformance` over the result,
+and exits non-zero if any expected check fails.
+
+## Tests
+
+Conformance-style coverage lives in
+[`packages/adapter-sdk/test/example-custom-transform.test.ts`](../../../packages/adapter-sdk/test/example-custom-transform.test.ts):
+tool and llm normalization, microsecond to millisecond duration conversion,
+unknown-channel warning behavior, input immutability, and composition with
+`createKindFilterTransform` plus `runAdapterConformance`.
+
+## Privacy defaults
+
+- Deterministic fake events only; no API keys, no network calls.
+- The transform strips vendor keys rather than copying unknown data forward,
+  and unknown channels are surfaced as warnings instead of silently guessed.

--- a/examples/adapter-sdk/custom-transform/package.json
+++ b/examples/adapter-sdk/custom-transform/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-inspect-example-custom-transform",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prestart": "pnpm --workspace-root run build && pnpm --filter @agent-inspect/adapter-sdk run build",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@agent-inspect/adapter-sdk": "workspace:*",
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/adapter-sdk/custom-transform/src/events.ts
+++ b/examples/adapter-sdk/custom-transform/src/events.ts
@@ -1,0 +1,84 @@
+import type { PersistedInspectEvent } from "agent-inspect/persisted";
+
+/**
+ * Deterministic fake events as a third-party framework might persist them:
+ * generic LOGIC kinds and vendor-specific `fakefw.*` attribute conventions
+ * (operation name, channel, duration in microseconds) instead of the standard
+ * AgentInspect fields. No secrets, no real data.
+ */
+export function fakeFrameworkEvents(): PersistedInspectEvent[] {
+  return [
+    {
+      schemaVersion: "1.0",
+      eventId: "run_1",
+      runId: "run_custom_transform",
+      kind: "RUN",
+      name: "fakefw-session",
+      status: "ok",
+      timestamp: "2023-11-14T22:13:20.000Z",
+      startedAt: "2023-11-14T22:13:20.000Z",
+      endedAt: "2023-11-14T22:13:24.000Z",
+      durationMs: 4000,
+      confidence: "explicit",
+      source: { type: "adapter", name: "fake-framework" },
+    },
+    {
+      schemaVersion: "1.0",
+      eventId: "call_1",
+      runId: "run_custom_transform",
+      parentId: "run_1",
+      kind: "LOGIC",
+      name: "fakefw.call",
+      status: "ok",
+      timestamp: "2023-11-14T22:13:21.000Z",
+      startedAt: "2023-11-14T22:13:21.000Z",
+      endedAt: "2023-11-14T22:13:21.250Z",
+      confidence: "explicit",
+      source: { type: "adapter", name: "fake-framework" },
+      attributes: {
+        "fakefw.op": "search-flights",
+        "fakefw.channel": "tool",
+        "fakefw.duration_us": 250000,
+      },
+    },
+    {
+      schemaVersion: "1.0",
+      eventId: "call_2",
+      runId: "run_custom_transform",
+      parentId: "run_1",
+      kind: "LOGIC",
+      name: "fakefw.call",
+      status: "ok",
+      timestamp: "2023-11-14T22:13:22.000Z",
+      startedAt: "2023-11-14T22:13:22.000Z",
+      endedAt: "2023-11-14T22:13:23.200Z",
+      confidence: "explicit",
+      source: { type: "adapter", name: "fake-framework" },
+      attributes: {
+        "fakefw.op": "draft-reply",
+        "fakefw.channel": "llm",
+        "fakefw.duration_us": 1200000,
+        "fakefw.model": "fixture-model",
+      },
+    },
+    {
+      schemaVersion: "1.0",
+      eventId: "call_3",
+      runId: "run_custom_transform",
+      parentId: "run_1",
+      kind: "LOGIC",
+      name: "fakefw.call",
+      status: "ok",
+      timestamp: "2023-11-14T22:13:23.500Z",
+      startedAt: "2023-11-14T22:13:23.500Z",
+      endedAt: "2023-11-14T22:13:23.600Z",
+      confidence: "explicit",
+      source: { type: "adapter", name: "fake-framework" },
+      attributes: {
+        "fakefw.op": "emit-metrics",
+        "fakefw.channel": "telemetry",
+        "fakefw.duration_us": 100000,
+      },
+    },
+  ];
+}

--- a/examples/adapter-sdk/custom-transform/src/index.ts
+++ b/examples/adapter-sdk/custom-transform/src/index.ts
@@ -1,0 +1,42 @@
+import { runAdapterConformance, runTransformPipeline } from "@agent-inspect/adapter-sdk";
+
+import { fakeFrameworkEvents } from "./events.js";
+import { createFakeFrameworkNormalizeTransform } from "./transform.js";
+
+async function main(): Promise<void> {
+  const input = fakeFrameworkEvents();
+  const normalize = createFakeFrameworkNormalizeTransform();
+
+  const result = runTransformPipeline(input, [normalize]);
+
+  console.log(JSON.stringify({ events: result.events, warnings: result.warnings }, null, 2));
+
+  const conformance = await runAdapterConformance({
+    adapterId: "fakefw-normalize-example",
+    events: result.events,
+    forbiddenRawStrings: ["fakefw-secret"],
+  });
+  console.log(JSON.stringify({ conformance }, null, 2));
+
+  const tool = result.events.find((event) => event.name === "tool:search-flights");
+  const llm = result.events.find((event) => event.name === "llm:draft-reply");
+  const untouched = result.events.find((event) => event.eventId === "call_3");
+  const checks: Array<[string, boolean]> = [
+    ["tool event normalized", tool?.kind === "TOOL" && tool.durationMs === 250],
+    ["llm event normalized", llm?.kind === "LLM" && llm.durationMs === 1200],
+    ["unknown channel left unchanged", untouched?.kind === "LOGIC"],
+    ["unknown channel warned", result.warnings.some((w) => w.code === "transform.fakefw.unknown-channel")],
+    ["conformance ok", conformance.ok],
+  ];
+  for (const [label, ok] of checks) {
+    if (!ok) {
+      console.error(`check failed: ${label}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/adapter-sdk/custom-transform/src/transform.ts
+++ b/examples/adapter-sdk/custom-transform/src/transform.ts
@@ -1,0 +1,87 @@
+import type { PersistedInspectEvent } from "agent-inspect/persisted";
+import type { TraceReadWarning } from "agent-inspect/readers";
+import { defineTransform, type TraceTransform } from "@agent-inspect/adapter-sdk";
+
+const CHANNEL_TO_KIND: Record<string, PersistedInspectEvent["kind"]> = {
+  tool: "TOOL",
+  llm: "LLM",
+};
+
+const CHANNEL_TO_PREFIX: Record<string, string> = {
+  tool: "tool:",
+  llm: "llm:",
+};
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Example TraceTransform that normalizes vendor-specific `fakefw.*` attribute
+ * conventions into standard persisted-event fields:
+ *
+ * - `fakefw.channel` ("tool" | "llm") -> event kind TOOL | LLM
+ * - `fakefw.op` -> `tool:<op>` / `llm:<op>` name plus toolName/model attribute
+ * - `fakefw.duration_us` (microseconds) -> `durationMs`
+ *
+ * Events without `fakefw.*` attributes pass through untouched. Unknown
+ * channels stay unchanged and surface a warning instead of being guessed.
+ */
+export function createFakeFrameworkNormalizeTransform(): TraceTransform {
+  return defineTransform({
+    id: "fakefw-normalize",
+    transform(input) {
+      const warnings: TraceReadWarning[] = [];
+      const events = input.map((event) => {
+        const attrs = event.attributes ?? {};
+        const channel = readString(attrs["fakefw.channel"]);
+        const op = readString(attrs["fakefw.op"]);
+        if (channel === undefined && op === undefined) {
+          return event;
+        }
+
+        const kind = channel !== undefined ? CHANNEL_TO_KIND[channel] : undefined;
+        if (kind === undefined) {
+          warnings.push({
+            code: "transform.fakefw.unknown-channel",
+            message: `event ${event.eventId} has unmapped fakefw.channel "${channel ?? "(missing)"}"; left unchanged`,
+            severity: "warning",
+          });
+          return event;
+        }
+
+        const nextAttributes: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(attrs)) {
+          if (!key.startsWith("fakefw.")) nextAttributes[key] = value;
+        }
+        if (op !== undefined) {
+          nextAttributes[kind === "TOOL" ? "toolName" : "operation"] = op;
+        }
+        const model = readString(attrs["fakefw.model"]);
+        if (model !== undefined) {
+          nextAttributes.model = model;
+        }
+
+        const next: PersistedInspectEvent = {
+          ...event,
+          kind,
+          name: op !== undefined ? `${CHANNEL_TO_PREFIX[channel!]}${op}` : event.name,
+          attributes: nextAttributes,
+        };
+
+        const durationUs = readFiniteNumber(attrs["fakefw.duration_us"]);
+        if (durationUs !== undefined && event.durationMs === undefined) {
+          next.durationMs = Math.round(durationUs / 1000);
+        }
+
+        return next;
+      });
+
+      return { events, warnings };
+    },
+  });
+}

--- a/packages/adapter-sdk/README.md
+++ b/packages/adapter-sdk/README.md
@@ -43,6 +43,12 @@ See [`examples/adapter-sdk/custom-renderer`](../../examples/adapter-sdk/custom-r
 for a standalone `TraceRenderer` that renders a metadata-only markdown summary
 from a persisted run tree and composes with `renderWithSafety`.
 
+## Custom transform example
+
+See [`examples/adapter-sdk/custom-transform`](../../examples/adapter-sdk/custom-transform)
+for a standalone `TraceTransform` that normalizes a vendor-specific event shape
+into standard persisted-event conventions with warnings for unmapped input.
+
 ## Privacy
 
 - SDK helpers enforce local-first patterns; adapters must not upload by default

--- a/packages/adapter-sdk/test/example-custom-transform.test.ts
+++ b/packages/adapter-sdk/test/example-custom-transform.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { createKindFilterTransform, runAdapterConformance, runTransformPipeline } from "../src/index.js";
+import { fakeFrameworkEvents } from "../../../examples/adapter-sdk/custom-transform/src/events.js";
+import { createFakeFrameworkNormalizeTransform } from "../../../examples/adapter-sdk/custom-transform/src/transform.js";
+
+describe("custom transform example", () => {
+  it("normalizes fakefw tool and llm events into standard conventions", () => {
+    const result = runTransformPipeline(fakeFrameworkEvents(), [
+      createFakeFrameworkNormalizeTransform(),
+    ]);
+
+    const tool = result.events.find((event) => event.eventId === "call_1");
+    expect(tool?.kind).toBe("TOOL");
+    expect(tool?.name).toBe("tool:search-flights");
+    expect(tool?.durationMs).toBe(250);
+    expect(tool?.attributes?.toolName).toBe("search-flights");
+    expect(Object.keys(tool?.attributes ?? {}).some((key) => key.startsWith("fakefw."))).toBe(
+      false,
+    );
+
+    const llm = result.events.find((event) => event.eventId === "call_2");
+    expect(llm?.kind).toBe("LLM");
+    expect(llm?.name).toBe("llm:draft-reply");
+    expect(llm?.durationMs).toBe(1200);
+    expect(llm?.attributes?.model).toBe("fixture-model");
+  });
+
+  it("leaves unknown channels unchanged and warns instead of guessing", () => {
+    const result = runTransformPipeline(fakeFrameworkEvents(), [
+      createFakeFrameworkNormalizeTransform(),
+    ]);
+
+    const telemetry = result.events.find((event) => event.eventId === "call_3");
+    expect(telemetry?.kind).toBe("LOGIC");
+    expect(telemetry?.attributes?.["fakefw.channel"]).toBe("telemetry");
+    expect(
+      result.warnings.some((warning) => warning.code === "transform.fakefw.unknown-channel"),
+    ).toBe(true);
+  });
+
+  it("does not mutate the input events", () => {
+    const input = fakeFrameworkEvents();
+    const before = JSON.stringify(input);
+    runTransformPipeline(input, [createFakeFrameworkNormalizeTransform()]);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  it("composes with kind filtering and passes adapter conformance", async () => {
+    const result = runTransformPipeline(fakeFrameworkEvents(), [
+      createFakeFrameworkNormalizeTransform(),
+      createKindFilterTransform(["TOOL", "LLM"]),
+    ]);
+    expect(
+      result.events.every(
+        (event) => event.kind === "TOOL" || event.kind === "LLM" || event.kind === "RUN",
+      ),
+    ).toBe(true);
+
+    const conformance = await runAdapterConformance({
+      adapterId: "fakefw-normalize-example",
+      events: result.events,
+      forbiddenRawStrings: ["fakefw-secret"],
+    });
+    expect(conformance.ok).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,18 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/adapter-sdk/custom-transform:
+    dependencies:
+      '@agent-inspect/adapter-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/adapter-sdk
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/adapter-sdk/minimal-source-adapter:
     dependencies:
       '@agent-inspect/adapter-sdk':


### PR DESCRIPTION
## Summary

Adds the custom transform example from #63: `examples/adapter-sdk/custom-transform/` normalizes one deterministic custom event shape into standard persisted-event conventions via the `TraceTransform` contract, with no schema changes.

- `src/events.ts` holds the fake input the way a third-party framework might persist it: generic `LOGIC` events named `fakefw.call` with vendor attributes `fakefw.op`, `fakefw.channel`, `fakefw.duration_us`, `fakefw.model`
- `src/transform.ts` defines `createFakeFrameworkNormalizeTransform()` via `defineTransform`: channel maps to `TOOL`/`LLM` kind, op becomes the `tool:`/`llm:` name plus `toolName`/`operation` attribute, microsecond durations convert to `durationMs`, vendor keys are stripped rather than copied forward. Unknown channels are left unchanged with a `transform.fakefw.unknown-channel` warning instead of being guessed, and the input array is never mutated
- `src/index.ts` runs the pipeline, prints normalized events and warnings, runs `runAdapterConformance` over the result, and exits non-zero if any expected check fails
- Conformance-style tests in `packages/adapter-sdk/test/example-custom-transform.test.ts` (root suite location, since root vitest excludes `examples/**`): both channel normalizations, duration conversion, warning behavior, input immutability, and composition with `createKindFilterTransform` plus a passing `runAdapterConformance`
- Linked from the adapter-sdk README; lockfile gains only the new workspace importer entry

Closes #63

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only (example package plus a test file under packages/adapter-sdk/test; no src changes)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/adapter-sdk/test/example-custom-transform.test.ts  # 4/4 pass
```

Ran the example end to end with the workspace tsx binary: normalized events and warnings print as documented, all five self-checks pass including `conformance.ok: true` (events-non-empty, schema-persisted, no-forbidden-raw-strings, run-tree-built, legacy-normalization, reader-round-trip), exit 0.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval (example package uses tsx like the existing example)
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
