### PR TITLE
examples: add decision metadata recipe

### DIFF
--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -43,6 +43,7 @@ Use `AGENT_INSPECT_SILENT=true` to suppress live terminal tree output during scr
 | [log4js-json-layout](log4js-json-layout) | log4js text + embedded JSON | `logs` with `--format log4js` | yes (CLI + samples) | no |
 | [nestjs-json-logging](nestjs-json-logging) | NestJS structured JSON without a framework adapter | `logs`, `message`/`timestamp` mapping | yes (CLI + samples) | no |
 | [retry-fallback](retry-fallback) | Primary LLM fails, fallback OK | `step.llm`, error + recovery | yes | no |
+| [decision-metadata](decision-metadata) | Safe decision context, no chain-of-thought | `decisionId`/`groupId` metadata, bounded reason codes | yes | no |
 | [parallel-tools](parallel-tools) | Sibling tools via `Promise.all` | `step.tool`, parallel siblings | yes | no |
 | [github-actions-artifact](github-actions-artifact) | CI trace + share-safe export recipe | `maybeInspectRun`, `AGENT_INSPECT=1`, export | yes | no |
 | [deterministic-ci-checks](deterministic-ci-checks) | v1.8 checks, baseline, safe artifacts, GitHub summary | `check`, `artifacts`, `agent-inspect/checks` | yes | no |

--- a/examples/recipes/decision-metadata/README.md
+++ b/examples/recipes/decision-metadata/README.md
@@ -1,0 +1,58 @@
+# Recipe: decision-metadata
+
+Record **which** decision an agent made and **under what configuration**,
+without recording chain-of-thought, raw prompts, or model reasoning.
+
+Agent runs often need decision context for debugging routing and policy bugs:
+which policy version was live, which feature flags were on, which route was
+chosen and why (as a bounded reason code). This recipe shows that context as
+structured metadata on `run_started` and step metadata, using the correlation
+fields (`decisionId`, `groupId`) from [docs/SCHEMA.md](../../../docs/SCHEMA.md).
+
+## Run it
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter agent-inspect-recipe-decision-metadata start
+```
+
+Then inspect locally:
+
+```bash
+npx agent-inspect list --dir examples/recipes/decision-metadata/.agent-inspect-runs
+npx agent-inspect view <run_id> --dir examples/recipes/decision-metadata/.agent-inspect-runs
+npx agent-inspect report <run_id> --dir examples/recipes/decision-metadata/.agent-inspect-runs
+```
+
+## Safe fields vs fields to avoid
+
+| Safe to record | Avoid recording |
+| -------------- | --------------- |
+| `decisionId`, `groupId` correlation ids | chain-of-thought or reasoning text |
+| `policyVersion`, config/flag snapshots | raw prompts or model outputs (opt-in only) |
+| `candidateRoutes`, `routeChosen` | user content or PII |
+| bounded `routeReasonCode` strings | free-form "why" explanations from the model |
+| bounded numeric signals (`queueDepth`) | full request/response payloads |
+
+The run metadata in this recipe is deterministic and fake: identifiers,
+versions, flags, and scores only. Manual metadata is redacted before disk by
+default for common sensitive keys, but redaction is a safeguard, not DLP:
+review artifacts before sharing per
+[SAFE-TRACE-SHARING.md](../../../docs/SAFE-TRACE-SHARING.md).
+
+## What the trace shows
+
+- `run_started` carries `decisionId`, `groupId`, `policyVersion`, and
+  `featureFlags`, so `list`/`search` can correlate runs by decision.
+- `choose-route` records the candidate routes and policy version it decided
+  under; `tool:resolve-ticket` records the chosen route and a reason code.
+- `report <run_id> --attributes` includes the bounded metadata in the local
+  report without any reasoning text.
+
+## Related
+
+- [multi-agent-handoff](../multi-agent-handoff) for session/group correlation
+- [what-report-inspect](../what-report-inspect) for the inspect flow
+- [SAFE-TRACE-SHARING.md](../../../docs/SAFE-TRACE-SHARING.md) before posting artifacts

--- a/examples/recipes/decision-metadata/expected-output.txt
+++ b/examples/recipes/decision-metadata/expected-output.txt
@@ -1,0 +1,5 @@
+Route chosen: fast-lane
+choose-route
+tool:resolve-ticket
+Safe fields recorded: decisionId, groupId, policyVersion,
+Not recorded: chain-of-thought, prompts, model reasoning.

--- a/examples/recipes/decision-metadata/package.json
+++ b/examples/recipes/decision-metadata/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agent-inspect-recipe-decision-metadata",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/recipes/decision-metadata/src/index.ts
+++ b/examples/recipes/decision-metadata/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Safe decision metadata: record WHICH routing decision was made and under
+ * WHAT configuration (policy version, feature flags, chosen route) without
+ * recording chain-of-thought, raw prompts, or model reasoning.
+ */
+import path from "node:path";
+
+import { inspectRun, step } from "agent-inspect";
+
+const silent = process.env.AGENT_INSPECT_SILENT === "true";
+const traceDir = path.join(process.cwd(), ".agent-inspect-runs");
+
+// Deterministic fake decision context, the kind a router would compute from
+// config and request attributes. Safe: identifiers, versions, flags, scores.
+const decisionContext = {
+  decisionId: "dec-routing-0001",
+  groupId: "grp-support-tickets",
+  policyVersion: "routing-policy-v7",
+  featureFlags: { fastLaneEnabled: true, betaSummarizer: false },
+};
+
+const routed = await inspectRun(
+  "decision-metadata-recipe",
+  async () => {
+    const route = await step("choose-route", async () => {
+      // The router picks a tier from bounded, structured signals only.
+      const signals = { queueDepth: 3, priority: "standard", locale: "en" };
+      const chosen = signals.queueDepth < 5 ? "fast-lane" : "deep-review";
+      return { chosen, signals };
+    }, {
+      metadata: {
+        policyVersion: decisionContext.policyVersion,
+        candidateRoutes: ["fast-lane", "deep-review"],
+      },
+    });
+
+    await step.tool("resolve-ticket", async () => ({ resolved: true }), {
+      metadata: {
+        routeChosen: route.chosen,
+        routeReasonCode: "queue-depth-below-threshold",
+      },
+    });
+
+    return route.chosen;
+  },
+  { silent, traceDir, metadata: decisionContext },
+);
+
+console.log("\nRoute chosen:", routed);
+console.log("\nSafe fields recorded: decisionId, groupId, policyVersion,");
+console.log("featureFlags, candidateRoutes, routeChosen, routeReasonCode.");
+console.log("Not recorded: chain-of-thought, prompts, model reasoning.");
+console.log("\nNext:");
+console.log("  npx agent-inspect list --dir ./.agent-inspect-runs");
+console.log("  npx agent-inspect view <run_id> --dir ./.agent-inspect-runs");
+console.log("  npx agent-inspect report <run_id> --dir ./.agent-inspect-runs");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,15 @@ importers:
         specifier: ^4.19.2
         version: 4.21.0
 
+  examples/recipes/decision-metadata:
+    dependencies:
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/recipes/deterministic-ci-checks:
     dependencies:
       agent-inspect:

--- a/scripts/validate-recipes.mjs
+++ b/scripts/validate-recipes.mjs
@@ -19,6 +19,7 @@ const RECIPES = [
   "log4js-json-layout",
   "nestjs-json-logging",
   "retry-fallback",
+  "decision-metadata",
   "parallel-tools",
   "github-actions-artifact",
   "deterministic-ci-checks",


### PR DESCRIPTION
## Summary

Adds the decision metadata recipe from #13: `examples/recipes/decision-metadata/` shows how to record which routing decision an agent made and under what configuration, without recording chain-of-thought, prompts, or model reasoning.

- `run_started` metadata carries the sanctioned correlation fields (`decisionId`, `groupId` per `docs/SCHEMA.md`) plus `policyVersion` and a feature-flag snapshot, so runs can be correlated by decision via `list`/`search`
- Step metadata records `candidateRoutes` on the routing step and `routeChosen` plus a bounded `routeReasonCode` on the tool step; the routing itself derives from bounded numeric signals, not model output
- The README documents a safe-vs-avoid field table, the local `list` / `view` / `report` flow, and links SAFE-TRACE-SHARING for artifact review before posting
- Registered in `scripts/validate-recipes.mjs` (now 37 recipes) and the recipes README; deterministic fake data only

Per the maintainer note on the issue, the recipe stays on safe structured decision metadata: nothing resembling reasoning text is captured, and the README explicitly lists free-form model explanations under fields to avoid.

Closes #13

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only (recipe package; no src changes)

## Validation

```bash
pnpm typecheck      # pass
pnpm recipes:check  # pass, 37 recipes validated
```

Ran the recipe end to end with the workspace tsx binary: the trace persists the decision metadata on `run_started` and both steps (verified in the JSONL), `view` renders the expected tree, and the script exits 0. Trace directory cleaned up afterward; nothing generated is committed.

## Screenshots / sample output

```text
Route chosen: fast-lane

Safe fields recorded: decisionId, groupId, policyVersion,
featureFlags, candidateRoutes, routeChosen, routeReasonCode.
Not recorded: chain-of-thought, prompts, model reasoning.
```

## Checklist

- [x] Tests added or updated (if behavior changed) - recipe validated by recipes:check; no runtime behavior change
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
