### PR TITLE
fix(cli): exit 1 when search --session id is not found

### DIFF
--- a/packages/cli/src/search.ts
+++ b/packages/cli/src/search.ts
@@ -69,6 +69,7 @@ export async function searchCommand(
           console.log(`Session not found: ${sessionId}`);
           console.log(`Trace directory: ${traceDir}`);
         }
+        process.exitCode = 1;
         return;
       }
       metas = scoped.metas;

--- a/packages/cli/test/search.test.ts
+++ b/packages/cli/test/search.test.ts
@@ -99,4 +99,30 @@ describe("search CLI", () => {
     ]);
     expect(parsed.every((row) => row.sessionId === "sess-handoff-001")).toBe(true);
   });
+
+  it("sets exit code 1 when the session id is not found", async () => {
+    const fixtures = path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      "../../../fixtures/sessions/multi-agent-handoff",
+    );
+    await cp(path.join(fixtures, "handoff-planner.jsonl"), path.join(tmpDir, "handoff-planner.jsonl"));
+
+    const prevExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+      await searchCommand({ dir: tmpDir, session: "sess-does-not-exist" });
+      const out = logSpy.mock.calls.flat().join("\n");
+      expect(out).toContain("Session not found: sess-does-not-exist");
+      expect(process.exitCode).toBe(1);
+
+      process.exitCode = 0;
+      logSpy.mockClear();
+      await searchCommand({ dir: tmpDir, session: "sess-does-not-exist", json: true });
+      const parsed = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+      expect(parsed).toEqual([]);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = prevExitCode ?? 0;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes `search --session <id>` exiting 0 when the session id does not exist. Every sibling id-based command (`sessions`, `view`, `timeline`, `what`, `report`) sets `process.exitCode = 1` on its not-found path, so scripts and CI can detect a bad id; only `search` returned success. The fix sets the exit code in the `scoped.notFound` branch, in both human and `--json` modes. Output text is unchanged.

Closes #90

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [x] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/cli/test/search.test.ts
# On my Windows machine this whole file fails on clean main too (fixture paths
# resolve via URL.pathname, producing doubled drive prefixes), so the new test
# is verified by CI on ubuntu-latest; the added test follows the file's
# existing pattern and asserts exit code 1 in both human and JSON modes.
```

Verified end to end against the rebuilt CLI with a session fixture in a temp directory:

- `search --session sess-does-not-exist` prints `Session not found: ...` and exits 1 (was 0)
- `search --session sess-does-not-exist --json` prints `[]` and exits 1 (was 0)
- `search --session sess-handoff-001` still finds the run and exits 0

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, no documented behavior change
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
