### PR TITLE
fix(core): match error/failed log tokens exactly in normalizer

### DIFF
--- a/packages/core/src/logs/normalizer.ts
+++ b/packages/core/src/logs/normalizer.ts
@@ -29,13 +29,18 @@ function hasToken(hay: string, token: string): boolean {
   return hay.includes(token);
 }
 
+// "error"/"failed" must be a complete dot-delimited token ("x.error",
+// "x.failed.y"); substrings like "error_budget" or "error_retry" are not
+// error signals.
+const ERROR_TOKEN_RE = /\.(error|failed)(\.|$)/;
+
 function inferKind(eventName: string): InspectKind {
   if (hasToken(eventName, ".llm.")) return "LLM";
   if (hasToken(eventName, ".tool.")) return "TOOL";
   if (hasToken(eventName, ".agent.")) return "AGENT";
   if (hasToken(eventName, ".retriever.")) return "RETRIEVER";
   if (hasToken(eventName, ".result.")) return "RESULT";
-  if (eventName.endsWith(".error") || eventName.endsWith(".failed") || eventName.includes(".error") || eventName.includes(".failed")) {
+  if (ERROR_TOKEN_RE.test(eventName)) {
     return "ERROR";
   }
   return "LOG";
@@ -139,7 +144,7 @@ export class EventNormalizer {
       status = mapping.status;
     } else if (mapping?.kind === "ERROR") {
       status = "error";
-    } else if (eventName.includes(".failed") || eventName.includes(".error")) {
+    } else if (ERROR_TOKEN_RE.test(eventName)) {
       status = "error";
     } else if (mapping?.startsRun || mapping?.startsStep) {
       status = "running";

--- a/packages/core/test/logs/normalizer.test.ts
+++ b/packages/core/test/logs/normalizer.test.ts
@@ -79,6 +79,37 @@ describe("EventNormalizer", () => {
     expect((e as any).status).toBe("error");
   });
 
+  it("error/failed match complete dot tokens, including mid-name", () => {
+    const n = new EventNormalizer({ config: baseConfig });
+    const mid = n.normalize(
+      rec({ decisionId: "d", event: "app.error.timeout", timestamp: 1 }),
+    );
+    expect((mid as any).kind).toBe("ERROR");
+    expect((mid as any).status).toBe("error");
+  });
+
+  it("does not flag error/failed substrings inside larger tokens", () => {
+    const n = new EventNormalizer({ config: baseConfig });
+
+    const budget = n.normalize(
+      rec({ decisionId: "d", event: "payment.error_budget.checked", timestamp: 1 }),
+    );
+    expect((budget as any).kind).toBe("LOG");
+    expect((budget as any).status).toBeUndefined();
+
+    const retry = n.normalize(
+      rec({ decisionId: "d", event: "proactive.tool.error_retry", timestamp: 1 }),
+    );
+    expect((retry as any).kind).toBe("TOOL");
+    expect((retry as any).status).toBeUndefined();
+
+    const reset = n.normalize(
+      rec({ decisionId: "d", event: "worker.failed_attempts_reset", timestamp: 1 }),
+    );
+    expect((reset as any).kind).toBe("LOG");
+    expect((reset as any).status).toBeUndefined();
+  });
+
   it("attributes exclude used keys and preserve metadata", () => {
     const n = new EventNormalizer({ config: baseConfig });
     const e = n.normalize(


### PR DESCRIPTION
## Summary

Fixes the log normalizer classifying any event name containing the substrings `.error` / `.failed` as an error, from #92. `payment.error_budget.checked` became `kind: ERROR, status: "error"`, and `proactive.tool.error_retry` kept kind TOOL but got `status: "error"` forced; one such event flips the whole log-derived run to errored.

The fix requires `error`/`failed` to be a complete dot-delimited token (`/\.(error|failed)(\.|$)/`), used by both `inferKind` and the status fallback. This matches the anchored semantics of the default `*.error` / `*.failed` config mappings and the dot-delimited style of the other kind checks (`.llm.`, `.tool.`), and is strictly narrowing:

- `x.failed`, `x.error`, `app.error.timeout` classify exactly as before (ERROR, status error)
- `payment.error_budget.checked`, `proactive.tool.error_retry`, `worker.failed_attempts_reset` no longer register as error signals
- Config-mapped events are untouched; the mapping path takes precedence over this fallback either way

Regression tests cover both directions. Conservative parsing only, per the safe parsing policy; no config schema or parser behavior changes beyond the classification fallback.

Closes #92

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/core/test/logs  # 61/61 pass across all 14 logs test files
```

Verified end to end against the rebuilt CLI with the repro from #92: before the fix `payment.error_budget.checked` rendered as `error:checked ✖`; after, it renders as a plain LOG event and the run carries no error signal. The genuine `*.failed` path still classifies as error (covered by the existing test and a new mid-name `app.error.timeout` case).

## Screenshots / sample output

```text
Run r1
├─ proactive.job.started
├─ payment.error_budget.checked      (was: error:checked ✖)
└─ result:done
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, behavior now matches the documented mapping semantics
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
