### PR TITLE
fix(core): stop double-counting output previews in diff

### DIFF
--- a/packages/core/src/diff/comparable.ts
+++ b/packages/core/src/diff/comparable.ts
@@ -98,7 +98,14 @@ export function manualTraceEventsToComparableRun(events: TraceEvent[]): RunCompa
       meta = { ...(meta ?? {}), agent_inspect_diff_parent_missing: true };
     }
 
+    // Previews are compared as their own "output" dimension; strip them from
+    // the metadata copy so one preview change is not also reported as a
+    // metadata diff.
     const outputPreview = extractOutputPreview(meta);
+    if (meta !== undefined && ("outputPreview" in meta || "resultPreview" in meta)) {
+      delete meta.outputPreview;
+      delete meta.resultPreview;
+    }
 
     const sc: StepComparable = {
       id: acc.id,

--- a/packages/core/test/diff/engine.test.ts
+++ b/packages/core/test/diff/engine.test.ts
@@ -304,6 +304,27 @@ describe("diffRuns", () => {
     ]);
     const out = diffRuns(left, right);
     expect(out.differences.some((d) => d.kind === "output")).toBe(true);
+    // One preview change is one difference, not also a metadata diff.
+    expect(out.differences.some((d) => d.kind === "metadata")).toBe(false);
+    expect(out.summary.totalDifferences).toBe(1);
+  });
+
+  it("still reports metadata diffs alongside output when other keys change", () => {
+    const left = manualTraceEventsToComparableRun([
+      rs("r", "n", 1),
+      ss("r", "s", "step", 2, "logic", undefined, { outputPreview: "a", model: "m1" }),
+      sc("r", "s", "success", 3, 1),
+      rc("r", "success", 4, 5),
+    ]);
+    const right = manualTraceEventsToComparableRun([
+      rs("r", "n", 1),
+      ss("r", "s", "step", 2, "logic", undefined, { outputPreview: "b", model: "m2" }),
+      sc("r", "s", "success", 3, 1),
+      rc("r", "success", 4, 5),
+    ]);
+    const out = diffRuns(left, right);
+    expect(out.differences.some((d) => d.kind === "output")).toBe(true);
+    expect(out.differences.some((d) => d.kind === "metadata")).toBe(true);
   });
 
   it("records first divergence from first filtered difference", () => {


### PR DESCRIPTION
## Summary

Fixes the diff engine double-counting `outputPreview` changes, from #94. `manualTraceEventsToComparableRun` copied `outputPreview`/`resultPreview` into the comparable's dedicated `outputPreview` field but left the keys in the metadata object, so a single preview change produced both a `metadata` diff ("Step metadata differs") and an `output` diff, inflating `summary.totalDifferences`.

The fix strips the preview keys from the metadata copy once extracted (the copy is already fresh per step, so input events are never mutated; the existing non-mutation contract holds). Behavior after the fix:

- A preview-only change yields exactly one `output` diff
- Steps whose metadata also differs in other keys still get a `metadata` diff alongside the `output` diff
- Empty-after-strip metadata collapses to `undefined` via the existing emptiness check

Tests: tightened the existing "detects output preview changed" case to assert no `metadata` diff and `totalDifferences === 1`, and added a mixed-change case asserting both kinds appear when another metadata key changes too.

Closes #94

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/core/test/diff  # 45/45 pass across all 5 diff test files
```

Verified end to end against the rebuilt CLI with two synthetic traces differing only in `outputPreview`:

- Before: `Differences: 2` (output plus a spurious metadata diff)
- After: `Differences: 1`, first divergence reported as `output at step (left: a, right: b)`

## Screenshots / sample output

```text
Summary:
  Differences: 1
  Errors: 0
  Warnings: 0
  Info: 1

First divergence:
  output at step
    left: a
    right: b
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, output format unchanged
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
