### PR TITLE
test(redact): execute README example

### DIFF
--- a/packages/redact/README.md
+++ b/packages/redact/README.md
@@ -27,7 +27,7 @@ npm install @agent-inspect/redact
 import { redact } from "@agent-inspect/redact";
 
 const result = redact(
-  { apiKey: "sk-secret", message: "hello" },
+  { apiKey: "demo-token", message: "hello" },
   { profile: "share" },
 );
 console.log(result.value, result.findings);

--- a/packages/redact/test/readme.test.ts
+++ b/packages/redact/test/readme.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { describe, expect, it, vi } from "vitest";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+function readExampleSnippet(): string {
+  const readme = readFileSync(path.join(packageRoot, "README.md"), "utf8");
+  const example = readme.match(/## Example\s+```ts\n([\s\S]*?)\n```/);
+
+  if (!example?.[1]) {
+    throw new Error("README Example must contain a TypeScript code block");
+  }
+
+  return example[1].replace(
+    'from "@agent-inspect/redact"',
+    `from ${JSON.stringify(path.join(packageRoot, "src", "index.ts"))}`
+  );
+}
+
+describe("@agent-inspect/redact README", () => {
+  it("runs the documented example", async () => {
+    const fixtureDir = mkdtempSync(
+      path.join(packageRoot, "test", ".readme-example-")
+    );
+    const snippetPath = path.join(fixtureDir, "example.ts");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      writeFileSync(snippetPath, readExampleSnippet());
+      await import(pathToFileURL(snippetPath).href);
+
+      const output = JSON.stringify(log.mock.calls);
+      expect(output).toContain("[REDACTED]");
+      expect(output).not.toContain("demo-token");
+    } finally {
+      log.mockRestore();
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- execute the `@agent-inspect/redact` README TypeScript example in Vitest
- resolve the documented package import to source so the check remains local, deterministic, and compatible with frozen installs
- replace the secret-shaped sample value with a neutral synthetic token while asserting it is redacted from output

Fixes #103

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/redact`

## Validation

```bash
pnpm exec vitest run -c vitest.config.ts packages/redact/test/readme.test.ts packages/redact/test/index.test.ts
# 2 files passed; 22 tests passed

pnpm --filter @agent-inspect/redact build
# ESM, CJS, and declarations built successfully

pnpm exec prettier --check packages/redact/test/readme.test.ts
git diff --check
# passed
```

The complete workspace install could not fit this runner, so I used a frozen filtered install for `@agent-inspect/redact`. Consequently, full `pnpm typecheck` and the unscoped workspace suite were attempted but could not complete because optional workspace dependencies such as `ai`, `@langchain/core`, and `better-sqlite3` were not installed. The focused package tests and build above pass.

## Screenshots / sample output

Not applicable; the new test executes the README snippet and verifies that output contains `[REDACTED]` and does not contain the synthetic input token.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
