### PR TITLE
fix: Windows file URL/path portability sweep

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -167,10 +167,13 @@ jobs:
 export async function planInit(options: InitCommandOptions = {}): Promise<InitPlan> {
   const framework = normalizeFramework(options.framework);
   const cwd = path.resolve(options.cwd ?? process.cwd());
+  // Planned-file paths are a display/JSON contract; keep them POSIX-style on
+  // every platform like the other candidates (filesystem access still goes
+  // through path.join(cwd, rel), which accepts forward slashes on Windows).
   const demoPath =
     framework === "custom"
-      ? path.join("examples", "agent-inspect-demo.mjs")
-      : path.join("examples", `agent-inspect-${framework}-demo.mjs`);
+      ? "examples/agent-inspect-demo.mjs"
+      : `examples/agent-inspect-${framework}-demo.mjs`;
 
   const candidates: Array<{ rel: string; content: string }> = [
     { rel: CONFIG_FILE, content: configTemplate(framework) },

--- a/packages/cli/test/cli-stability.test.ts
+++ b/packages/cli/test/cli-stability.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Readable } from "node:stream";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,7 +21,7 @@ function jsonl(...lines: string[]): string {
   return lines.join("\n") + "\n";
 }
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
 describe("CLI stability (v1.0 Pass 1)", () => {
   let traceDir: string;

--- a/packages/cli/test/list.test.ts
+++ b/packages/cli/test/list.test.ts
@@ -1,6 +1,7 @@
 import { cp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -290,7 +291,7 @@ describe("list", () => {
 
   it("lists v0.2 metadata from the embedded run", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/dual-format-parity.jsonl",
     );
     await cp(fixture, path.join(traceDir, "dual-format-parity.jsonl"));

--- a/packages/cli/test/report.test.ts
+++ b/packages/cli/test/report.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -33,7 +34,7 @@ describe("report CLI", () => {
 
   it("renders markdown report to stdout", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -47,7 +48,7 @@ describe("report CLI", () => {
 
   it("writes html report to file", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -65,7 +66,7 @@ describe("report CLI", () => {
 
   it("emits valid JSON wrapper", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");

--- a/packages/cli/test/search.test.ts
+++ b/packages/cli/test/search.test.ts
@@ -1,6 +1,7 @@
 import { cp, mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,7 +24,7 @@ describe("search CLI", () => {
 
   it("finds error status", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces",
     );
     await cp(path.join(fixtures, "minimal-error.jsonl"), path.join(tmpDir, "minimal-error.jsonl"));
@@ -34,7 +35,7 @@ describe("search CLI", () => {
 
   it("finds tool steps", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces",
     );
     await cp(path.join(fixtures, "tool-with-io.jsonl"), path.join(tmpDir, "tool-with-io.jsonl"));
@@ -45,7 +46,7 @@ describe("search CLI", () => {
 
   it("emits valid JSON", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces",
     );
     await cp(path.join(fixtures, "minimal-success.jsonl"), path.join(tmpDir, "minimal-success.jsonl"));
@@ -56,7 +57,7 @@ describe("search CLI", () => {
 
   it("finds v0.2 runs and steps by normalized metadata", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/dual-format-parity.jsonl",
     );
     await cp(fixture, path.join(tmpDir, "dual-format-parity.jsonl"));
@@ -83,7 +84,7 @@ describe("search CLI", () => {
 
   it("filters results by session id", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/sessions/multi-agent-handoff",
     );
     await cp(path.join(fixtures, "handoff-planner.jsonl"), path.join(tmpDir, "handoff-planner.jsonl"));
@@ -102,7 +103,7 @@ describe("search CLI", () => {
 
   it("sets exit code 1 when the session id is not found", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/sessions/multi-agent-handoff",
     );
     await cp(path.join(fixtures, "handoff-planner.jsonl"), path.join(tmpDir, "handoff-planner.jsonl"));

--- a/packages/cli/test/sessions-index-parity.test.ts
+++ b/packages/cli/test/sessions-index-parity.test.ts
@@ -1,6 +1,7 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { buildSessionIndex } from "@agent-inspect/core/advanced";
 import { buildIndex } from "@agent-inspect/index-sqlite";
@@ -9,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadSessionRuns } from "../src/sessions-load.js";
 
 const fixturesRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/sessions",
 );
 

--- a/packages/cli/test/sessions.test.ts
+++ b/packages/cli/test/sessions.test.ts
@@ -1,6 +1,7 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -15,7 +16,7 @@ import {
 } from "../src/sessions.js";
 
 const fixturesRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/sessions",
 );
 

--- a/packages/cli/test/stats.test.ts
+++ b/packages/cli/test/stats.test.ts
@@ -1,6 +1,7 @@
 import { cp, mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,7 +29,7 @@ describe("stats CLI", () => {
 
   it("aggregates fixture directory", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces",
     );
     await cp(path.join(fixtures, "minimal-success.jsonl"), path.join(tmpDir, "minimal-success.jsonl"));
@@ -40,7 +41,7 @@ describe("stats CLI", () => {
 
   it("emits valid JSON", async () => {
     const fixtures = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces",
     );
     await cp(path.join(fixtures, "minimal-success.jsonl"), path.join(tmpDir, "minimal-success.jsonl"));
@@ -52,7 +53,7 @@ describe("stats CLI", () => {
 
   it("aggregates v0.2 run metadata and steps", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/dual-format-parity.jsonl",
     );
     await cp(fixture, path.join(tmpDir, "dual-format-parity.jsonl"));

--- a/packages/cli/test/timeline-v02.test.ts
+++ b/packages/cli/test/timeline-v02.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,7 +29,7 @@ describe("timeline CLI v0.2 fixtures", () => {
 
   it("renders manual-basic v0.2 fixture", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/manual-basic.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");

--- a/packages/cli/test/timeline.test.ts
+++ b/packages/cli/test/timeline.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -33,7 +34,7 @@ describe("timeline CLI", () => {
 
   it("renders fixture run", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const { readFile } = await import("node:fs/promises");
@@ -47,7 +48,7 @@ describe("timeline CLI", () => {
 
   it("emits valid JSON", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const { readFile } = await import("node:fs/promises");

--- a/packages/cli/test/what-v02.test.ts
+++ b/packages/cli/test/what-v02.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,7 +29,7 @@ describe("what CLI v0.2 fixtures", () => {
 
   it("summarizes manual-basic v0.2 fixture", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/manual-basic.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");

--- a/packages/cli/test/what.test.ts
+++ b/packages/cli/test/what.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -39,7 +40,7 @@ describe("what CLI", () => {
 
   it("renders concise summary for fixture run", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const { readFile } = await import("node:fs/promises");
@@ -53,7 +54,7 @@ describe("what CLI", () => {
 
   it("emits valid JSON", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/llm-with-tokens.jsonl",
     );
     const { readFile } = await import("node:fs/promises");

--- a/packages/core/test/persisted/to-trace-event.test.ts
+++ b/packages/core/test/persisted/to-trace-event.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -90,7 +91,7 @@ describe("persistedInspectEventToTraceEvents", () => {
 
   it("converts native v0.2 manual-basic fixture rows", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../../fixtures/traces-v0.2/manual-basic.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -103,7 +104,7 @@ describe("persistedInspectEventToTraceEvents", () => {
 
   it("maps native tool error fixture to step error", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../../fixtures/traces-v0.2/manual-tool-error.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");

--- a/packages/core/test/read-trace.test.ts
+++ b/packages/core/test/read-trace.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -9,7 +10,7 @@ import { validateEvent } from "../src/storage.js";
 describe("parseTraceJsonl", () => {
   it("reads v0.1 fixtures unchanged", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces/minimal-success.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -23,7 +24,7 @@ describe("parseTraceJsonl", () => {
 
   it("normalizes v0.2 fixtures to trace events", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v0.2/llm-tokens-and-streaming.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -46,7 +47,7 @@ describe("parseTraceJsonl", () => {
 
   it("normalizes v1.0 fixtures to trace events and preserves persisted rows", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "../../../fixtures/traces-v1.0/manual-basic.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -95,7 +96,7 @@ describe("parseTraceJsonl", () => {
 
   it("preserves source-row order across v0.1, v0.2, and v1.0 rows", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "fixtures/mixed-v0.1-v0.2-v1.0-order.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");
@@ -132,7 +133,7 @@ describe("parseTraceJsonl", () => {
 
   it("preserves source-row order and adjacent one-to-many expansion", async () => {
     const fixture = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "fixtures/mixed-v0.1-v0.2-order.jsonl",
     );
     const raw = await readFile(fixture, "utf-8");

--- a/packages/core/test/readers.test.ts
+++ b/packages/core/test/readers.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -16,7 +17,7 @@ import {
 } from "../src/readers/index.js";
 
 const repoRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../..",
 );
 

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -6,11 +7,11 @@ import { extractMetadata } from "../src/trace-metadata.js";
 import { parseDurationFilter, searchTraces } from "../src/search.js";
 
 const fixturesDir = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/traces",
 );
 const fixturesV02Dir = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/traces-v0.2",
 );
 

--- a/packages/core/test/sessions/scope.test.ts
+++ b/packages/core/test/sessions/scope.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +13,7 @@ import {
 } from "../../src/sessions/index.js";
 
 const fixturesRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../../fixtures/sessions",
 );
 

--- a/packages/core/test/sessions/session-index.test.ts
+++ b/packages/core/test/sessions/session-index.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -11,7 +12,7 @@ import {
 } from "../../src/sessions/index.js";
 
 const fixturesRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../../fixtures/sessions",
 );
 

--- a/packages/core/test/stats.test.ts
+++ b/packages/core/test/stats.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -6,11 +7,11 @@ import { extractMetadata } from "../src/trace-metadata.js";
 import { buildTraceStats } from "../src/stats.js";
 
 const fixturesDir = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/traces",
 );
 const fixturesV02Dir = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/traces-v0.2",
 );
 

--- a/packages/core/test/timeline.test.ts
+++ b/packages/core/test/timeline.test.ts
@@ -1,12 +1,13 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 import { buildRunTimeline, renderTimeline } from "../src/timeline.js";
 
 const fixturesDir = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../../fixtures/traces",
 );
 

--- a/packages/core/test/trace-metadata.test.ts
+++ b/packages/core/test/trace-metadata.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 import type { TokenMetadata, TraceEvent } from "../src/types.js";
@@ -8,7 +9,7 @@ import { extractMetadata, buildRunSummary } from "../src/trace-metadata.js";
 
 const ts = 1_700_000_000_000;
 const repoRoot = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../..",
 );
 

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import {
   openTrace,
   TraceReadError,
@@ -156,7 +158,9 @@ function isTraceReadResult(value: unknown): value is TraceReadResult {
 }
 
 function traceInputFrom(value: string | URL): TraceInput {
-  return { type: "file", path: value instanceof URL ? value.pathname : value };
+  // URL.pathname is not a filesystem path on Windows (leading slash before
+  // the drive letter); fileURLToPath handles file: URLs on every platform.
+  return { type: "file", path: value instanceof URL ? fileURLToPath(value) : value };
 }
 
 async function resolveRead(

--- a/packages/eval/test/index.test.ts
+++ b/packages/eval/test/index.test.ts
@@ -1,3 +1,8 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -297,5 +302,31 @@ describe("@agent-inspect/eval", () => {
     expect(result.ok).toBe(false);
     expect(result.status).toBe("error");
     expect(result.diagnostics[0]?.code).toBe("AI_EVAL_UNSUPPORTED_FORMAT");
+  });
+
+  it("accepts a file: URL input on every platform", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-eval-url-"));
+    try {
+      const file = path.join(dir, "run.jsonl");
+      const lines = [
+        '{"schemaVersion":"0.1","event":"run_started","timestamp":1,"runId":"url-run","name":"url-run","startTime":1}',
+        '{"schemaVersion":"0.1","event":"run_completed","timestamp":2,"runId":"url-run","status":"success","endTime":2,"durationMs":1}',
+      ];
+      await writeFile(file, lines.join("\n") + "\n", "utf8");
+
+      const result = await evalRun(
+        { trace: pathToFileURL(file) },
+        { checks: [checks.maxDurationMs(2000)] },
+      );
+
+      // A file: URL must resolve to the same trace a plain path would; a
+      // POSIX-only conversion produces an unreadable path and a diagnostic.
+      expect(result.diagnostics).toEqual([]);
+      expect(result.format).toBe("agent-inspect-v0.1-jsonl");
+      expect(result.runId).toBe("url-run");
+      expect(result.ok).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Windows file URL/path portability sweep from #104, developed and verified on a Windows 11 machine where the failures reproduce.

Audit results (every `.pathname` usage in the repo was reviewed):

| Location | Verdict | Action |
| -------- | ------- | ------ |
| 20 test files in `packages/core/test` and `packages/cli/test` using `path.dirname(new URL(import.meta.url).pathname)` | Broken on Windows (`/C:/...` leading-slash paths, surfacing as doubled `C:\C:\` prefixes) | Converted to `fileURLToPath(import.meta.url)`, the pattern the rest of the repo already uses |
| `packages/eval/src/index.ts` `traceInputFrom` | Runtime bug: a user-supplied `file:` URL (`EvalInput.trace`) was converted via `URL.pathname`, unreadable on Windows | Use `fileURLToPath`; regression test added asserting a `file:` URL resolves to the same trace a plain path does (no diagnostics, correct format and runId) |
| `packages/cli/src/init.ts` planned demo path | Runtime bug: built with `path.join`, leaking a backslash into the planned-files display/JSON contract on Windows while sibling candidates are forward-slash literals | Emit the POSIX-style literal; filesystem access still goes through `path.join(cwd, rel)`, which accepts forward slashes on Windows. The existing "dry-run reports planned files deterministically" test now passes on Windows unchanged |
| `packages/studio/src/server.ts`, `packages/viewer/src/server.ts` `url.pathname` | Correct as-is: these parse HTTP request URLs, not filesystem paths | No change |

POSIX behavior is unchanged: for these paths `fileURLToPath` and `.pathname` agree on Linux/macOS (with `fileURLToPath` additionally handling percent-encoding correctly), the init literal is byte-identical to what `path.join` produced there, and CI stays green for the same reason it was green before.

Closes #104

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core` (tests only)
- [x] `@agent-inspect/cli` (init planned-path literal + tests)
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/eval` (file: URL input fix + regression test)

## Validation

```bash
pnpm typecheck  # pass
pnpm test       # on Windows 11 / Node 24: 96 failed -> 26 failed (1366 passed)
git diff --check  # clean
```

The 26 remaining local failures are all `better-sqlite3` native-binding tests (`packages/index-sqlite`, `packages/studio`, `packages/cli/test/index-sqlite.test.ts`, `sessions-index-parity`): no Node 24 prebuilds plus a missing ClangCL toolset locally. That is the native SQLite install-matrix area the issue explicitly leaves to the advanced backlog, unrelated to path handling.

Spot checks on Windows after the sweep: previously failing suites (`cli/test/search`, `cli/test/report`, `cli/test/stats`, `cli/test/timeline`, `core/test/readers`, `core/test/read-trace`, `core/test/sessions/*`, `cli/test/init`, `eval`) now pass locally, and `agent-inspect init --dry-run` prints forward-slash planned paths.

## Screenshots / sample output

```text
Dry run — would create:
- agent-inspect.config.ts
- .agent-inspect/.gitkeep
- examples/agent-inspect-demo.mjs      (was: examples\agent-inspect-demo.mjs on Windows)
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, no documented behavior change
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
