### PR TITLE
test(cli): add cross-command not-found exit-code parity suite

### DIFF
--- a/packages/cli/test/notfound-exit-parity.test.ts
+++ b/packages/cli/test/notfound-exit-parity.test.ts
@@ -1,0 +1,173 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { diffCommand } from "../src/diff.js";
+import { exportCommand } from "../src/export.js";
+import { explainCommand } from "../src/explain.js";
+import { list } from "../src/list.js";
+import { openCommand } from "../src/open.js";
+import { reportCommand } from "../src/report.js";
+import { searchCommand } from "../src/search.js";
+import { sessionCommand } from "../src/sessions.js";
+import { timelineCommand } from "../src/timeline.js";
+import { view } from "../src/view.js";
+import { whatCommand } from "../src/what.js";
+
+function jsonl(...lines: string[]): string {
+  return lines.join("\n") + "\n";
+}
+
+function syntheticTrace(runId: string, sessionId?: string): string {
+  return jsonl(
+    JSON.stringify({
+      schemaVersion: "0.1",
+      event: "run_started",
+      timestamp: 1_700_000_000_000,
+      runId,
+      name: runId,
+      startTime: 1_700_000_000_000,
+      ...(sessionId !== undefined ? { metadata: { sessionId } } : {}),
+    }),
+    JSON.stringify({
+      schemaVersion: "0.1",
+      event: "run_completed",
+      timestamp: 1_700_000_000_100,
+      runId,
+      status: "success",
+      endTime: 1_700_000_000_100,
+      durationMs: 100,
+    }),
+  );
+}
+
+/**
+ * Cross-command parity contract (#105): a missing explicitly requested
+ * resource exits nonzero in human AND JSON modes; empty list/search results
+ * remain successful. Each case runs the real command function against a
+ * synthetic temp trace directory.
+ */
+describe("not-found exit-code parity", () => {
+  let traceDir: string;
+  let traceFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  const prevExitCode = process.exitCode;
+
+  beforeEach(async () => {
+    traceDir = path.join(
+      os.tmpdir(),
+      `agent-inspect-parity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    await mkdir(traceDir, { recursive: true });
+    traceFile = path.join(traceDir, "existing-run.jsonl");
+    await writeFile(traceFile, syntheticTrace("existing-run", "sess-known"), "utf-8");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = prevExitCode ?? 0;
+    await rm(traceDir, { recursive: true, force: true });
+  });
+
+  type Case = { name: string; run: (json: boolean) => Promise<void> };
+
+  const lookupCases: Case[] = [
+    {
+      name: "view",
+      run: (json) => view("missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "report",
+      run: (json) => reportCommand("missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "timeline",
+      run: (json) => timelineCommand("missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "what",
+      run: (json) => whatCommand("missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "export",
+      run: (json) => exportCommand("missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "diff (missing left)",
+      run: (json) => diffCommand("missing-run", "existing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "diff (missing right)",
+      run: (json) => diffCommand("existing-run", "missing-run", { dir: traceDir, json }),
+    },
+    {
+      name: "session",
+      run: (json) => sessionCommand("sess-missing", { dir: traceDir, json }),
+    },
+    {
+      name: "search --session",
+      run: (json) => searchCommand({ dir: traceDir, session: "sess-missing", json }),
+    },
+  ];
+
+  for (const { name, run } of lookupCases) {
+    it(`${name}: missing resource exits nonzero in human mode`, async () => {
+      await run(false);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it(`${name}: missing resource exits nonzero in JSON mode`, async () => {
+      await run(true);
+      expect(process.exitCode).toBe(1);
+    });
+  }
+
+  it("explain --run: missing run exits nonzero in human and JSON modes", async () => {
+    await explainCommand(traceFile, { run: "missing-run" });
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = 0;
+    await explainCommand(traceFile, { run: "missing-run", json: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("open --run: missing run exits nonzero in human and JSON modes", async () => {
+    await openCommand(traceFile, { run: "missing-run" });
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = 0;
+    await openCommand(traceFile, { run: "missing-run", json: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("found resources still exit zero (control)", async () => {
+    await view("existing-run", { dir: traceDir });
+    expect(process.exitCode).toBe(0);
+
+    await sessionCommand("sess-known", { dir: traceDir, json: true });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("empty list results remain success in human and JSON modes", async () => {
+    await list({ dir: traceDir, name: "zzz-no-match" });
+    expect(process.exitCode).toBe(0);
+
+    await list({ dir: traceDir, name: "zzz-no-match", json: true });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("empty search results remain success in human and JSON modes", async () => {
+    await searchCommand({ dir: traceDir, name: "zzz-no-match" });
+    expect(process.exitCode).toBe(0);
+
+    await searchCommand({ dir: traceDir, name: "zzz-no-match", json: true });
+    expect(process.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Cross-command not-found exit-code parity audit and regression suite from #105.

### Audit notes

Every explicit lookup path in `packages/cli/src` was reviewed (source plus empirical runs of the built CLI against a synthetic trace directory):

| Command | Missing resource, human | Missing resource, `--json` | Source |
| ------- | ----------------------- | -------------------------- | ------ |
| `view <run-id>` | exit 1 | exit 1 | `view.ts` sets exitCode before mode handling |
| `report <run-id>` | exit 1 | exit 1 | `report.ts:83` |
| `timeline <run-id>` | exit 1 | exit 1 | `timeline.ts:42` |
| `what <run-id>` | exit 1 | exit 1 | `what.ts:43` |
| `export <run-id>` | exit 1 | exit 1 | `export.ts:90` |
| `diff <left> <right>` (either side missing) | exit 1 | exit 1 | `diff.ts:109,116` |
| `session <session-id>` | exit 1 | exit 1 | `sessions.ts:385` |
| `search --session <id>` | exit 1 | exit 1 | fixed in #91 |
| `explain <file> --run <id>` | exit 1 | exit 1 | `explain.ts:127` (exitCode set before the JSON/human branch) |
| `open <file> --run <id>` | exit 1 | exit 1 | `open.ts:155` (same pattern) |
| `bundle` (unresolvable run ids) | exit 1 | exit 1 | `bundle.ts:224,250,267` |

Empty-result semantics verified as success: `list`/`search` with filters matching nothing, and `sessions` over a directory without session metadata, all exit 0 in both modes.

Conclusion: after #91, no parity gaps remain, so this PR is tests-only. One observation left as-is to avoid UX redesign: `session`'s not-found branch prints human text even under `--json` (exit code is correct); flagging in case you want a follow-up.

### The suite

`packages/cli/test/notfound-exit-parity.test.ts`: 23 table-driven cases over the real command functions with synthetic temp traces (no fixtures, no network): nonzero exits for all missing-resource lookups in both modes, exit 0 controls for found resources, and exit 0 for empty list/search results in both modes, so any future regression on either side of the contract fails loudly.

Closes #105

## Type of change

- [x] Bug fix (non-breaking) - regression tests for exit-code contract; no behavior change needed
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [x] `@agent-inspect/cli` (tests only)
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/cli/test/notfound-exit-parity.test.ts  # 23/23 pass
git diff --check  # clean
```

Also verified empirically against the built CLI on Windows: all 20 missing-resource invocations exit 1, all 6 empty-result invocations exit 0 (script output in the audit above).

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, tests only
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
