### PR TITLE
test: add malformed JSONL final-line corpus

### DIFF
--- a/fixtures/logs/README.md
+++ b/fixtures/logs/README.md
@@ -15,6 +15,10 @@ Text files for **v0.3 log-to-tree**, **v0.4 tail**, parser warnings, and integra
 | `malformed-json.log` | **No** (intentionally broken lines) | Parser skips garbage |
 | `missing-run-id.log` | Yes, but no join key | Missing run id warnings |
 | `mixed-valid-invalid.log` | Mixed | Resilience / warning summaries |
+| `tail-truncated-final.log` | **No** (final line cut mid-write, no trailing newline) | Interrupted-write tail degradation |
+| `tail-missing-newline.log` | Yes (no trailing newline at EOF) | EOF without newline parses cleanly |
+| `tail-partial-object.log` | **No** (unterminated JSON object at EOF) | Partial-object tail degradation |
+| `tail-mixed-valid-invalid.log` | Mixed (truncated line between valid tail lines) | Interleaved-write tail resilience |
 
 ## Safety
 

--- a/fixtures/logs/tail-missing-newline.log
+++ b/fixtures/logs/tail-missing-newline.log
@@ -1,0 +1,3 @@
+{"event":"proactive.job.started","decisionId":"fixture_tail_no_newline","timestamp":1746451221000}
+{"event":"proactive.tool.search","decisionId":"fixture_tail_no_newline","timestamp":1746451221100}
+{"event":"proactive.job.completed","decisionId":"fixture_tail_no_newline","timestamp":1746451221200}

--- a/fixtures/logs/tail-mixed-valid-invalid.log
+++ b/fixtures/logs/tail-mixed-valid-invalid.log
@@ -1,0 +1,4 @@
+{"event":"proactive.job.started","decisionId":"fixture_tail_mixed","timestamp":1746451223000}
+{"event":"proactive.tool.search","decisionId":"fixture_tail_mixed","timestamp":1746451223100}
+{"event":"proactive.tool.search_completed","decisionId":"fixture_tail_mixed","timest
+{"event":"proactive.job.completed","decisionId":"fixture_tail_mixed","timestamp":1746451223300}

--- a/fixtures/logs/tail-partial-object.log
+++ b/fixtures/logs/tail-partial-object.log
@@ -1,0 +1,3 @@
+{"event":"proactive.job.started","decisionId":"fixture_tail_partial","timestamp":1746451222000}
+{"event":"proactive.llm.generate","decisionId":"fixture_tail_partial","timestamp":1746451222100}
+{"event":"proactive.job.completed","decisionId":"fixture_tail_partial"

--- a/fixtures/logs/tail-truncated-final.log
+++ b/fixtures/logs/tail-truncated-final.log
@@ -1,0 +1,4 @@
+{"event":"proactive.job.started","decisionId":"fixture_tail_truncated","timestamp":1746451220000}
+{"event":"proactive.tool.search","decisionId":"fixture_tail_truncated","timestamp":1746451220100}
+{"event":"proactive.result.done","decisionId":"fixture_tail_truncated","timestamp":1746451220200}
+{"event":"proactive.job.completed","decisionId":"fixture_tail_truncated","timesta

--- a/packages/cli/test/logs.test.ts
+++ b/packages/cli/test/logs.test.ts
@@ -96,6 +96,19 @@ describe("logs", () => {
     logSpy.mockRestore();
   });
 
+  it("truncated final line degrades with a warning and keeps the run", async () => {
+    const fixture = path.join(repoRoot, "fixtures/logs/tail-truncated-final.log");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await logs(fixture, { format: "json", warnings: "all" });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    // Prior valid lines still build the run tree...
+    expect(out).toContain("Run fixture_tail_truncated");
+    // ...and the interrupted tail surfaces as a warning, not a crash.
+    expect(out).toContain("MALFORMED_JSON");
+    expect(process.exitCode).toBe(0);
+    logSpy.mockRestore();
+  });
+
   it("missing file fails clearly", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await logs("/no/such/file.log", { format: "json" });

--- a/packages/core/test/logs/malformed-tail.test.ts
+++ b/packages/core/test/logs/malformed-tail.test.ts
@@ -1,0 +1,108 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { JsonLogParser } from "../../src/logs/json-parser.js";
+import { openTrace } from "../../src/entries/readers.js";
+
+const fixturesDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../fixtures/logs",
+);
+
+const parser = new JsonLogParser();
+
+/**
+ * Malformed final-line corpus (#107): interrupted writes must degrade with
+ * warnings, never throw, and never drop or reorder earlier valid records.
+ */
+describe("malformed JSONL final-line corpus", () => {
+  it("truncated final line warns and preserves prior records in order", async () => {
+    const result = await parser.parseFile(path.join(fixturesDir, "tail-truncated-final.log"));
+
+    expect(result.records).toHaveLength(3);
+    expect(result.records.map((r) => r.line)).toEqual([1, 2, 3]);
+    expect(result.records.map((r) => r.raw.event)).toEqual([
+      "proactive.job.started",
+      "proactive.tool.search",
+      "proactive.result.done",
+    ]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({ code: "MALFORMED_JSON", line: 4 });
+  });
+
+  it("missing trailing newline parses every line without warnings", async () => {
+    const result = await parser.parseFile(path.join(fixturesDir, "tail-missing-newline.log"));
+
+    expect(result.records).toHaveLength(3);
+    expect(result.warnings).toEqual([]);
+    expect(result.records[2]?.raw.event).toBe("proactive.job.completed");
+  });
+
+  it("partial JSON object at EOF warns and keeps prior records", async () => {
+    const result = await parser.parseFile(path.join(fixturesDir, "tail-partial-object.log"));
+
+    expect(result.records).toHaveLength(2);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({ code: "MALFORMED_JSON", line: 3 });
+  });
+
+  it("mixed valid/invalid tail keeps valid lines on both sides of the break", async () => {
+    const result = await parser.parseFile(
+      path.join(fixturesDir, "tail-mixed-valid-invalid.log"),
+    );
+
+    expect(result.records.map((r) => r.line)).toEqual([1, 2, 4]);
+    expect(result.records[2]?.raw.event).toBe("proactive.job.completed");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({ code: "MALFORMED_JSON", line: 3 });
+  });
+});
+
+describe("trace reader final-line degradation", () => {
+  const validRow = (event: string, extra: string) =>
+    `{"schemaVersion":"0.1","event":"${event}","timestamp":1,"runId":"tail-run",${extra}}`;
+
+  it("truncated final trace row warns and preserves accepted events in order", async () => {
+    const content = [
+      validRow("run_started", '"name":"tail-run","startTime":1'),
+      validRow("step_started", '"stepId":"s1","name":"step-one","type":"logic","startTime":2'),
+      '{"schemaVersion":"0.1","event":"step_completed","timestamp":3,"runId":"tail-ru',
+    ].join("\n");
+
+    const read = await openTrace({ type: "string", content });
+
+    expect(read.warnings.some((w) => w.code === "invalid_jsonl_rows" && w.line === 3)).toBe(
+      true,
+    );
+    expect(read.events.map((e) => e.name)).toEqual(["tail-run", "step-one"]);
+  });
+
+  it("does not throw for a file that is only a partial object", async () => {
+    const read = await openTrace(
+      { type: "string", content: '{"schemaVersion":"0.1","event":"run_star' },
+      { format: "agent-inspect-jsonl" },
+    ).catch((error) => error as Error);
+
+    // Either a warning-bearing empty read or a typed TraceReadError is
+    // acceptable; an unhandled parser throw is not.
+    if (read instanceof Error) {
+      expect(read.name).toBe("TraceReadError");
+    } else {
+      expect(read.events).toEqual([]);
+    }
+  });
+
+  it("missing trailing newline on the final trace row reads cleanly", async () => {
+    const content =
+      validRow("run_started", '"name":"tail-run","startTime":1') +
+      "\n" +
+      validRow("run_completed", '"status":"success","endTime":2,"durationMs":1');
+
+    const read = await openTrace({ type: "string", content });
+
+    expect(read.warnings.filter((w) => w.code === "invalid_jsonl_rows")).toEqual([]);
+    expect(read.events).toHaveLength(2);
+  });
+});

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -61,6 +61,10 @@ const REQUIRED = {
     "fixtures/logs/malformed-json.log",
     "fixtures/logs/missing-run-id.log",
     "fixtures/logs/mixed-valid-invalid.log",
+    "fixtures/logs/tail-truncated-final.log",
+    "fixtures/logs/tail-missing-newline.log",
+    "fixtures/logs/tail-partial-object.log",
+    "fixtures/logs/tail-mixed-valid-invalid.log",
   ],
   configs: [
     "fixtures/configs/proactive-agent-inspect.logs.json",
@@ -82,6 +86,9 @@ const REQUIRED = {
 const MALFORMED_LOGS = new Set([
   "malformed-json.log",
   "mixed-valid-invalid.log",
+  "tail-truncated-final.log",
+  "tail-partial-object.log",
+  "tail-mixed-valid-invalid.log",
 ]);
 
 const FORBIDDEN = [
@@ -230,7 +237,8 @@ function validateJsonLog(rel) {
     base === "pino-agent-json.log" ||
     base === "mcp-tool-call-json.log" ||
     base === "nestjs-agent-json.log" ||
-    base === "proactive-json.log"
+    base === "proactive-json.log" ||
+    base === "tail-missing-newline.log"
   ) {
     for (let i = 0; i < lines.length; i++) {
       JSON.parse(lines[i]);


### PR DESCRIPTION
## Summary

Malformed JSONL final-line corpus from #107: deterministic fixtures for the interrupted-write failure mode plus tests pinning the degrade contract at three layers. No parsing-policy changes.

### Corpus (`fixtures/logs/`)

| File | Shape | Case from the issue |
| ---- | ----- | ------------------- |
| `tail-truncated-final.log` | 3 valid lines, final line cut mid-write, no trailing newline | truncated final line |
| `tail-missing-newline.log` | all lines valid, EOF without newline | missing trailing newline |
| `tail-partial-object.log` | 2 valid lines, unterminated JSON object at EOF | partial JSON object at EOF |
| `tail-mixed-valid-invalid.log` | truncated line between valid tail lines | mixed valid/invalid tail |

Registered in `scripts/validate-fixtures.mjs` (`REQUIRED.logs`, with the three intentionally broken files in `MALFORMED_LOGS` and the missing-newline file in the parse-all group) and documented in `fixtures/logs/README.md`. Synthetic `proactive.*` events and fixture ids only.

### Tests

- `packages/core/test/logs/malformed-tail.test.ts` (7 cases)
  - `JsonLogParser`: each broken tail yields exactly one `MALFORMED_JSON` warning with the correct line number; prior records stay accepted and ordered; the missing-newline file parses all lines with zero warnings
  - trace reader (`openTrace`): a truncated final trace row yields `invalid_jsonl_rows` with the first bad line while earlier events stay ordered; a file that is nothing but a partial object either reads empty or raises a typed `TraceReadError`, never an unhandled parser throw; a final row lacking only its newline reads cleanly
- `packages/cli/test/logs.test.ts`: the truncated fixture still renders the run tree, the warning surfaces under `--warnings all`, and exit stays 0 because valid events exist (distinct from the existing all-garbage case which exits 1)

Closes #107

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core` (tests only)
- [x] `@agent-inspect/cli` (tests only)
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck       # pass
pnpm fixtures:check  # pass, logs corpus now 13 files
pnpm exec vitest run packages/core/test/logs/malformed-tail.test.ts packages/cli/test/logs.test.ts  # 17/17 pass
git diff --check     # clean (the missing-newline fixtures intentionally end without \n)
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
