### PR TITLE
fix(core): apply cohort maxRelativeDelta to every numeric metric

### DIFF
--- a/packages/core/src/cohort/compare.ts
+++ b/packages/core/src/cohort/compare.ts
@@ -89,6 +89,8 @@ export function compareCohortAggregates(
           "Average duration (ms)",
           baselineAgg?.avgDurationMs,
           candidateAgg?.avgDurationMs,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -99,6 +101,8 @@ export function compareCohortAggregates(
           "Average LLM calls",
           baselineAgg?.avgLlmCallCount,
           candidateAgg?.avgLlmCallCount,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -109,6 +113,8 @@ export function compareCohortAggregates(
           "Average token usage",
           baselineAgg?.avgTokenUsage,
           candidateAgg?.avgTokenUsage,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -119,6 +125,8 @@ export function compareCohortAggregates(
           "Average retries",
           baselineAgg?.avgRetryCount,
           candidateAgg?.avgRetryCount,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -129,6 +137,8 @@ export function compareCohortAggregates(
           "Observation failure rate",
           baselineAgg?.observationFailureRate,
           candidateAgg?.observationFailureRate,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -165,6 +175,8 @@ export function compareCohortAggregates(
           "Guardrail failures",
           baselineAgg?.avgGuardrailFailures,
           candidateAgg?.avgGuardrailFailures,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -175,6 +187,8 @@ export function compareCohortAggregates(
           "Circuit violations",
           baselineAgg?.avgCircuitViolations,
           candidateAgg?.avgCircuitViolations,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;
@@ -185,6 +199,8 @@ export function compareCohortAggregates(
           "Redaction warnings",
           baselineAgg?.avgRedactionWarnings,
           candidateAgg?.avgRedactionWarnings,
+          true,
+          tolerance,
         );
         if (item) comparisons.push(item);
         break;

--- a/packages/core/test/cohort/compare-tolerance.test.ts
+++ b/packages/core/test/cohort/compare-tolerance.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareCohortAggregates,
+  type CohortAggregateMetrics,
+  type CohortMetricId,
+} from "../../src/entries/advanced.js";
+
+function aggregate(
+  cohortLabel: string,
+  overrides: Partial<CohortAggregateMetrics> = {},
+): CohortAggregateMetrics {
+  return {
+    groupKey: "all",
+    cohortLabel,
+    runCount: 10,
+    errorRate: 0.1,
+    avgDurationMs: 100,
+    avgLlmCallCount: 4,
+    avgTokenUsage: 1000,
+    avgRetryCount: 1,
+    observationFailureRate: 0.1,
+    avgGuardrailFailures: 1,
+    avgCircuitViolations: 1,
+    avgRedactionWarnings: 1,
+    ...overrides,
+  };
+}
+
+const NUMERIC_METRICS: Array<{
+  metric: CohortMetricId;
+  field: keyof CohortAggregateMetrics;
+  baseline: number;
+  withinTolerance: number;
+  beyondTolerance: number;
+}> = [
+  { metric: "errorRate", field: "errorRate", baseline: 0.1, withinTolerance: 0.105, beyondTolerance: 0.2 },
+  { metric: "duration", field: "avgDurationMs", baseline: 100, withinTolerance: 105, beyondTolerance: 200 },
+  { metric: "llmCallCount", field: "avgLlmCallCount", baseline: 4, withinTolerance: 4.2, beyondTolerance: 8 },
+  { metric: "tokenUsage", field: "avgTokenUsage", baseline: 1000, withinTolerance: 1050, beyondTolerance: 2000 },
+  { metric: "retryCount", field: "avgRetryCount", baseline: 1, withinTolerance: 1.05, beyondTolerance: 2 },
+  { metric: "observationFailure", field: "observationFailureRate", baseline: 0.1, withinTolerance: 0.105, beyondTolerance: 0.2 },
+  { metric: "guardrailFailure", field: "avgGuardrailFailures", baseline: 1, withinTolerance: 1.05, beyondTolerance: 2 },
+  { metric: "circuitViolation", field: "avgCircuitViolations", baseline: 1, withinTolerance: 1.05, beyondTolerance: 2 },
+  { metric: "redactionWarning", field: "avgRedactionWarnings", baseline: 1, withinTolerance: 1.05, beyondTolerance: 2 },
+];
+
+/**
+ * maxRelativeDelta is documented generically ("Allowed relative delta (0-1)
+ * before a metric comparison is a regression"), so it must gate every numeric
+ * metric, not just errorRate.
+ */
+describe("cohort compare maxRelativeDelta tolerance", () => {
+  for (const { metric, field, baseline, withinTolerance, beyondTolerance } of NUMERIC_METRICS) {
+    it(`${metric}: within-tolerance delta is not a regression`, () => {
+      const comparisons = compareCohortAggregates(
+        [
+          aggregate("before", { [field]: baseline }),
+          aggregate("after", { [field]: withinTolerance }),
+        ],
+        {
+          baseline: "before",
+          candidate: "after",
+          metrics: [metric],
+          maxRelativeDelta: 0.1,
+        },
+      );
+
+      expect(comparisons).toHaveLength(1);
+      expect(comparisons[0]?.metric).toBe(metric);
+      expect(comparisons[0]?.regression).toBe(false);
+    });
+
+    it(`${metric}: beyond-tolerance delta stays a regression`, () => {
+      const comparisons = compareCohortAggregates(
+        [
+          aggregate("before", { [field]: baseline }),
+          aggregate("after", { [field]: beyondTolerance }),
+        ],
+        {
+          baseline: "before",
+          candidate: "after",
+          metrics: [metric],
+          maxRelativeDelta: 0.1,
+        },
+      );
+
+      expect(comparisons[0]?.regression).toBe(true);
+    });
+
+    it(`${metric}: without tolerance any worsening delta is a regression`, () => {
+      const comparisons = compareCohortAggregates(
+        [
+          aggregate("before", { [field]: baseline }),
+          aggregate("after", { [field]: withinTolerance }),
+        ],
+        {
+          baseline: "before",
+          candidate: "after",
+          metrics: [metric],
+        },
+      );
+
+      expect(comparisons[0]?.regression).toBe(true);
+    });
+  }
+
+  it("categorical toolChoice changes are unaffected by tolerance", () => {
+    const comparisons = compareCohortAggregates(
+      [
+        aggregate("before", { dominantToolChoice: "search" }),
+        aggregate("after", { dominantToolChoice: "browse" }),
+      ],
+      {
+        baseline: "before",
+        candidate: "after",
+        metrics: ["toolChoice"],
+        maxRelativeDelta: 0.5,
+      },
+    );
+
+    expect(comparisons[0]?.regression).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `tolerance.maxRelativeDelta` being silently ignored for every cohort metric except `errorRate`, from #120.

The option is documented generically ("Allowed relative delta (0-1) before a metric comparison is a regression") and `analyzeCohort` threads it for all metrics, but `compareCohortAggregates` passed it to `compareNumber` only in the `errorRate` case. The other eight numeric metrics (`duration`, `llmCallCount`, `tokenUsage`, `retryCount`, `observationFailure`, `guardrailFailure`, `circuitViolation`, `redactionWarning`) omitted the argument, so the tolerance check at the top of `compareNumber` never ran for them: a 1% duration increase with a 10% allowed delta still flipped `result.ok` to false.

The fix passes the tolerance to every `compareNumber` call. Scope notes:

- Categorical `toolChoice` / `toolOrdering` comparisons are unchanged; a relative delta has no meaning for them (covered by a control test)
- Behavior with no tolerance set is byte-identical (`maxRelativeDelta === undefined` short-circuits), so existing callers and the existing cohort fixture tests are unaffected
- The existing `compareNumber` semantics (tolerance only forgives regressions, `baseline === 0` never divides) are untouched

Tests: `packages/core/test/cohort/compare-tolerance.test.ts`, a per-metric matrix over all nine numeric metrics asserting within-tolerance deltas are not regressions, beyond-tolerance deltas remain regressions, and any worsening delta without a tolerance remains a regression, plus the categorical control. 28 new cases; the existing cohort suite still passes.

Closes #120

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/core/test/cohort  # 30/30 pass (28 new + 2 existing)
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, behavior now matches the documented option
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
