### PR TITLE
test(mcp): extend privacy/adversarial coverage; harden summarizer

### DIFF
--- a/packages/mcp/src/summarize.ts
+++ b/packages/mcp/src/summarize.ts
@@ -1,5 +1,13 @@
 const DEFAULT_MAX_SUMMARY_LENGTH = 240;
 
+function fallbackString(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 export function summarizeMcpValue(
   value: unknown,
   maxLength = DEFAULT_MAX_SUMMARY_LENGTH,
@@ -9,10 +17,14 @@ export function summarizeMcpValue(
     if (typeof value === "string") {
       text = value;
     } else {
-      text = JSON.stringify(value);
+      // JSON.stringify returns undefined (not a string) for undefined,
+      // functions, and symbols; falling through with undefined would crash
+      // instrumentation at text.length below.
+      const serialized = JSON.stringify(value);
+      text = serialized === undefined ? fallbackString(value) : serialized;
     }
   } catch {
-    text = String(value);
+    text = fallbackString(value);
   }
   if (text.length <= maxLength) return text;
   return `${text.slice(0, Math.max(0, maxLength - 3))}...`;

--- a/packages/mcp/test/adversarial.test.ts
+++ b/packages/mcp/test/adversarial.test.ts
@@ -1,0 +1,213 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inspectRun } from "agent-inspect";
+
+import { resetMcpToolCallIdsForTests, wrapMcpClient } from "../src/index.js";
+import { summarizeMcpValue } from "../src/summarize.js";
+
+/**
+ * Adversarial privacy/serialization coverage (#110): hostile or edge-case
+ * values must degrade into bounded, redacted summaries without throwing into
+ * user code or leaking raw data to disk. Synthetic values only.
+ */
+describe("summarizeMcpValue adversarial inputs", () => {
+  it("degrades values JSON.stringify cannot represent instead of crashing", () => {
+    expect(summarizeMcpValue(undefined)).toBe("undefined");
+    expect(summarizeMcpValue(() => "x")).toContain("=>");
+    expect(summarizeMcpValue(Symbol("secret-tag"))).toBe("Symbol(secret-tag)");
+  });
+
+  it("degrades BigInt values via String fallback", () => {
+    expect(summarizeMcpValue(BigInt("9007199254740993"))).toBe("9007199254740993");
+    expect(summarizeMcpValue({ total: BigInt(7) })).toBe("[object Object]");
+  });
+
+  it("degrades cyclic structures without throwing", () => {
+    const cyclic: Record<string, unknown> = { name: "loop" };
+    cyclic.self = cyclic;
+    expect(summarizeMcpValue(cyclic)).toBe("[object Object]");
+  });
+
+  it("degrades throwing toJSON serializers without throwing", () => {
+    const hostile = {
+      toJSON() {
+        throw new Error("serializer exploded");
+      },
+    };
+    expect(summarizeMcpValue(hostile)).toBe("[object Object]");
+  });
+
+  it("degrades values whose String conversion also throws", () => {
+    const doubleHostile = {
+      toJSON() {
+        throw new Error("no json");
+      },
+      toString() {
+        throw new Error("no string");
+      },
+    };
+    expect(summarizeMcpValue(doubleHostile)).toBe("[unserializable]");
+  });
+
+  it("bounds non-ASCII and multibyte payloads to the summary length", () => {
+    const emoji = "🛰️".repeat(300);
+    const bounded = summarizeMcpValue(emoji, 40);
+    expect(bounded.length).toBeLessThanOrEqual(40);
+    expect(bounded.endsWith("...")).toBe(true);
+
+    const cjk = summarizeMcpValue({ 質問: "こんにちは世界".repeat(50) }, 64);
+    expect(cjk.length).toBeLessThanOrEqual(64);
+  });
+
+  it("handles degenerate maxLength values without negative slices", () => {
+    expect(summarizeMcpValue("abcdef", 3)).toBe("...");
+    expect(summarizeMcpValue("abcdef", 1)).toBe("...");
+    expect(summarizeMcpValue("abcdef", 0)).toBe("...");
+  });
+});
+
+describe("wrapMcpClient adversarial capture", () => {
+  let traceDir: string;
+
+  beforeEach(async () => {
+    resetMcpToolCallIdsForTests();
+    traceDir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-mcp-adv-"));
+    process.env.AGENT_INSPECT_TRACE_DIR = traceDir;
+  });
+
+  afterEach(async () => {
+    delete process.env.AGENT_INSPECT_TRACE_DIR;
+    await rm(traceDir, { recursive: true, force: true });
+  });
+
+  async function readTraceText(): Promise<string> {
+    const traceFiles = await readdir(traceDir);
+    const traceFile = traceFiles.find((file) => file.endsWith(".jsonl"));
+    expect(traceFile).toBeDefined();
+    return readFile(path.join(traceDir, traceFile!), "utf-8");
+  }
+
+  function fixtureClient() {
+    return wrapMcpClient(
+      {
+        async callTool({ name }: { name: string; arguments?: unknown }) {
+          return { content: [{ type: "text", text: `ok:${name}` }] };
+        },
+      },
+      { serverName: "adversarial-fixture" },
+    );
+  }
+
+  it("cyclic tool arguments do not throw into user code and degrade in the trace", async () => {
+    const client = fixtureClient();
+    const cyclic: Record<string, unknown> = { query: "loop" };
+    cyclic.self = cyclic;
+
+    let result: unknown;
+    await inspectRun(
+      "mcp-adversarial-cyclic",
+      async () => {
+        result = await client.callTool({ name: "echo", arguments: cyclic });
+      },
+      { traceDir, silent: true },
+    );
+
+    expect(result).toMatchObject({ content: [{ type: "text", text: "ok:echo" }] });
+    const text = await readTraceText();
+    expect(text).toContain('"argumentSummary":"[object Object]"');
+  });
+
+  it("BigInt and undefined arguments are captured as degraded summaries", async () => {
+    const client = fixtureClient();
+    await inspectRun(
+      "mcp-adversarial-bigint",
+      async () => {
+        await client.callTool({ name: "count", arguments: { total: BigInt(9) } });
+        await client.callTool({ name: "blank", arguments: undefined });
+      },
+      { traceDir, silent: true },
+    );
+
+    const text = await readTraceText();
+    expect(text).toContain("mcp:count");
+    expect(text).toContain("mcp:blank");
+    // undefined arguments fall back to the empty-object summary.
+    expect(text).toContain('"argumentSummary":"{}"');
+  });
+
+  it("oversized arguments are bounded before they reach disk", async () => {
+    const client = fixtureClient();
+    const oversized = { blob: "A".repeat(50_000), nested: { pad: "B".repeat(50_000) } };
+
+    await inspectRun(
+      "mcp-adversarial-oversized",
+      async () => {
+        await client.callTool({ name: "upload", arguments: oversized });
+      },
+      { traceDir, silent: true },
+    );
+
+    const text = await readTraceText();
+    const line = text
+      .split(/\r?\n/)
+      .find((row) => row.includes('"toolName":"upload"'));
+    expect(line).toBeDefined();
+    const parsed = JSON.parse(line!) as {
+      metadata?: { argumentSummary?: string };
+    };
+    expect(parsed.metadata?.argumentSummary?.length).toBeLessThanOrEqual(240);
+    expect(text).not.toContain("A".repeat(1000));
+  });
+
+  it("sensitive keys in wrapper metadata are redacted before disk", async () => {
+    const client = wrapMcpClient(
+      {
+        async callTool({ name }: { name: string; arguments?: unknown }) {
+          return { content: [{ type: "text", text: `ok:${name}` }] };
+        },
+      },
+      {
+        serverName: "adversarial-fixture",
+        metadata: {
+          apiKey: "sk_test_fake_adversarial_key",
+          password: "fixture-password-value",
+          channel: "fixture-safe-value",
+        },
+      },
+    );
+
+    await inspectRun(
+      "mcp-adversarial-redaction",
+      async () => {
+        await client.callTool({ name: "echo", arguments: { message: "hi" } });
+      },
+      { traceDir, silent: true },
+    );
+
+    const text = await readTraceText();
+    expect(text).not.toContain("sk_test_fake_adversarial_key");
+    expect(text).not.toContain("fixture-password-value");
+    expect(text).toContain("fixture-safe-value");
+  });
+
+  it("non-ASCII tool names and arguments survive capture as UTF-8", async () => {
+    const client = fixtureClient();
+    await inspectRun(
+      "mcp-adversarial-unicode",
+      async () => {
+        await client.callTool({
+          name: "翻訳-🌐",
+          arguments: { 質問: "¿dónde está la estación?" },
+        });
+      },
+      { traceDir, silent: true },
+    );
+
+    const text = await readTraceText();
+    expect(text).toContain("mcp:翻訳-🌐");
+    expect(text).toContain("dónde");
+  });
+});


### PR DESCRIPTION
## Summary

Extends MCP privacy/adversarial coverage from #110 with 12 new synthetic test cases, plus one small, explicitly flagged hardening fix the tests uncovered.

### Adversarial coverage (`packages/mcp/test/adversarial.test.ts`)

| Case from the issue | Coverage |
| ------------------- | -------- |
| non-ASCII / byte-bound values | emoji and CJK payloads bounded to the summary length; degenerate `maxLength` values (0, 1, 3) produce `...` without negative slices; non-ASCII tool names and arguments round-trip as UTF-8 in the persisted trace |
| cyclic values | unit degrade to `[object Object]`, plus end-to-end through `wrapMcpClient`: the tool call still returns and the persisted `argumentSummary` is the degraded form, nothing thrown into user code |
| BigInt | unit degrade via `String` fallback and end-to-end capture |
| serialization failure handling | throwing `toJSON` degrades; a value whose `String` conversion also throws degrades to `[unserializable]` |
| oversized metadata | 100 KB arguments bounded to the 240-char summary before disk; raw payload never appears in the trace file |
| redaction boundary cases | `apiKey` / `password` values in wrapper metadata are redacted before disk while a safe sibling key survives |

All values are synthetic; no real traffic, tokens, or secrets (fixture strings use the sanctioned `sk_test_fake` shape).

### Behavioral change, flagged for maintainer review per the issue

`summarizeMcpValue` crashed with `TypeError: Cannot read properties of undefined (reading 'length')` for inputs where `JSON.stringify` returns `undefined` rather than throwing (`undefined`, functions, symbols): the undefined result fell through to `text.length`. Since the helper is exported and also runs inside instrumentation, this was a brittle-crash path of exactly the kind the issue describes. The fix falls back to `String(value)` (and to a literal `[unserializable]` if `String` itself throws). Verified both directions: with the fix all 14 package tests pass; without it, two of the new tests fail with the TypeError. Redaction behavior, size limits, and existing summaries are byte-identical.

Closes #110

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture (test fixtures)
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/mcp` (summarizer hardening + adversarial tests)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/mcp/test  # 14/14 pass (2 existing + 12 new)
git diff --check  # clean
```

Counter-verification: with the summarizer fix stashed, the undefined/function/symbol cases fail with the pre-existing TypeError, proving the crash was real and is now covered.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, no documented behavior change
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
