### PR TITLE
test: add index-sqlite clean-consumer pack smoke

### DIFF
--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -473,6 +473,122 @@ const optionalPackageChecks = [
       void runner.listTargets();
     `,
   },
+  {
+    dir: "packages/index-sqlite",
+    name: "@agent-inspect/index-sqlite",
+    peerDependencies: {},
+    installPeers: [],
+    // better-sqlite3 needs its install script to fetch/build the native
+    // binding; the global install stays --ignore-scripts and only this dep
+    // is rebuilt afterward.
+    rebuildNativeDeps: ["better-sqlite3"],
+    esm: `
+      import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+      import os from "node:os";
+      import path from "node:path";
+      import {
+        buildIndex,
+        cleanIndex,
+        indexStatus,
+        queryRuns,
+        resolveIndexDbPath,
+        INDEX_DB_FILENAME,
+      } from "@agent-inspect/index-sqlite";
+
+      const traceDir = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-sqlite-smoke-"));
+      try {
+        writeFileSync(
+          path.join(traceDir, "smoke-run.jsonl"),
+          [
+            '{"schemaVersion":"0.1","event":"run_started","timestamp":1700000000000,"runId":"smoke-run","name":"smoke-run","startTime":1700000000000}',
+            '{"schemaVersion":"0.1","event":"step_started","timestamp":1700000000010,"runId":"smoke-run","stepId":"s1","name":"tool:probe","type":"tool","startTime":1700000000010}',
+            '{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000000060,"runId":"smoke-run","stepId":"s1","status":"success","endTime":1700000000060,"durationMs":50}',
+            '{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000000100,"runId":"smoke-run","status":"success","endTime":1700000000100,"durationMs":100}',
+          ].join("\\n") + "\\n",
+        );
+
+        const built = await buildIndex({ traceDir });
+        if (built.runs !== 1 || built.steps < 1) throw new Error("buildIndex counts wrong");
+        const dbPath = resolveIndexDbPath(traceDir);
+        if (!dbPath.endsWith(INDEX_DB_FILENAME)) throw new Error("db path wrong");
+        const status = indexStatus(dbPath);
+        if (!status.exists || !status.healthy || status.runs !== 1) throw new Error("status wrong");
+        const runs = queryRuns(dbPath, { status: "success" });
+        if (runs.length !== 1 || runs[0].runId !== "smoke-run") throw new Error("query wrong");
+        await cleanIndex(dbPath);
+        if (existsSync(dbPath)) throw new Error("cleanIndex left db behind");
+      } finally {
+        rmSync(traceDir, { recursive: true, force: true });
+      }
+    `,
+    cjs: `
+      const { mkdtempSync, writeFileSync, existsSync, rmSync } = require("node:fs");
+      const os = require("node:os");
+      const path = require("node:path");
+      const {
+        buildIndex,
+        cleanIndex,
+        indexStatus,
+        queryRuns,
+        resolveIndexDbPath,
+        INDEX_DB_FILENAME,
+      } = require("@agent-inspect/index-sqlite");
+
+      (async () => {
+        const traceDir = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-sqlite-smoke-cjs-"));
+        try {
+          writeFileSync(
+            path.join(traceDir, "smoke-run.jsonl"),
+            [
+              '{"schemaVersion":"0.1","event":"run_started","timestamp":1700000000000,"runId":"smoke-run","name":"smoke-run","startTime":1700000000000}',
+              '{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000000100,"runId":"smoke-run","status":"success","endTime":1700000000100,"durationMs":100}',
+            ].join("\\n") + "\\n",
+          );
+
+          const built = await buildIndex({ traceDir });
+          if (built.runs !== 1) throw new Error("buildIndex counts wrong");
+          const dbPath = resolveIndexDbPath(traceDir);
+          const runs = queryRuns(dbPath, { name: "smoke" });
+          if (runs.length !== 1) throw new Error("query wrong");
+          if (!indexStatus(dbPath).healthy) throw new Error("status wrong");
+          await cleanIndex(dbPath);
+          if (existsSync(dbPath)) throw new Error("cleanIndex left db behind");
+        } finally {
+          rmSync(traceDir, { recursive: true, force: true });
+        }
+      })().catch((error) => {
+        console.error(error);
+        process.exit(1);
+      });
+    `,
+    ts: `
+      import {
+        buildIndex,
+        queryRuns,
+        indexStatus,
+        isIndexStale,
+        INDEX_SCHEMA_VERSION,
+        type BuildIndexOptions,
+        type BuildIndexResult,
+        type IndexedRun,
+        type IndexStatus,
+        type RunQuery,
+      } from "@agent-inspect/index-sqlite";
+
+      const options: BuildIndexOptions = { traceDir: ".agent-inspect", maxRuns: 10 };
+      const result: Promise<BuildIndexResult> = buildIndex(options);
+      void result;
+      const query: RunQuery = { status: "success", tool: "probe", limit: 5 };
+      const runs: IndexedRun[] = queryRuns("trace-index.sqlite", query);
+      void runs;
+      const status: IndexStatus = indexStatus("trace-index.sqlite");
+      void status;
+      const stale: boolean = isIndexStale("trace-index.sqlite", 0);
+      void stale;
+      const version: "1" = INDEX_SCHEMA_VERSION;
+      void version;
+    `,
+  },
 ];
 
 function assertHelp(label, stdout, stderr, status) {
@@ -535,8 +651,20 @@ function fail(label, detail) {
   process.exit(1);
 }
 
+// npm/pnpm and .bin entries are cmd shims on Windows and can only be spawned
+// through a shell; real executables (node.exe) spawn directly so paths with
+// spaces stay intact. Whitespace-bearing args are quoted for shell mode.
+function spawnCli(cmd, args, opts = {}) {
+  const useShell =
+    process.platform === "win32" && !cmd.toLowerCase().endsWith(".exe");
+  const safeArgs = useShell
+    ? args.map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
+    : args;
+  return spawnSync(cmd, safeArgs, { encoding: "utf8", shell: useShell, ...opts });
+}
+
 function run(label, cmd, args, opts = {}) {
-  const result = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  const result = spawnCli(cmd, args, opts);
   if (result.status !== 0) {
     fail(label, `${result.stdout || ""}\n${result.stderr || ""}`.trim());
   }
@@ -730,6 +858,14 @@ function smokeOptionalPackages(rootTgzPath, tmpRoot) {
       ...bundledTarballs,
       ...check.installPeers,
     ]);
+    for (const nativeDep of check.rebuildNativeDeps ?? []) {
+      // The clean install runs with --ignore-scripts; native deps that need
+      // their install script (prebuild download/build) are rebuilt one by one.
+      run(`${check.name} rebuild ${nativeDep}`, "npm", ["rebuild", nativeDep], {
+        cwd: installDir,
+        stdio: "inherit",
+      });
+    }
     runOptionalConsumer(check, installDir);
     smoked.push(check.name);
   }
@@ -745,9 +881,8 @@ function smokeOptionalPackages(rootTgzPath, tmpRoot) {
 
 // Force non-JSON output so we can reliably read the .tgz filename even when
 // the environment sets npm_config_json=true (common in CI/release tooling).
-const packProc = spawnSync("npm", ["pack", "--silent", "--ignore-scripts"], {
+const packProc = spawnCli("npm", ["pack", "--silent", "--ignore-scripts"], {
   cwd: root,
-  encoding: "utf8",
   env: {
     ...process.env,
     npm_config_json: "false",
@@ -824,23 +959,21 @@ try {
     process.exit(1);
   }
 
-  const binVersion = spawnSync(binPath, ["--version"], {
+  const binVersion = spawnCli(binPath, ["--version"], {
     cwd: tmpRoot,
-    encoding: "utf8",
   });
   if (
     binVersion.status !== 0 ||
-    binVersion.stdout.trim() !== expectedVersion
+    (binVersion.stdout ?? "").trim() !== expectedVersion
   ) {
     console.error(
-      `[pack:smoke] CLI version mismatch: expected ${expectedVersion}, got ${binVersion.stdout.trim() || "<empty>"}\n${binVersion.stderr}`,
+      `[pack:smoke] CLI version mismatch: expected ${expectedVersion}, got ${(binVersion.stdout ?? "").trim() || "<empty>"}\n${binVersion.stderr ?? ""}`,
     );
     process.exit(1);
   }
 
-  const binHelp = spawnSync(binPath, ["--help"], {
+  const binHelp = spawnCli(binPath, ["--help"], {
     cwd: tmpRoot,
-    encoding: "utf8",
   });
   assertHelp("./node_modules/.bin/agent-inspect --help", binHelp.stdout, binHelp.stderr, binHelp.status);
 


### PR DESCRIPTION
## Summary

Adds clean-consumer pack smoke for `@agent-inspect/index-sqlite` from #106. Audit first: every other public optional package already has an entry in `scripts/package-smoke.mjs` (16 of 17); `index-sqlite` was the gap.

### The new entry

- Packs `packages/index-sqlite`, installs the tarball into a clean fixture next to the root tarball, and verifies **ESM import**, **CJS require**, and **TypeScript declarations** (NodeNext strict, noEmit)
- Minimal documented usage runs offline end to end in both module systems: write a synthetic v0.1 trace, `buildIndex`, `resolveIndexDbPath` + `INDEX_DB_FILENAME`, `indexStatus` health checks, `queryRuns` with filters, and `cleanIndex` leaving no database behind; the types snippet pins `BuildIndexOptions`, `BuildIndexResult`, `IndexedRun`, `IndexStatus`, `RunQuery`, and `INDEX_SCHEMA_VERSION`
- **Native dependency handling**: the global clean install intentionally stays `--ignore-scripts`. A new per-check `rebuildNativeDeps` hook then runs `npm rebuild better-sqlite3` in the fixture, so only that one dependency's install script (prebuild download) executes; script execution is not widened for anything else

### Windows portability fixes in the same harness

The smoke script previously could not run on Windows at all (it died parsing the very first `npm pack` because `.cmd` shims cannot be spawned without a shell). Since #106 needs the harness runnable to be verified, the spawn layer is fixed in the same PR: a `spawnCli` helper shells npm/pnpm/`.bin` shims on win32 with whitespace-safe arg quoting, while real executables (`node.exe`) spawn directly so paths with spaces survive. POSIX behavior is unchanged (shell mode is win32-gated), so CI runs exactly what it ran before.

Verified on Windows 11: `node scripts/package-smoke.mjs` completes with

```text
[pack:smoke] optional packages OK: ... @agent-inspect/harness, @agent-inspect/index-sqlite
[pack:smoke] OK: tarball install, ESM import, CJS require, CLI 6.7.2, optional package installs, ...
```

Note: the `pack:smoke` npm script chains `scripts/packed-quickstart-e2e.mjs` afterwards, which fails on Windows for pre-existing, unrelated reasons (root `clean` uses `rm -rf`, the script shells `ls -1`, and it spawns the `.bin` shim without a shell). A focused follow-up PR fixes that script separately to keep this one on the #106 concern.

Closes #106

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture (smoke fixture + harness support)
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added (npm registry fetches during install only, same as existing checks)
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Release tooling only (`scripts/package-smoke.mjs`); `packages/index-sqlite` untouched

## Validation

```bash
pnpm build                        # pass
node scripts/package-smoke.mjs   # pass on Windows 11: all 17 optional packages OK incl. index-sqlite
git diff --check                  # clean
```

The index-sqlite fixture exercised the real native path locally: `npm rebuild better-sqlite3` fetched the prebuilt binding on Node 24/win32, and the ESM/CJS snippets built, queried, and cleaned a real SQLite index in the fixture directory.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, tooling only
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
