### PR TITLE
fix: make quickstart E2E and readme snippet test cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "commander": "^12.1.0"
   },
   "scripts": {
-    "clean": "pnpm -r exec -- rm -rf dist",
+    "clean": "pnpm -r exec -- node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm exec tsup --config tsup.core.config.ts && pnpm exec tsup --config tsup.cli.config.ts && pnpm exec tsup --config tsup.langchain.config.ts && pnpm exec tsup --config tsup.tui.config.ts && pnpm exec tsup --config tsup.ai-sdk.config.ts && pnpm exec tsup --config tsup.vitest.config.ts && pnpm exec tsup --config tsup.jest.config.ts && pnpm exec tsup --config tsup.openai-agents.config.ts && pnpm exec tsup --config tsup.harness.config.ts && pnpm exec tsup --config tsup.redact.config.ts && pnpm exec tsup --config tsup.eval.config.ts && pnpm exec tsup --config tsup.mcp.config.ts && pnpm exec tsup --config tsup.guardrails.config.ts && pnpm exec tsup --config tsup.circuit.config.ts && pnpm exec tsup --config tsup.viewer.config.ts && pnpm exec tsup --config tsup.mcp-server.config.ts && pnpm exec tsup --config tsup.adapter-sdk.config.ts && pnpm exec tsup --config tsup.vscode.config.ts && pnpm exec tsup --config tsup.index-sqlite.config.ts && pnpm exec tsup --config tsup.studio.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/redact/test/readme.test.ts
+++ b/packages/redact/test/readme.test.ts
@@ -11,7 +11,8 @@ const packageRoot = path.resolve(
 
 function readExampleSnippet(): string {
   const readme = readFileSync(path.join(packageRoot, "README.md"), "utf8");
-  const example = readme.match(/## Example\s+```ts\n([\s\S]*?)\n```/);
+  // \r? keeps the match working on CRLF checkouts (git autocrlf on Windows).
+  const example = readme.match(/## Example\s+```ts\r?\n([\s\S]*?)\r?\n```/);
 
   if (!example?.[1]) {
     throw new Error("README Example must contain a TypeScript code block");

--- a/scripts/packed-quickstart-e2e.mjs
+++ b/scripts/packed-quickstart-e2e.mjs
@@ -6,6 +6,7 @@ import { execSync, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -25,18 +26,32 @@ function fail(message, detail = "") {
   process.exit(1);
 }
 
+// .bin entries are cmd shims on Windows and can only be spawned through a
+// shell; POSIX behavior is unchanged.
+function spawnBin(bin, args, opts = {}) {
+  return spawnSync(bin, args, {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+    ...opts,
+  });
+}
+
 const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-quickstart-"));
 try {
   execSync("pnpm pack --pack-destination " + JSON.stringify(tmpRoot), {
     cwd: root,
     stdio: "pipe",
   });
-  const tgz = execSync("ls -1 *.tgz", { cwd: tmpRoot, encoding: "utf8" })
-    .trim()
-    .split("\n")[0];
+  const tgz = readdirSync(tmpRoot).find((file) => file.endsWith(".tgz"));
   if (!tgz) fail("no tarball produced");
   const installDir = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-quickstart-install-"));
-  execSync(`npm install ${path.join(tmpRoot, tgz)}`, {
+  // npm only links .bin shims for a real consumer project; without a
+  // package.json newer npm versions install the tarball but skip the bins.
+  writeFileSync(
+    path.join(installDir, "package.json"),
+    `${JSON.stringify({ name: "agent-inspect-quickstart-smoke", private: true, type: "module" }, null, 2)}\n`,
+  );
+  execSync(`npm install ${JSON.stringify(path.join(tmpRoot, tgz))}`, {
     cwd: installDir,
     stdio: "pipe",
   });
@@ -44,7 +59,7 @@ try {
   const bin = path.join(installDir, "node_modules", ".bin", "agent-inspect");
   if (!existsSync(bin)) fail("CLI binary missing after install");
 
-  const init = spawnSync(bin, ["init", "--yes"], { cwd: installDir, encoding: "utf8" });
+  const init = spawnBin(bin, ["init", "--yes"], { cwd: installDir });
   if (init.status !== 0) {
     fail("agent-inspect init --yes failed", init.stderr || init.stdout);
   }
@@ -53,7 +68,7 @@ try {
   if (!existsSync(demoPath)) fail("demo script missing after init");
   execSync(`node ${JSON.stringify(demoPath)}`, { cwd: installDir, stdio: "pipe" });
 
-  const list = spawnSync(bin, ["list", "--dir", ".agent-inspect", "--json"], {
+  const list = spawnBin(bin, ["list", "--dir", ".agent-inspect", "--json"], {
     cwd: installDir,
     encoding: "utf8",
   });
@@ -62,13 +77,13 @@ try {
   const runId = Array.isArray(runs) && runs[0]?.runId ? runs[0].runId : runs.runs?.[0]?.runId;
   if (!runId) fail("no run id from list", list.stdout);
 
-  const verify = spawnSync(bin, ["verify-safe", runId, "--dir", ".agent-inspect", "--json"], {
+  const verify = spawnBin(bin, ["verify-safe", runId, "--dir", ".agent-inspect", "--json"], {
     cwd: installDir,
     encoding: "utf8",
   });
   if (verify.status !== 0) fail("verify-safe failed", verify.stderr || verify.stdout);
 
-  const version = spawnSync(bin, ["--version"], { cwd: installDir, encoding: "utf8" });
+  const version = spawnBin(bin, ["--version"], { cwd: installDir });
   if (version.stdout.trim() !== expectedVersion) {
     fail(`version mismatch: expected ${expectedVersion}, got ${version.stdout.trim()}`);
   }


### PR DESCRIPTION
## Summary

Windows portability follow-up to #104, covering the release tooling that the earlier sweep did not reach. Three independent-root-cause fixes, one theme:

1. **Root `clean` script**: used `rm -rf`, which does not exist in cmd.exe, so any `pnpm pack` of the root package broke on Windows (prepack runs `clean && build`). Replaced with a `node -e "fs.rmSync(...)"` one-liner; byte-identical effect on POSIX.
2. **`scripts/packed-quickstart-e2e.mjs`**:
   - `ls -1 *.tgz` replaced with `readdirSync().find(...)` (no POSIX shell tools)
   - the installed `.bin` shim is spawned through a shell on win32 only (cmd shims cannot be spawned directly), matching the pattern from #123
   - a consumer `package.json` is written into the install directory before `npm install <tarball>`: newer npm versions (npm 11 / Node 24) skip `.bin` links entirely when the target directory is not a project, so the E2E failed with "CLI binary missing" even with a valid tarball. This also hardens the check for future npm on POSIX. Verified empirically: bare dir + tarball produces no `.bin` on npm 11, adding the manifest produces all three shims
3. **`packages/redact/test/readme.test.ts`**: the README example regex required LF immediately after the ` ```ts ` fence, so the test failed on CRLF checkouts (`git autocrlf`, the Windows default). Allow `\r?\n` on both fence boundaries.

With these plus the merged #116 and the fixes in #123, the repo is fully green on Windows for the first time:

```text
node scripts/packed-quickstart-e2e.mjs
[quickstart-e2e] OK: init → demo → list → verify-safe (6.7.2)

pnpm test
Tests  1416 passed (1416)
```

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root runtime; only the `clean` script line in package.json changed, no dependency or version changes)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Release tooling (`scripts/packed-quickstart-e2e.mjs`) + `@agent-inspect/redact` (test only)

## Validation

```bash
pnpm typecheck                          # pass
node scripts/packed-quickstart-e2e.mjs # OK on Windows 11 (was: 'rm' is not recognized, then CLI binary missing)
pnpm exec vitest run packages/redact/test/readme.test.ts  # pass on a CRLF checkout
pnpm test                               # 1416/1416 pass locally
git diff --check                        # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed) - the fixed readme test is itself the regression coverage; E2E script is self-verifying
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
