### PR TITLE
docs: fail active docs that link into archived guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 - [docs/community/FIRST-PR-WALKTHROUGH.md](docs/community/FIRST-PR-WALKTHROUGH.md) — fork, branch, validation, and PR flow
 - [ROADMAP.md](ROADMAP.md) — Now / Next / Future
 - [docs/community/GOOD-FIRST-ISSUES.md](docs/community/GOOD-FIRST-ISSUES.md) — expanded list with issue draft links
-- Draft issues in [.github/ISSUE_DRAFTS/](.github/ISSUE_DRAFTS/) — copy into GitHub Issues when ready
+- [Live issues](https://github.com/rajudandigam/agent-inspect/issues) — pick `status:ready`, `community-owned` work
 
 ## Code of conduct
 

--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -23,7 +23,7 @@ agent-inspect/
 ## Workflow
 
 1. Fork and branch from `main`.
-2. Pick an issue from [GOOD-FIRST-ISSUES.md](../../GOOD-FIRST-ISSUES.md) or [.github/ISSUE_DRAFTS/](../../.github/ISSUE_DRAFTS/).
+2. Pick an issue from [GOOD-FIRST-ISSUES.md](../../GOOD-FIRST-ISSUES.md) or the [live issue list](https://github.com/rajudandigam/agent-inspect/issues).
 3. Comment before starting **maintainer-owned** work.
 4. Keep PRs focused; match existing code style.
 5. Run validation (see root CONTRIBUTING.md).

--- a/packages/core/test/docs/archived-link-rule.test.ts
+++ b/packages/core/test/docs/archived-link-rule.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+// Pure rule module shared with scripts/validate-doc-links.mjs; imported via a
+// computed specifier because the scripts tree is not part of the TS project.
+const rulePath = new URL(
+  "../../../../scripts/lib/archived-link-rule.mjs",
+  import.meta.url,
+).href;
+
+type Violation = { source: string; href: string; target: string };
+type RuleModule = {
+  findArchivedLinkViolations: (
+    entries: Array<{ source: string; text: string }>,
+  ) => Violation[];
+  ALLOWED_HISTORICAL_LINKS: Array<{ source: string; targetPrefix: string }>;
+};
+
+async function loadRule(): Promise<RuleModule> {
+  return (await import(rulePath)) as RuleModule;
+}
+
+describe("archived-link rule", () => {
+  it("fails on a synthetic archived link from an active doc", async () => {
+    const { findArchivedLinkViolations } = await loadRule();
+    const violations = findArchivedLinkViolations([
+      {
+        source: "docs/GUIDE.md",
+        text: "See the [old roadmap](./archive/implementation/OLD.md) for details.",
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      source: "docs/GUIDE.md",
+      target: "docs/archive/implementation/OLD.md",
+    });
+  });
+
+  it("resolves relative traversal from nested sources", async () => {
+    const { findArchivedLinkViolations } = await loadRule();
+    const violations = findArchivedLinkViolations([
+      {
+        source: "docs/community/DEEP.md",
+        text: "[drafts](../../.github/ISSUE_DRAFTS/001.md)",
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.target).toBe(".github/ISSUE_DRAFTS/001.md");
+  });
+
+  it("passes allowlisted historical citations", async () => {
+    const { findArchivedLinkViolations } = await loadRule();
+    const violations = findArchivedLinkViolations([
+      {
+        source: "GOOD-FIRST-ISSUES.md",
+        text: "Historical issue drafts: [archive](docs/archive/github/)",
+      },
+      {
+        source: "docs/HARNESS.md",
+        text: "Full historical doc: [archived](./archive/public/HARNESS.md)",
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does not allowlist the same target from other sources", async () => {
+    const { findArchivedLinkViolations } = await loadRule();
+    const violations = findArchivedLinkViolations([
+      {
+        source: "docs/GETTING-STARTED.md",
+        text: "[archived harness](./archive/public/HARNESS.md)",
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+  });
+
+  it("ignores external, anchor, and normal relative links", async () => {
+    const { findArchivedLinkViolations } = await loadRule();
+    const violations = findArchivedLinkViolations([
+      {
+        source: "docs/GUIDE.md",
+        text: [
+          "[site](https://example.test/docs/archive/x)",
+          "[mail](mailto:person@example.test)",
+          "[anchor](#archive)",
+          "[sibling](./API.md)",
+          "[fragment of archived](./API.md#docs-archive)",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/scripts/lib/archived-link-rule.mjs
+++ b/scripts/lib/archived-link-rule.mjs
@@ -1,0 +1,72 @@
+/**
+ * Archived-link rule: active public docs must not link into archived or
+ * internal-only guidance. Pure module so the doc-link checker and unit tests
+ * share one implementation.
+ */
+import path from "node:path";
+
+/** Repo-relative prefixes active public docs must not link into. */
+export const DISALLOWED_LINK_PREFIXES = [
+  "docs/archive/",
+  ".github/ISSUE_DRAFTS/",
+  "docs-local/",
+];
+
+/**
+ * Explicitly sanctioned historical citations: sources that intentionally
+ * catalog archived material and say so in their surrounding prose.
+ */
+export const ALLOWED_HISTORICAL_LINKS = [
+  // Contributor indexes label these pointers as historical drafts.
+  { source: "GOOD-FIRST-ISSUES.md", targetPrefix: "docs/archive/github/" },
+  { source: "GOOD-FIRST-ISSUES.md", targetPrefix: ".github/ISSUE_DRAFTS/" },
+  { source: "ROADMAP.md", targetPrefix: "docs/archive/implementation/" },
+  { source: "docs/community/CONTRIBUTOR-ROLES.md", targetPrefix: "docs/archive/github/" },
+  { source: "docs/community/GOOD-FIRST-ISSUES.md", targetPrefix: "docs/archive/github/" },
+  // Stub docs that explicitly say "(archived)" and redirect to the full
+  // historical version.
+  { source: "docs/COMMUNITY-EXTENSION-REGISTRY.md", targetPrefix: "docs/archive/public/" },
+  { source: "docs/HARNESS.md", targetPrefix: "docs/archive/public/" },
+  { source: "docs/IDE-SURFACES.md", targetPrefix: "docs/archive/public/" },
+  // The docs index links the archive index as its labeled historical section.
+  { source: "docs/README.md", targetPrefix: "docs/archive/README.md" },
+];
+
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+function normalizeRepoRelative(sourceRel, href) {
+  const target = path.posix.normalize(
+    path.posix.join(path.posix.dirname(sourceRel.replaceAll("\\", "/")), href),
+  );
+  return target.replaceAll("\\", "/");
+}
+
+/**
+ * Find links from active public docs into disallowed prefixes.
+ * @param {Array<{ source: string, text: string }>} entries repo-relative
+ *   markdown sources with their content
+ * @returns {Array<{ source: string, href: string, target: string }>}
+ */
+export function findArchivedLinkViolations(entries) {
+  const violations = [];
+  for (const { source, text } of entries) {
+    const sourceRel = source.replaceAll("\\", "/");
+    LINK_RE.lastIndex = 0;
+    let match;
+    while ((match = LINK_RE.exec(text))) {
+      const href = match[2].split("#")[0].split("?")[0].trim();
+      if (!href || /^[a-z]+:/i.test(href) || href.startsWith("/")) continue;
+      const target = normalizeRepoRelative(sourceRel, href);
+      const disallowed = DISALLOWED_LINK_PREFIXES.find((prefix) =>
+        target.startsWith(prefix),
+      );
+      if (!disallowed) continue;
+      const allowlisted = ALLOWED_HISTORICAL_LINKS.some(
+        (entry) => entry.source === sourceRel && target.startsWith(entry.targetPrefix),
+      );
+      if (allowlisted) continue;
+      violations.push({ source: sourceRel, href, target });
+    }
+  }
+  return violations;
+}

--- a/scripts/validate-doc-links.mjs
+++ b/scripts/validate-doc-links.mjs
@@ -1,10 +1,13 @@
 /**
- * Check relative markdown links in key public docs resolve on disk.
+ * Check relative markdown links in key public docs resolve on disk, and that
+ * active public docs do not link into archived or internal-only guidance.
  * Run: node scripts/validate-doc-links.mjs
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { findArchivedLinkViolations } from "./lib/archived-link-rule.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -54,9 +57,46 @@ for (const doc of relDocLinks) {
   }
 }
 
+// Active public docs must not link into archived/internal-only guidance.
+// Scope: root contributor entry points plus every markdown doc outside
+// docs/archive (implementation/proposal notes cite history on purpose and
+// stay exempt).
+function collectActivePublicDocs() {
+  const entries = [];
+  const rootDocs = ["README.md", "CONTRIBUTING.md", "GOOD-FIRST-ISSUES.md", "ROADMAP.md"];
+  for (const rel of rootDocs) {
+    const abs = path.join(root, rel);
+    if (existsSync(abs)) entries.push({ source: rel, text: readFileSync(abs, "utf8") });
+  }
+  const skipPrefixes = ["docs/archive/", "docs/implementation/", "docs/proposals/"];
+  const walk = (dirRel) => {
+    for (const ent of readdirSync(path.join(root, dirRel), { withFileTypes: true })) {
+      const rel = `${dirRel}/${ent.name}`;
+      if (skipPrefixes.some((prefix) => rel.startsWith(prefix) || `${rel}/`.startsWith(prefix))) {
+        continue;
+      }
+      if (ent.isDirectory()) walk(rel);
+      else if (ent.name.endsWith(".md")) {
+        entries.push({ source: rel, text: readFileSync(path.join(root, rel), "utf8") });
+      }
+    }
+  };
+  walk("docs");
+  return entries;
+}
+
+const activeDocs = collectActivePublicDocs();
+for (const violation of findArchivedLinkViolations(activeDocs)) {
+  failures.push(
+    `${violation.source}: links into archived/internal path ${violation.target} (${violation.href})`,
+  );
+}
+
 if (failures.length > 0) {
   console.error("[docs:links] failures:\n" + failures.map((f) => `  - ${f}`).join("\n"));
   process.exit(1);
 }
 
-console.log(`[docs:links] OK (${files.length} docs + README packed-files check)`);
+console.log(
+  `[docs:links] OK (${files.length} docs + README packed-files check + archived-link rule over ${activeDocs.length} active docs)`,
+);


### PR DESCRIPTION
## Summary

Adds archived-link regression checks to `docs:links` from #102, extending the existing checker rather than adding a parallel one.

### The rule

`scripts/lib/archived-link-rule.mjs` (shared by the checker and unit tests): every markdown doc outside `docs/archive/` plus the root contributor entry points (README, CONTRIBUTING, GOOD-FIRST-ISSUES, ROADMAP) must not link into `docs/archive/`, `.github/ISSUE_DRAFTS/`, or `docs-local/`. A source-scoped allowlist covers sanctioned historical citations, each justified in a comment:

- contributor indexes whose prose labels the pointers as historical drafts (`GOOD-FIRST-ISSUES.md`, `ROADMAP.md`, `docs/community/*`)
- the three "(archived)" stub docs that exist to redirect to their full archived versions
- the docs index's labeled archive section

`docs/implementation/**` and `docs/proposals/**` stay out of scope: they cite history on purpose. Checks are filesystem-local only; no network crawling.

### Violations found and fixed in this PR

Running the new rule over the repo found two active docs steering contributors at raw draft markdown, exactly the stale-truth pattern the issue describes:

- `CONTRIBUTING.md` "Where to start" linked `.github/ISSUE_DRAFTS/` ("copy into GitHub Issues when ready"); now points at the live issue list filtered to `status:ready` / `community-owned`
- `docs/community/CONTRIBUTING.md` workflow step 2 linked the drafts folder; now points at the live issue list

### Tests

`packages/core/test/docs/archived-link-rule.test.ts` (5 cases): fails on a synthetic archived link, resolves nested relative traversal (`../../.github/...`), passes allowlisted citations, refuses to extend an allowlist entry to other sources, and ignores external / mailto / anchor / ordinary relative links.

Closes #102

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only (docs tooling + two doc link fixes)
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core` (rule unit test only)
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community + docs tooling (`scripts/`)

## Validation

```bash
node scripts/validate-doc-links.mjs
# [docs:links] OK (8 docs + README packed-files check + archived-link rule over 85 active docs)
pnpm docs:check   # all three checkers pass
pnpm exec vitest run packages/core/test/docs/archived-link-rule.test.ts  # 5/5 pass
pnpm typecheck    # pass
git diff --check  # clean
```

Counter-verified: before the two doc fixes and the allowlist, the rule correctly failed with six findings (the four sanctioned citations plus the two real violations), so the check demonstrably catches regressions.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
