### PR TITLE
docs: modernize the PR template for the current package map

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,56 +1,74 @@
 ## Summary
 
-<!-- What does this PR change and why? Link issue: # -->
+<!-- What does this PR change and why? -->
+
+**Linked issue (required):** #
 
 ## Type of change
 
 - [ ] Bug fix (non-breaking)
 - [ ] Documentation only
 - [ ] Example / recipe / fixture
+- [ ] Test / regression coverage
 - [ ] Feature or enhancement (scoped)
 - [ ] Breaking change (requires major version plan — maintainer approval required)
+
+## Reproduction / evidence
+
+<!-- For bug fixes: how the bug reproduces and how this PR was verified against it.
+     For tests/fixtures: what regression the coverage locks in. -->
 
 ## Product boundaries (check all that apply)
 
 - [ ] Local-first only — no network upload added
 - [ ] No new vendor sinks
 - [ ] No SaaS / dashboard scope added
-- [ ] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
+- [ ] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
 - [ ] No `step_failed` event introduced
-- [ ] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)
+- [ ] `inspectRun` default tracing behavior unchanged
+- [ ] Redaction, size bounds, and privacy defaults not weakened
 
 ## Packages touched
 
-- [ ] `agent-inspect` (root)
-- [ ] `@agent-inspect/core`
-- [ ] `@agent-inspect/cli`
-- [ ] `@agent-inspect/langchain`
-- [ ] `@agent-inspect/tui`
-- [ ] Docs / community only
+- [ ] `agent-inspect` (root: core + CLI, published)
+- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
+- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
+- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
+- [ ] Private workspace internals (`packages/core`, `packages/cli` — ships via root `agent-inspect`)
+- [ ] Docs / fixtures / recipes / community only
 
 ## Validation
 
-<!-- Paste commands run and results -->
+<!-- Paste the commands you ran and their results -->
 
 ```bash
-# Docs-only minimum:
 pnpm typecheck
 pnpm test
-
-# Runtime / export changes:
-pnpm test:all
+# focused suites while iterating:
+pnpm exec vitest run <relevant-test-files>
+# docs changes:
+pnpm docs:check
+# fixtures / recipes:
+pnpm fixtures:check
+pnpm recipes:check
+# package/export surface changes:
 pnpm pack:smoke
-# npm pack --dry-run  # if package files/exports changed
 ```
 
-## Screenshots / sample output
+## Data safety
 
-<!-- CLI output, trace snippets, or doc previews if relevant -->
+- [ ] Synthetic data only — no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
+- [ ] Trace/log samples in the PR were redacted or generated from fixtures
+
+## Release hygiene
+
+- [ ] No version bumps and **no Changesets** — maintainers own Changesets and releases
+- [ ] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
+- [ ] No publish, tag, or workflow changes
 
 ## Checklist
 
-- [ ] Tests added or updated (if behavior changed)
-- [ ] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
-- [ ] No new runtime dependencies without approval
-- [ ] No version bump in this PR (Changesets used for releases)
-- [ ] No secrets, production logs, or real PII in commits
+- [ ] Linked issue explains the why (comment on the issue before large PRs)
+- [ ] Tests added or updated for behavior changes
+- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
+- [ ] `git diff --check` clean


### PR DESCRIPTION
## Summary

Modernizes `.github/PULL_REQUEST_TEMPLATE.md` from #98. The old template reflected the pre-v4 five-package world and did not prompt for linked issues, reproductions, or data-safety confirmation.

What changed, mapped to the issue's scope:

- **Package areas**: checklist now matches the 6.7.2 family: root `agent-inspect`, framework adapters (`ai-sdk`/`openai-agents`/`langchain`/`mcp`/`adapter-sdk`), test reporters and gates (`vitest`/`jest`/`eval`/`guardrails`/`circuit`/`harness`), inspection surfaces (`viewer`/`tui`/`studio`/`mcp-server`/`index-sqlite`/`redact`), with private workspace internals (`packages/core`, `packages/cli`) called out as shipping via the root package
- **Linked-issue requirement**: a required `Linked issue:` field at the top of the summary
- **Reproduction requirement**: a dedicated evidence section for bug fixes and regression tests
- **Synthetic-data requirement**: a data-safety section requiring synthetic data only, naming the sanctioned fixture token shapes (`sk_test_fake`, `Bearer fake-token`)
- **Privacy/schema awareness**: boundaries extended with schema compatibility across 0.1/0.2/1.0 and a "redaction, size bounds, and privacy defaults not weakened" line
- **Changesets ownership**: an explicit release-hygiene section stating maintainers own Changesets; contributor PRs must not add Changesets or bump versions, and root runtime deps stay `chalk`/`commander`/`nanoid`
- **Current validation commands**: `pnpm typecheck`, `pnpm test`, focused Vitest, `pnpm docs:check` for docs changes, `fixtures:check`/`recipes:check`/`pack:smoke` where relevant

No workflow, branch-protection, or runtime changes. `CONTRIBUTING.md` paths referenced by the template are current (its stale draft-issue pointer is being fixed in #125).

Closes #98

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] Docs / community only (`.github/PULL_REQUEST_TEMPLATE.md`)

## Validation

```bash
pnpm typecheck   # pass
pnpm docs:check  # pass (template is not scanned, run as the docs-change gate)
git diff --check # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed) - not applicable, template only
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
