### PR TITLE
fix(core): emit OpenInference nano timestamps as decimal strings

### DIFF
--- a/packages/core/src/exporters/openinference-exporter.ts
+++ b/packages/core/src/exporters/openinference-exporter.ts
@@ -11,8 +11,9 @@ export interface OpenInferenceSpan {
   span_id: string;
   parent_span_id?: string;
   name: string;
-  start_time_unix_nano: number;
-  end_time_unix_nano?: number;
+  /** Decimal string: epoch-nanosecond values exceed Number.MAX_SAFE_INTEGER. */
+  start_time_unix_nano: string;
+  end_time_unix_nano?: string;
   attributes: Record<string, unknown>;
   status?: {
     code: "OK" | "ERROR" | "UNSET";
@@ -32,6 +33,17 @@ export interface OpenInferenceExport {
 
 function hexFrom(seed: string, byteLen: number): string {
   return crypto.createHash("sha256").update(seed, "utf8").digest("hex").slice(0, byteLen * 2);
+}
+
+/**
+ * Convert epoch milliseconds to exact epoch nanoseconds. Computed in BigInt
+ * because realistic epochs exceed Number.MAX_SAFE_INTEGER once scaled to
+ * nanoseconds (1.7e18 vs 9.0e15), which silently loses precision in doubles.
+ */
+function unixNano(ms: number): bigint {
+  const whole = Math.trunc(ms);
+  const fractionNs = Math.round((ms - whole) * 1e6);
+  return BigInt(whole) * 1_000_000n + BigInt(fractionNs);
 }
 
 function mapInspectKindToOI(
@@ -95,10 +107,10 @@ export function exportOpenInference(
     const parentSpanHex = ev.parentId
       ? hexFrom(`${tree.runId}:${ev.parentId}`, 8)
       : undefined;
-    const startNs = Math.round(ev.timestamp * 1e6);
-    let endNs: number | undefined;
+    const startNs = unixNano(ev.timestamp);
+    let endNs: bigint | undefined;
     if (ev.durationMs !== undefined && Number.isFinite(ev.durationMs)) {
-      endNs = startNs + Math.round(ev.durationMs * 1e6);
+      endNs = startNs + unixNano(ev.durationMs);
     }
 
     const { openInferenceKind } = mapInspectKindToOI(ev.kind, warnings);
@@ -156,8 +168,8 @@ export function exportOpenInference(
       span_id: spanId,
       parent_span_id: parentSpanHex,
       name: ev.name,
-      start_time_unix_nano: startNs,
-      end_time_unix_nano: endNs,
+      start_time_unix_nano: startNs.toString(),
+      end_time_unix_nano: endNs?.toString(),
       attributes: attrs,
       status,
     });

--- a/packages/core/test/exporters/openinference-exporter.test.ts
+++ b/packages/core/test/exporters/openinference-exporter.test.ts
@@ -121,4 +121,76 @@ describe("exportOpenInference", () => {
     };
     expect(parsed.spans[0]!.status?.code).toBe("ERROR");
   });
+
+  it("emits exact nanosecond timestamps as decimal strings for realistic epochs", () => {
+    // 1750000000123 ms * 1e6 = 1.750000000123e18 ns, far beyond
+    // Number.MAX_SAFE_INTEGER; a double round-trip loses up to ~128 ns.
+    const startMs = 1_750_000_000_123;
+    const durationMs = 456;
+    const events: TraceEvent[] = [
+      {
+        schemaVersion: "0.1",
+        event: "run_started",
+        timestamp: startMs,
+        runId: "run_ns",
+        name: "ns",
+        startTime: startMs,
+      },
+      {
+        schemaVersion: "0.1",
+        event: "step_started",
+        timestamp: startMs,
+        runId: "run_ns",
+        stepId: "s",
+        name: "x",
+        type: "logic",
+        startTime: startMs,
+      },
+      {
+        schemaVersion: "0.1",
+        event: "step_completed",
+        timestamp: startMs + durationMs,
+        runId: "run_ns",
+        stepId: "s",
+        status: "success",
+        endTime: startMs + durationMs,
+        durationMs,
+      },
+      {
+        schemaVersion: "0.1",
+        event: "run_completed",
+        timestamp: startMs + durationMs,
+        runId: "run_ns",
+        status: "success",
+        endTime: startMs + durationMs,
+        durationMs,
+      },
+    ];
+    const tree = manualTraceEventsToRunTree(events);
+    const parsed = JSON.parse(exportOpenInference(tree).content) as {
+      spans: { start_time_unix_nano: string; end_time_unix_nano?: string }[];
+    };
+
+    const span = parsed.spans[0]!;
+    expect(span.start_time_unix_nano).toBe("1750000000123000000");
+    expect(span.end_time_unix_nano).toBe("1750000000579000000");
+    // Values of this magnitude exceed Number.MAX_SAFE_INTEGER, so they must
+    // never appear as raw JSON number literals (RFC 8259 interop range).
+    expect(BigInt(span.start_time_unix_nano) > BigInt(Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(exportOpenInference(tree).content).not.toMatch(/_unix_nano":\s*\d/);
+  });
+
+  it("matches the OTLP exporter's string encoding and the committed import fixture", () => {
+    const tree = manualTraceEventsToRunTree(treeWithLlm());
+    const parsed = JSON.parse(exportOpenInference(tree).content) as {
+      spans: { start_time_unix_nano: unknown; end_time_unix_nano?: unknown }[];
+    };
+    for (const span of parsed.spans) {
+      expect(typeof span.start_time_unix_nano).toBe("string");
+      expect(span.start_time_unix_nano).toMatch(/^\d+$/);
+      if (span.end_time_unix_nano !== undefined) {
+        expect(typeof span.end_time_unix_nano).toBe("string");
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #128: the OpenInference exporter emitted `start_time_unix_nano` / `end_time_unix_nano` as raw JSON numbers around 1.7e18, beyond `Number.MAX_SAFE_INTEGER` and the RFC 8259 interoperable range, and inconsistent with the OTLP exporter and both committed OpenInference import fixtures, which all use decimal strings.

The fix:

- nanoseconds are computed in BigInt: whole milliseconds scaled exactly, sub-millisecond fractions rounded to nanoseconds, so values are exact by construction rather than within ~128 ns of the true product
- `OpenInferenceSpan.start_time_unix_nano` / `end_time_unix_nano` are decimal strings, matching the OTLP exporter's encoding and the committed `fixtures/standards/openinference-basic.json` shape

Compatibility, verified in-repo: the reader's `parseUnixNanoToIso` already accepts decimal strings (so export → import round-trips keep working), `validateExport` does not constrain the field type, and the export surface is documented as experimental/compatibility-oriented. All 60 exporter + conformance tests and the full core suite (108 files) pass.

Regression tests added: exact string values for a realistic epoch plus duration, a guard that nano fields never appear as raw JSON number literals in the payload, and an encoding check across all spans.

Sequencing note: the #7 export golden will be built on top of this encoding so the committed standards evidence does not bake in the unsafe number form.

Closes #128

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core` (OpenInference exporter)
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] Docs / community only

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/core/test/exporters packages/core/test/conformance  # 60/60 pass
pnpm exec vitest run packages/core/test  # 108/108 files pass
git diff --check  # clean
```

The exported shape is an experimental surface; the only observable change is the JSON type of the two nano fields, now consistent with every other unix-nano producer and consumer in the repo.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - EXPORTS.md already labels the format compatibility-oriented; no doc claims the numeric type
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
