### PR TITLE
test: add studio/viewer empty-state and accessibility coverage

### DIFF
--- a/packages/studio/test/ui-states.test.ts
+++ b/packages/studio/test/ui-states.test.ts
@@ -1,0 +1,157 @@
+import http from "node:http";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createStudioContext, createStudioServer } from "../src/index.js";
+import { studioIndexHtml } from "../src/html.js";
+
+async function get(baseUrl: string, route: string) {
+  return new Promise<{ status: number; text: string }>((resolve, reject) => {
+    http.get(`${baseUrl}${route}`, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => chunks.push(chunk as Buffer));
+      res.on("end", () =>
+        resolve({ status: res.statusCode ?? 0, text: Buffer.concat(chunks).toString("utf8") }),
+      );
+    }).on("error", reject);
+  });
+}
+
+/**
+ * Studio empty-state, load-error, and accessibility coverage (#111).
+ * Static assertions pin the shell the browser receives; server assertions
+ * pin the API responses the client renders for no-data and error states.
+ * No browser E2E; preview UI, synthetic data only.
+ */
+describe("studio shell accessibility and states", () => {
+  it("declares language, charset, title, and a CSP", () => {
+    expect(studioIndexHtml).toContain('<html lang="en">');
+    expect(studioIndexHtml).toContain('<meta charset="utf-8" />');
+    expect(studioIndexHtml).toContain("<title>AgentInspect Studio</title>");
+    expect(studioIndexHtml).toContain("Content-Security-Policy");
+  });
+
+  it("keeps keyboard-reachable navigation: every nav entry is a real link", () => {
+    const nav = studioIndexHtml.match(/<nav id="nav">([\s\S]*?)<\/nav>/)?.[1] ?? "";
+    const anchors = [...nav.matchAll(/<a\s+([^>]+)>/g)].map((m) => m[1]!);
+    expect(anchors.length).toBeGreaterThanOrEqual(7);
+    for (const attrs of anchors) {
+      // href makes the entry focusable and Enter-activatable by default;
+      // no tabindex removal or click-only div navigation.
+      expect(attrs).toMatch(/href="#/);
+      expect(attrs).not.toContain("tabindex=\"-1\"");
+    }
+    expect(studioIndexHtml).not.toContain("onclick=");
+  });
+
+  it("uses landmark structure and a visible loading state", () => {
+    expect(studioIndexHtml).toContain("<header>");
+    expect(studioIndexHtml).toContain('<main id="content">');
+    expect(studioIndexHtml).toContain("Loading…");
+  });
+
+  it("ships the no-data onboarding row and error affordance in the client", () => {
+    expect(studioIndexHtml).toContain("No projects imported");
+    expect(studioIndexHtml).toContain('class="error"');
+    // Every dynamic interpolation goes through the client-side escaper.
+    expect(studioIndexHtml).toContain("function escapeHtml(");
+  });
+
+  describe("no-data project server states", () => {
+    let server: http.Server | undefined;
+    let baseUrl: string;
+
+    beforeEach(async () => {
+      // The registry schema requires at least one project, so the no-data
+      // onboarding state is a workspace project whose trace directory has no
+      // runs yet.
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-studio-empty-"));
+      const workspaceDir = path.join(tmpDir, "empty-project", ".agent-inspect");
+      await mkdir(path.join(workspaceDir, "runs"), { recursive: true });
+      await writeFile(
+        path.join(workspaceDir, "workspace.json"),
+        `${JSON.stringify(
+          {
+            schemaVersion: "1.0",
+            project: "empty",
+            createdAt: "2026-07-09T00:00:00.000Z",
+            traceDirs: ["runs"],
+            reportsDir: "reports",
+            artifactsDir: "artifacts",
+            bundlesDir: "bundles",
+            notesDir: "notes",
+            redactionProfile: "share",
+            index: { enabled: false, type: "none" },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+      const registryPath = path.join(tmpDir, "studio-registry.json");
+      await writeFile(
+        registryPath,
+        `${JSON.stringify(
+          {
+            schemaVersion: "1.0",
+            name: "empty-fixture",
+            projects: [{ id: "empty", path: "empty-project", label: "Empty Project" }],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+      const context = await createStudioContext({
+        workspacePath: registryPath,
+        dbPath: path.join(tmpDir, "studio.db"),
+        cwd: tmpDir,
+      });
+      server = createStudioServer({ context, port: 0 });
+      await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", () => resolve()));
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      if (!server) return;
+      await new Promise<void>((resolve, reject) => {
+        server!.close((error) => (error ? reject(error) : resolve()));
+      });
+    });
+
+    it("serves the shell and a zero-run project without errors", async () => {
+      const shell = await get(baseUrl, "/");
+      expect(shell.status).toBe(200);
+      expect(shell.text).toContain("AgentInspect Studio");
+
+      const projects = await get(baseUrl, "/api/projects");
+      expect(projects.status).toBe(200);
+      const body = JSON.parse(projects.text) as {
+        projects: Array<{ id: string; traceCount: number }>;
+      };
+      expect(body.projects).toHaveLength(1);
+      expect(body.projects[0]).toMatchObject({ id: "empty", traceCount: 0 });
+
+      const runs = await get(baseUrl, "/api/projects/empty/runs");
+      expect(runs.status).toBe(200);
+      expect(JSON.parse(runs.text)).toMatchObject({ runs: [] });
+
+      const health = await get(baseUrl, "/api/health");
+      expect(health.status).toBe(200);
+    });
+
+    it("returns a safe JSON error for an unknown project instead of crashing", async () => {
+      const missing = await get(baseUrl, "/api/projects/does-not-exist/runs");
+      expect(missing.status).toBeGreaterThanOrEqual(400);
+      expect(missing.status).toBeLessThan(500);
+      const body = JSON.parse(missing.text) as { error?: string };
+      expect(typeof body.error).toBe("string");
+      expect(body.error!.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/viewer/test/ui-states.test.ts
+++ b/packages/viewer/test/ui-states.test.ts
@@ -1,0 +1,83 @@
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createViewerServer } from "../src/index.js";
+import { viewerIndexHtml } from "../src/html.js";
+
+async function get(baseUrl: string, route: string) {
+  return new Promise<{ status: number; text: string }>((resolve, reject) => {
+    http.get(`${baseUrl}${route}`, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => chunks.push(chunk as Buffer));
+      res.on("end", () =>
+        resolve({ status: res.statusCode ?? 0, text: Buffer.concat(chunks).toString("utf8") }),
+      );
+    }).on("error", reject);
+  });
+}
+
+/**
+ * Viewer empty-state, load-error, and accessibility coverage (#111).
+ * Preview UI; static shell assertions plus server behavior over an empty
+ * trace directory. Synthetic data only, no browser E2E.
+ */
+describe("viewer shell accessibility and states", () => {
+  it("declares language, charset, title, and a visible loading state", () => {
+    expect(viewerIndexHtml).toContain('<html lang="en">');
+    expect(viewerIndexHtml).toContain('<meta charset="utf-8" />');
+    expect(viewerIndexHtml).toContain("<title>AgentInspect Viewer</title>");
+    expect(viewerIndexHtml).toContain("Loading…");
+  });
+
+  it("keeps navigation as real links and routes errors to visible text", () => {
+    // API navigation is emitted as anchors (focusable/Enter-activatable).
+    expect(viewerIndexHtml).toContain("'<a href=\"/api/traces\">/api/traces</a>");
+    // Load failures land in the output element as text, never thrown away.
+    expect(viewerIndexHtml).toMatch(/load\(\)\.catch\(/);
+    expect(viewerIndexHtml).toContain("function escapeHtml(");
+  });
+
+  describe("empty trace directory", () => {
+    let traceDir: string;
+    let server: http.Server;
+    let baseUrl: string;
+
+    beforeEach(async () => {
+      traceDir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-viewer-empty-"));
+      server = createViewerServer({ traceDir, port: 0 });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await rm(traceDir, { recursive: true, force: true });
+    });
+
+    it("serves the shell and an empty trace list without errors", async () => {
+      const shell = await get(baseUrl, "/");
+      expect(shell.status).toBe(200);
+      expect(shell.text).toContain("AgentInspect local viewer");
+
+      const traces = await get(baseUrl, "/api/traces");
+      expect(traces.status).toBe(200);
+      expect(JSON.parse(traces.text)).toEqual([]);
+    });
+
+    it("returns a safe non-2xx JSON error for an unknown run", async () => {
+      const missing = await get(baseUrl, "/api/trace/does-not-exist");
+      expect(missing.status).toBeGreaterThanOrEqual(400);
+      expect(missing.status).toBeLessThan(500);
+      const body = JSON.parse(missing.text) as { error?: string };
+      expect(typeof body.error).toBe("string");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Studio/viewer empty-state and accessibility coverage from #111, using the existing package test stacks only — no Playwright/Cypress, per the issue's out-of-scope list.

### What is covered (10 new tests)

| Issue dimension | Coverage |
| --------------- | -------- |
| empty state | viewer serves its shell plus an empty `/api/traces` array over an empty directory; studio's client shell carries the "No projects imported" empty-state row |
| no-data onboarding | studio serves a zero-run workspace project end to end: `/api/projects` reports `traceCount: 0`, `/api/projects/<id>/runs` returns `{ runs: [] }`, health stays 200 |
| load error | unknown project (studio) and unknown run (viewer) return safe 4xx JSON `{ error }` payloads — the exact shapes the clients render into their error affordances — instead of crashing |
| keyboard navigation | every studio nav entry is a real `href` anchor (focusable and Enter-activatable by default), no `tabindex="-1"`, no inline `onclick` handlers; viewer API navigation is emitted as anchors |
| focus behavior | pinned via the same structural checks (native anchors and inputs, nothing removing default focusability) plus landmark structure (`header`/`main`) so focus order follows the document |

Also pinned: `lang="en"` and charset declarations, page titles, studio's CSP meta, visible loading states, and the presence of the client-side `escapeHtml` used for all dynamic interpolation.

### Notes

- The studio registry schema requires at least one project, so the no-data onboarding fixture is a minimal valid workspace manifest (generated in a temp dir per run) with zero traces — the state a first-time self-hoster actually sees
- Discovered while writing the fixture: the manifest validator requires `reportsDir`/`artifactsDir`/`bundlesDir`/`notesDir` even for a trace-only workspace; noting it here as potential onboarding friction, no behavior change made
- Everything runs against the real servers on `127.0.0.1` ephemeral ports, matching the existing `workspace-views` and viewer test conventions

Closes #111

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture (regression tests)
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/studio` + `@agent-inspect/viewer` (tests only)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/studio/test packages/viewer/test  # 36/36 pass (26 existing + 10 new)
git diff --check  # clean
```

Runs against the real better-sqlite3 binding locally (studio context opens a real SQLite db per test).

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, tests only
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
