### PR TITLE
fix(studio): honor registry HTTP ingest config on lazy context

### DIFF
--- a/packages/studio/src/ingest/http.ts
+++ b/packages/studio/src/ingest/http.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import type { StudioContext } from "../context.js";
 import { insertIngestFile } from "../db.js";
 import { importStudioRegistry } from "../import.js";
+import type { StudioRegistryHttpIngest } from "../registry.js";
 import type { StudioServerOptions } from "../types.js";
 import {
   buildGitHubArtifactSourceKey,
@@ -34,10 +35,14 @@ export interface HttpIngestConfig {
 
 export function resolveHttpIngestConfig(
   options: StudioServerOptions,
-  registryEnabled?: boolean,
+  registryHttp?: StudioRegistryHttpIngest,
 ): HttpIngestConfig {
-  const http = options.context?.registry.ingest?.http;
-  const enabled = options.ingestHttp === true || registryEnabled === true || http?.enabled === true;
+  // Prefer the resolved registry config: on the lazy-context path
+  // (createStudioServer without options.context) options.context stays
+  // undefined, and reading it here silently dropped registry path/tokenEnv/
+  // maxBytes while only `enabled` was threaded through.
+  const http = registryHttp ?? options.context?.registry.ingest?.http;
+  const enabled = options.ingestHttp === true || http?.enabled === true;
   const basePath = (http?.path ?? DEFAULT_HTTP_INGEST_BASE_PATH).trim() || DEFAULT_HTTP_INGEST_BASE_PATH;
   const tokenEnv = resolveIngestTokenEnv({
     ...(options.ingestTokenEnv !== undefined ? { tokenEnv: options.ingestTokenEnv } : {}),
@@ -88,7 +93,7 @@ export async function handleHttpIngestRequest(
   options: StudioServerOptions,
   pathname: string,
 ): Promise<boolean> {
-  const config = resolveHttpIngestConfig(options, ctx.registry.ingest?.http?.enabled);
+  const config = resolveHttpIngestConfig(options, ctx.registry.ingest?.http);
   if (!isHttpIngestRoute(pathname, config)) return false;
 
   if (!config.enabled) {

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -52,7 +52,7 @@ export function createStudioServer(options: StudioServerOptions = {}): Server {
         contextPromise = createStudioContext(options);
       }
       const ctx = await contextPromise;
-      const httpConfig = resolveHttpIngestConfig(options, ctx.registry.ingest?.http?.enabled);
+      const httpConfig = resolveHttpIngestConfig(options, ctx.registry.ingest?.http);
 
       if (isHttpIngestRoute(pathname, httpConfig)) {
         const handled = await handleHttpIngestRequest(req, res, ctx, options, pathname);

--- a/packages/studio/test/ingest-config.test.ts
+++ b/packages/studio/test/ingest-config.test.ts
@@ -1,0 +1,166 @@
+import http from "node:http";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createStudioServer } from "../src/index.js";
+import { resolveHttpIngestConfig } from "../src/ingest/http.js";
+
+const TOKEN_ENV = "STUDIO_INGEST_CONFIG_TEST_TOKEN";
+
+async function post(
+  baseUrl: string,
+  route: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      `${baseUrl}${route}`,
+      { method: "POST", headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk as Buffer));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          resolve({
+            status: res.statusCode ?? 0,
+            body: text.length > 0 ? JSON.parse(text) : null,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+/**
+ * Registry-configured HTTP ingest settings must apply on the lazy-context
+ * path too: createStudioServer without options.context previously fell back
+ * to the default tokenEnv/path/maxBytes because the resolver read
+ * options.context instead of the resolved registry.
+ */
+describe("studio HTTP ingest config resolution", () => {
+  it("prefers the resolved registry config over options.context", () => {
+    const config = resolveHttpIngestConfig(
+      {},
+      { enabled: true, path: "/custom/ingest", tokenEnv: "MY_INGEST_TOKEN", maxBytes: 1234 },
+    );
+    expect(config).toEqual({
+      enabled: true,
+      basePath: "/custom/ingest",
+      tokenEnv: "MY_INGEST_TOKEN",
+      maxBytes: 1234,
+    });
+  });
+
+  it("falls back to defaults when no registry config is provided", () => {
+    const config = resolveHttpIngestConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.basePath).toBe("/api/ingest");
+    expect(config.tokenEnv).toBe("STUDIO_INGEST_TOKEN");
+    expect(config.maxBytes).toBe(52_428_800);
+  });
+
+  describe("lazy-context server honors registry tokenEnv and maxBytes", () => {
+    let server: http.Server | undefined;
+    let baseUrl: string;
+    let previousToken: string | undefined;
+
+    beforeEach(async () => {
+      previousToken = process.env[TOKEN_ENV];
+      process.env[TOKEN_ENV] = "fixture-ingest-token";
+
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-ingest-config-"));
+      const workspaceDir = path.join(tmpDir, "demo-project", ".agent-inspect");
+      await mkdir(path.join(workspaceDir, "runs"), { recursive: true });
+      await mkdir(path.join(tmpDir, "imports", "bundles"), { recursive: true });
+      await mkdir(path.join(tmpDir, "imports", "ci"), { recursive: true });
+      await writeFile(
+        path.join(workspaceDir, "workspace.json"),
+        `${JSON.stringify({
+          schemaVersion: "1.0",
+          project: "demo",
+          createdAt: "2026-07-09T00:00:00.000Z",
+          traceDirs: ["runs"],
+          reportsDir: "reports",
+          artifactsDir: "artifacts",
+          bundlesDir: "bundles",
+          notesDir: "notes",
+          redactionProfile: "share",
+          index: { enabled: false, type: "none" },
+        })}\n`,
+        "utf-8",
+      );
+      await writeFile(
+        path.join(tmpDir, "studio-registry.json"),
+        `${JSON.stringify({
+          schemaVersion: "1.0",
+          name: "ingest-config-fixture",
+          projects: [{ id: "demo", path: "demo-project" }],
+          import: { bundlesDir: "imports/bundles", ciArtifactsDir: "imports/ci" },
+          ingest: { http: { enabled: true, tokenEnv: TOKEN_ENV, maxBytes: 64 } },
+        })}\n`,
+        "utf-8",
+      );
+
+      // Lazy-context path on purpose: no options.context.
+      server = createStudioServer({
+        workspacePath: path.join(tmpDir, "studio-registry.json"),
+        dbPath: path.join(tmpDir, "studio.db"),
+        cwd: tmpDir,
+        port: 0,
+      });
+      await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", () => resolve()));
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      if (previousToken === undefined) delete process.env[TOKEN_ENV];
+      else process.env[TOKEN_ENV] = previousToken;
+      if (!server) return;
+      await new Promise<void>((resolve, reject) => {
+        server!.close((error) => (error ? reject(error) : resolve()));
+      });
+    });
+
+    it("accepts the registry-configured token instead of the default env", async () => {
+      const response = await post(baseUrl, "/api/ingest/artifact", "small-body", {
+        authorization: "Bearer fixture-ingest-token",
+        "content-type": "application/octet-stream",
+      });
+      // Anything but 403 proves the token from the registry env was used;
+      // the payload itself may still be rejected downstream.
+      expect(response.status).not.toBe(403);
+    });
+
+    it("rejects tokens that only match the default env", async () => {
+      const previousDefault = process.env.STUDIO_INGEST_TOKEN;
+      process.env.STUDIO_INGEST_TOKEN = "default-env-token";
+      try {
+        const response = await post(baseUrl, "/api/ingest/artifact", "small-body", {
+          authorization: "Bearer default-env-token",
+          "content-type": "application/octet-stream",
+        });
+        expect(response.status).toBe(403);
+      } finally {
+        if (previousDefault === undefined) delete process.env.STUDIO_INGEST_TOKEN;
+        else process.env.STUDIO_INGEST_TOKEN = previousDefault;
+      }
+    });
+
+    it("enforces the registry-configured maxBytes", async () => {
+      const oversized = "A".repeat(200);
+      const response = await post(baseUrl, "/api/ingest/artifact", oversized, {
+        authorization: "Bearer fixture-ingest-token",
+        "content-type": "application/octet-stream",
+      });
+      expect(response.status).toBe(413);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #135: registry-configured HTTP ingest settings (`tokenEnv`, `maxBytes`, `path`) were silently ignored on the lazy-context path. `resolveHttpIngestConfig` read `options.context?.registry.ingest?.http`, but `createStudioServer` without a prebuilt context creates it inside the request handler and never assigns it back to `options`, so only `enabled` (threaded separately as a boolean) survived — token validation fell back to the default `STUDIO_INGEST_TOKEN` env and the size cap to 50 MB.

The security-relevant part, proven by the regression tests: with a registry demanding a custom `tokenEnv`, a client presenting a token that matched only the **default** env was accepted (200), while the intended registry token got 403.

### The fix

`resolveHttpIngestConfig` now takes the resolved registry's `http` block directly (`StudioRegistryHttpIngest`) — both internal call sites already hold `ctx` — with `options.context` kept as a fallback so external callers of the exported helper keep working. Precedence is unchanged: CLI `ingestHttp`/`ingestTokenEnv` options still override the registry, which overrides defaults.

### Regression tests (`packages/studio/test/ingest-config.test.ts`, 5 cases)

- resolver unit behavior: registry block wins; defaults apply when nothing is configured
- lazy-context server end to end: the registry-env token is accepted, a token matching only the default env is rejected with 403, and a 200-byte body against a registry `maxBytes: 64` returns 413

Counter-verified: with the fix stashed, four of the five tests fail exactly along the bug's fault lines (`403` where acceptance was expected, `200` where 403 was expected, `403` instead of `413`).

Closes #135

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/studio` (support:preview)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/studio/test  # 33/33 pass (28 existing + 5 new)
git diff --check  # clean
```

The exported helper's second parameter changes from `registryEnabled?: boolean` to `registryHttp?: StudioRegistryHttpIngest`. Both in-repo call sites are updated; flagging per the preview support level in case any external caller relies on the boolean form.

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, behavior now matches documented registry config
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
