### PR TITLE
fix(studio): dedup bundle uploads by full contents

### DIFF
--- a/packages/studio/src/ingest/bundle-upload.ts
+++ b/packages/studio/src/ingest/bundle-upload.ts
@@ -72,6 +72,34 @@ export async function validateBundleDirectory(bundleDir: string): Promise<string
   return errors;
 }
 
+/**
+ * Deterministic hash over the full bundle contents (sorted relative paths and
+ * file bytes). Hashing only metadata.json let edited trace files slip past
+ * dedup, so a re-imported bundle kept serving the stale copy.
+ */
+async function hashBundleContents(bundleDir: string): Promise<string> {
+  const hash = createHash("sha256");
+  const walk = async (dir: string, relPrefix: string): Promise<void> => {
+    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      const rel = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(abs, rel);
+      } else if (entry.isFile()) {
+        hash.update(rel);
+        hash.update("\0");
+        hash.update(await readFile(abs));
+        hash.update("\0");
+      }
+    }
+  };
+  await walk(bundleDir, "");
+  return hash.digest("hex");
+}
+
 async function copyDirectoryRecursive(sourceDir: string, destDir: string): Promise<void> {
   await mkdir(destDir, { recursive: true });
   const entries = await readdir(sourceDir, { withFileTypes: true });
@@ -134,8 +162,7 @@ export async function importBundleUpload(
     };
   }
 
-  const metadataRaw = await readFile(path.join(bundlePath, "metadata.json"), "utf8");
-  const contentHash = createHash("sha256").update(metadataRaw).digest("hex");
+  const contentHash = await hashBundleContents(bundlePath);
   const sourceKey = `bundle:${bundlePath}`;
   const existing = findIngestFileBySourceKey(options.db, sourceKey);
   if (existing && existing.contentHash === contentHash) {

--- a/packages/studio/test/bundle-upload.test.ts
+++ b/packages/studio/test/bundle-upload.test.ts
@@ -103,5 +103,33 @@ describe("studio bundle upload importer", () => {
     });
     expect(second.imported).toBe(false);
     expect(second.destPath).toBe(first.destPath);
+
+    // Edited bundle CONTENT with unchanged metadata.json must re-import;
+    // hashing only metadata previously kept serving the stale copy.
+    await writeFile(path.join(bundleSrc, "summary.md"), "# summary (edited)", "utf8");
+    const third = await importBundleUpload({
+      db,
+      registryPath,
+      registry: parsed.registry!,
+      bundlePath: bundleSrc,
+      enabled: true,
+    });
+    expect(third.imported).toBe(true);
+    expect(third.destPath).not.toBe(first.destPath);
+    const fsp = await import("node:fs/promises");
+    expect(await fsp.readFile(path.join(third.destPath!, "summary.md"), "utf8")).toBe(
+      "# summary (edited)",
+    );
+
+    // And the edited state is itself idempotent on the next re-import.
+    const fourth = await importBundleUpload({
+      db,
+      registryPath,
+      registry: parsed.registry!,
+      bundlePath: bundleSrc,
+      enabled: true,
+    });
+    expect(fourth.imported).toBe(false);
+    expect(fourth.destPath).toBe(third.destPath);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the studio bundle-upload dedup blind spot. Change detection hashed only `metadata.json`; since that file (version, `runIds`, `files` list) is stable across re-bundles of the same runs, editing any actual content inside the bundle and re-importing returned `imported: false` with the old `destPath`, so Studio kept serving the stale evidence copy. Every sibling importer (file drop, HTTP body, GitHub artifact archive) already hashes its full payload — the directory-bundle path was the only one keyed on a sub-file.

### The fix

`hashBundleContents` walks the bundle directory deterministically (entries sorted, relative path + file bytes fed to one SHA-256) and replaces the metadata-only hash. Interactions verified:

- `uniqueDestPath` already derives the destination name from the content hash, so a changed bundle lands beside the previous copy (older evidence is preserved on disk) while `insertIngestFile` updates the row for the source key
- identical re-imports remain idempotent (same hash, same early return)
- no behavior change for first-time imports

### Tests

Extended `packages/studio/test/bundle-upload.test.ts`: after the existing identical-reimport idempotency assertions, the bundle's `summary.md` is edited with `metadata.json` untouched — the third import must re-import to a new `destPath` whose copy carries the edited content, and a fourth import of the edited state must be idempotent again. Counter-verified: with the fix stashed, the edit case fails (`imported` stays `false`).

Closes #137

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/studio` (support:preview)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/studio/test/bundle-upload.test.ts  # 2/2 pass (expanded case)
pnpm exec vitest run packages/studio/test  # full studio suite passes
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
