### PR TITLE
fix(core): honor canonical and multi-entry contract allowedStatuses

### DIFF
--- a/packages/core/src/checks/contract.ts
+++ b/packages/core/src/checks/contract.ts
@@ -78,22 +78,76 @@ export interface TraceContract {
 }
 
 function normalizeStatus(status: string): "ok" | "error" | "running" {
+  if (status === "ok" || status === "error" || status === "running") return status;
   if (status === "success") return "ok";
   if (status === "failed") return "error";
-  if (status === "running") return "running";
   return "error";
 }
 
 function contractToRules(contract: TraceContract): TraceCheckRule[] {
   const rules: TraceCheckRule[] = [];
 
-  if (contract.run?.allowedStatuses?.length === 1) {
+  const allowedStatuses = contract.run?.allowedStatuses ?? [];
+  if (allowedStatuses.length === 1) {
     rules.push(
       createRunStatusRule({
-        expected: normalizeStatus(contract.run.allowedStatuses[0]!),
-        allowIncomplete: contract.run.requireCompleted === false,
+        expected: normalizeStatus(allowedStatuses[0]!),
+        allowIncomplete: contract.run?.requireCompleted === false,
       }),
     );
+  } else if (allowedStatuses.length > 1) {
+    const expected = [...new Set(allowedStatuses.map(normalizeStatus))];
+    const allowIncomplete = contract.run?.requireCompleted === false;
+    rules.push({
+      id: "contract.run.allowedStatuses",
+      category: "run",
+      defaultSeverity: "error",
+      evaluate(context) {
+        const findings: TraceCheckFinding[] = [];
+        const actual = context.selectedRun?.status ?? "unknown";
+        if (!expected.includes(actual as "ok" | "error" | "running")) {
+          findings.push(
+            contractFailFinding(
+              "contract.run.allowedStatuses",
+              `Run status ${actual} is not one of the allowed statuses: ${expected.join(", ")}.`,
+              context.selectedRun
+                ? [
+                    {
+                      runId: context.selectedRun.runId,
+                      kind: "RUN",
+                      name: context.selectedRun.name,
+                      status: context.selectedRun.status,
+                    },
+                  ]
+                : [],
+              expected,
+              actual,
+            ),
+          );
+        }
+        if (!allowIncomplete) {
+          const running = context.events.filter((event) => event.status === "running");
+          if (running.length > 0) {
+            findings.push(
+              contractFailFinding(
+                "contract.run.allowedStatuses",
+                "Run contains incomplete running events.",
+                running.map((event) => ({
+                  runId: event.runId,
+                  eventId: event.eventId,
+                  kind: event.kind,
+                  name: event.name,
+                  status: event.status,
+                })),
+                "no running events",
+                running.length,
+              ),
+            );
+          }
+        }
+        return findings;
+      },
+    });
   } else if (contract.run?.requireCompleted !== false) {
     rules.push(createRunStatusRule({ allowIncomplete: false }));
   }

--- a/packages/core/test/checks/contract.test.ts
+++ b/packages/core/test/checks/contract.test.ts
@@ -4,6 +4,96 @@ import { describe, expect, it } from "vitest";
 
 import { defineTraceContract, evaluateTraceContract } from "../../src/checks/contract.js";
 import { openTrace } from "../../src/entries/readers.js";
+import type { TraceReadResult } from "../../src/readers/index.js";
+import type { InspectNode, InspectRunTree } from "../../src/types/inspect-event.js";
+import type { PersistedInspectEvent } from "../../src/types/persisted-inspect-event.js";
+
+function persisted(
+  eventId: string,
+  overrides: Partial<PersistedInspectEvent> = {},
+): PersistedInspectEvent {
+  return {
+    schemaVersion: "0.2",
+    eventId,
+    runId: "run-contract",
+    kind: "LOGIC",
+    name: eventId,
+    status: "ok",
+    timestamp: "2026-07-11T00:00:01.000Z",
+    confidence: "explicit",
+    source: { type: "manual" },
+    ...overrides,
+  };
+}
+
+function node(event: PersistedInspectEvent): InspectNode {
+  return {
+    event: {
+      eventId: event.eventId,
+      runId: event.runId,
+      parentId: event.parentId,
+      kind: event.kind,
+      name: event.name,
+      status: event.status === "unknown" ? undefined : event.status,
+      timestamp: Date.parse(event.timestamp),
+      durationMs: event.durationMs,
+      attributes: event.attributes,
+      confidence: event.confidence,
+      source: { type: "manual" },
+    },
+    children: [],
+    depth: 1,
+  };
+}
+
+function readResult(
+  runStatus: "running" | "ok" | "error",
+  events: PersistedInspectEvent[],
+): TraceReadResult {
+  const children = events.map((event) => node(event));
+  const run: InspectRunTree = {
+    runId: "run-contract",
+    name: "contract",
+    status: runStatus,
+    children,
+    metadata: {
+      totalEvents: children.length,
+      confidenceBreakdown: {
+        explicit: children.length,
+        correlated: 0,
+        heuristic: 0,
+        unknown: 0,
+      },
+      kinds: {
+        RUN: 0,
+        AGENT: 0,
+        LLM: 0,
+        TOOL: 0,
+        CHAIN: 0,
+        RETRIEVER: 0,
+        DECISION: 0,
+        RESULT: 0,
+        ERROR: 0,
+        LOGIC: children.length,
+        LOG: 0,
+        OUTCOME: 0,
+      },
+    },
+  };
+
+  return {
+    format: "agent-inspect-jsonl",
+    events,
+    runs: [run],
+    warnings: [],
+    unsupportedFields: [],
+    sourceFiles: [],
+  };
+}
+
+function failFindings(result: ReturnType<typeof evaluateTraceContract>) {
+  return result.findings.filter((finding) => finding.status === "fail");
+}
 
 describe("trace contract", () => {
   it("evaluates run duration and tool requirements", async () => {
@@ -19,5 +109,68 @@ describe("trace contract", () => {
       true,
     );
     expect(result.status).toBeDefined();
+  });
+
+  describe("run.allowedStatuses", () => {
+    it("accepts a canonical ok status without remapping it", () => {
+      const read = readResult("ok", [persisted("event-a")]);
+      const contract = defineTraceContract({ run: { allowedStatuses: ["ok"] } });
+      const result = evaluateTraceContract({ read }, contract);
+      expect(failFindings(result)).toEqual([]);
+      expect(result.status).toBe("pass");
+    });
+
+    it("still accepts the success and failed aliases", () => {
+      const okRead = readResult("ok", [persisted("event-a")]);
+      const okResult = evaluateTraceContract(
+        { read: okRead },
+        defineTraceContract({ run: { allowedStatuses: ["success"] } }),
+      );
+      expect(failFindings(okResult)).toEqual([]);
+
+      const errorRead = readResult("error", [persisted("event-a", { status: "error" })]);
+      const errorResult = evaluateTraceContract(
+        { read: errorRead },
+        defineTraceContract({ run: { allowedStatuses: ["failed"] } }),
+      );
+      expect(failFindings(errorResult)).toEqual([]);
+    });
+
+    it("honors multi-entry allowedStatuses for a matching run", () => {
+      const read = readResult("error", [persisted("event-a", { status: "error" })]);
+      const contract = defineTraceContract({ run: { allowedStatuses: ["ok", "error"] } });
+      const result = evaluateTraceContract({ read }, contract);
+      expect(failFindings(result)).toEqual([]);
+      expect(result.status).toBe("pass");
+    });
+
+    it("fails multi-entry allowedStatuses when the run status is not listed", () => {
+      const read = readResult("error", [persisted("event-a", { status: "error" })]);
+      const contract = defineTraceContract({ run: { allowedStatuses: ["ok", "running"] } });
+      const result = evaluateTraceContract({ read }, contract);
+      const failed = failFindings(result);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]?.ruleId).toBe("contract.run.allowedStatuses");
+      expect(failed[0]?.actual).toBe("error");
+      expect(failed[0]?.evidence.length).toBeGreaterThan(0);
+    });
+
+    it("allows an incomplete run when requireCompleted is false", () => {
+      const read = readResult("running", [persisted("event-a", { status: "running" })]);
+      const contract = defineTraceContract({
+        run: { allowedStatuses: ["ok", "running"], requireCompleted: false },
+      });
+      const result = evaluateTraceContract({ read }, contract);
+      expect(failFindings(result)).toEqual([]);
+    });
+
+    it("flags incomplete running events unless requireCompleted is false", () => {
+      const read = readResult("ok", [persisted("event-a", { status: "running" })]);
+      const contract = defineTraceContract({ run: { allowedStatuses: ["ok", "error"] } });
+      const result = evaluateTraceContract({ read }, contract);
+      const failed = failFindings(result);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]?.message).toContain("incomplete running events");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes two holes in the experimental trace contract's `run.allowedStatuses` (`packages/core/src/checks/contract.ts`):

1. **Canonical statuses were remapped to `error`.** `normalizeStatus` only recognized the `success`/`failed` aliases plus `running`; the canonical `InspectRunTree.status` values fell through to `error`. So `allowedStatuses: ["ok"]` built a rule expecting `error`, and a successful run failed with `Run status ok did not match expected error`.
2. **Multi-entry lists were silently ignored.** The list was only honored when `length === 1`; `["ok", "running"]` fell through to the default require-ok rule, giving stricter behavior than declared with no warning.

### The fix

- `normalizeStatus` passes `ok`/`error`/`running` through unchanged; the `success` and `failed` aliases keep working.
- Multi-entry lists install a dedicated `contract.run.allowedStatuses` rule that accepts any listed status (normalized, deduped) and keeps the incomplete-running-events guard unless `requireCompleted: false`, mirroring the single-entry `run.status` semantics. Single-entry and empty-list paths are unchanged.

Heads up on semantics: this surface is `@experimental` (evolving during v6.5.x), and the change means contracts that accidentally relied on the `ok` to `error` mismapping now behave as written. Happy to gate or split if you want this staged differently.

### Tests

New `run.allowedStatuses` block in `packages/core/test/checks/contract.test.ts` using synthetic traces: canonical `["ok"]` passes an ok run, both aliases still work, multi-entry passes a listed status and fails an unlisted one (rule id `contract.run.allowedStatuses`, evidence populated), `requireCompleted: false` allows an incomplete run, and incomplete running events still fail otherwise. Counter-verified: with the fix stashed, three of the new tests fail with the exact messages above.

Closes #139

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [x] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] `@agent-inspect/studio` (support:preview)

## Validation

```bash
pnpm typecheck  # pass
pnpm exec vitest run packages/core/test/checks/contract.test.ts  # 7/7 pass
pnpm exec vitest run packages/core/test  # 949/949 pass
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed)
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, only the roadmap references allowedStatuses and it uses the still-supported success alias
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
