### PR TITLE
docs(community): add review SLA and refresh issue triage guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,8 @@ Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 - [ROADMAP.md](ROADMAP.md) — Now / Next / Future
 - [docs/community/GOOD-FIRST-ISSUES.md](docs/community/GOOD-FIRST-ISSUES.md) — expanded list with issue draft links
 - [Live issues](https://github.com/rajudandigam/agent-inspect/issues) — pick `status:ready`, `community-owned` work
+- [docs/community/ISSUE-TRIAGE.md](docs/community/ISSUE-TRIAGE.md) — claim flow, labels, and stale-work policy
+- [docs/community/REVIEW-SLA.md](docs/community/REVIEW-SLA.md) — response-time targets for issues and PR reviews
 
 ## Code of conduct
 

--- a/docs/community/ISSUE-TRIAGE.md
+++ b/docs/community/ISSUE-TRIAGE.md
@@ -1,36 +1,88 @@
-# Issue triage task list (maintainer)
+# Issue triage guide
 
-A manual triage checklist for aligning the public issue tracker with the v3.5.6 source-of-truth cleanup and v4 workspace direction.
+How issues move from report to resolution at 6.7.2. Covers the label taxonomy, the contributor claim flow, needs-info handling, draft PR guidance, and the stale-work policy.
 
-> **Maintainer-owned, manual only.** This is a task list, not an automation. Do **not** auto-close, auto-label, or bulk-edit GitHub issues from this document. Each row is a decision for a human maintainer to make in the GitHub UI.
+> **Maintainer-owned, manual only.** Triage actions (labels, closures, comments) are human maintainer decisions made in the GitHub UI. Do **not** auto-close, auto-label, or bulk-edit issues. Response-time targets live in [REVIEW-SLA.md](./REVIEW-SLA.md).
 
-## Triage categories
+## Label taxonomy
 
-- **Keep** — still accurate and aligned; leave as-is.
-- **Refresh** — still relevant but wording/labels/version references need updating for 3.5.5 / v4 planning.
-- **Close** — shipped, superseded, or out of current scope; close manually with a short note.
+### Status (lifecycle)
 
-## Suggested triage pass
+| Label | Meaning |
+| ----- | ------- |
+| `status:needs-triage` | Awaiting maintainer triage |
+| `status:ready` | Triaged and ready for contributors |
+| `status:claimed` | Claimed by a contributor (see claim flow) |
+| `status:in-progress` | Actively being worked |
+| `status:needs-review` | PR open, awaiting review |
+| `status:changes-requested` | Review feedback awaiting the contributor |
+| `status:needs-rebase` | PR needs a rebase onto `main` |
+| `status:needs-info` | Waiting on information from the reporter |
+| `status:blocked` | Blocked on a decision or dependency; do not pick up |
 
-| Area | Example issues | Suggested action | Notes |
-| ---- | -------------- | ---------------- | ----- |
-| Shipped features (timeline/stats CLI, CI artifact recipe, ai-sdk, logging recipes, safe-sharing checklist) | see GOOD-FIRST-ISSUES "shipped/closed" | Keep closed | Do not reopen |
-| ROADMAP/README alignment | #58 | Close if satisfied by v3.5.6 cleanup | Verify 3.5.5 references landed first |
-| OSS hygiene lane | #9, #18, #19, #67 | Refresh | Point at CONTRIBUTOR-LANES.md |
-| Examples and fixtures lane | #10, #13, #27, #29, #69 | Keep / Refresh | Confirm still open and scoped |
-| Adapter SDK examples lane | #60–#64 | Keep | Align with adapter-sdk docs |
-| UI and performance lane | #65, #66, #68 | Keep | Align with viewer/vscode docs |
-| Standards and graduation lane | #7, #25 | Keep | Feeds v6.4 standards graduation |
+### Priority and difficulty
 
-## Process
+| Label | Meaning |
+| ----- | ------- |
+| `priority:p0` … `priority:p3` | Highest to lower priority |
+| `good first issue` | Safe for new contributors; docs, fixtures, examples |
+| `difficulty:intermediate` | Intermediate contributor work |
+| `difficulty:advanced` | Advanced, high-context work |
 
-1. Confirm the 3.5.5 version references and v4 planning links are live on `main`.
-2. Walk the table above; for each row, verify current issue state in GitHub.
-3. Apply **Keep / Refresh / Close** manually, one issue at a time, with a short human-written comment.
-4. Update [GOOD-FIRST-ISSUES.md](../../GOOD-FIRST-ISSUES.md) if any lane's live-issue list changes.
+### Ownership and area
+
+| Label | Meaning |
+| ----- | ------- |
+| `community-owned` | Suitable for community ownership |
+| `maintainer-owned` | Core API, schema, packaging; requires maintainer coordination |
+| `area:*` | Subsystem (`area:core`, `area:cli`, `area:studio`, `area:community`, …) |
+| `support:*` | Support level of the touched surface (`support:stable` … `support:experimental`) |
+
+Type labels (`bug`, `enhancement`, `documentation`, `security`, `proposal`, `recipe`, …) describe what the issue is; status labels describe where it stands.
+
+## Claim flow
+
+1. Pick an issue labeled `status:ready` and `community-owned` (or `good first issue`).
+2. **Comment on the issue before opening a PR** — one line saying you are taking it is enough.
+3. A maintainer applies `status:claimed`. First come, first served; if someone already claimed it, pick another or offer to collaborate.
+4. Open your PR referencing the issue (`Closes #NNN`). The issue moves to `status:in-progress` / `status:needs-review` as work lands.
+
+One issue per contributor at a time is a good default for first-time contributors.
+
+## Needs-info flow
+
+When a report is missing reproduction steps, versions, or trace samples:
+
+1. A maintainer asks for the missing details and applies `status:needs-info`.
+2. No response after **14 days**: a maintainer posts one reminder.
+3. No response **30 days after the reminder**: the issue may be closed manually with a note that it can be reopened with the requested details.
+
+Reporters: never paste secrets, production logs, or unredacted traces into public issues. Redact first; see [SECURITY.md](../../SECURITY.md) for sensitive reports.
+
+## Draft PR guidance
+
+- Open a **draft PR early** for anything beyond a small fix; it signals progress and invites direction checks before the work is large.
+- Keep drafts out of the review queue: the first-review SLA starts when you mark the PR **ready for review**, not when the draft opens.
+- Before marking ready: validation commands pass locally (see [CONTRIBUTING.md](../../CONTRIBUTING.md)), one concern per PR, no version bumps or Changesets.
+- An open draft PR counts as claimed work for the stale-work policy below.
+
+## Stale-work policy
+
+- **Claimed work is never auto-closed.** No bot closes issues or PRs in this repository; every closure is a manual maintainer action with a human-written comment.
+- A claimed issue with no visible activity for **30 days** gets a friendly check-in, not a closure. If the contributor has gone silent through a full needs-info cycle (14-day reminder plus 30 days), a maintainer may unclaim it (back to `status:ready`) so someone else can pick it up, crediting any partial work.
+- Contributors can unclaim at any time by commenting; that is a normal outcome, not a failure.
+- During the 6.7.2 adoption freeze, prefer unclaiming over closing so scoped work stays visible for the next contributor.
+
+## Maintainer triage pass
+
+1. New issue arrives with `status:needs-triage`.
+2. Check product boundaries: local-first, no vendor sinks, no SaaS scope (see [CONTRIBUTING.md](../../CONTRIBUTING.md)); out-of-scope requests are closed politely with a pointer to [docs/LIMITATIONS.md](../LIMITATIONS.md).
+3. Apply type, `area:*`, `priority:*`, and ownership labels; add `good first issue` or `difficulty:*` where clear.
+4. Move to `status:ready` (or `status:needs-info` / `status:blocked`) and acknowledge within the [REVIEW-SLA.md](./REVIEW-SLA.md) target.
+5. Update [GOOD-FIRST-ISSUES.md](../../GOOD-FIRST-ISSUES.md) if a lane's live-issue list changes.
 
 ## Guardrails
 
 - No automated issue closing or bulk mutation.
-- No changes to issue content beyond maintainer-authored triage comments/labels.
-- Keep triage aligned with [CONTRIBUTOR-LANES.md](./CONTRIBUTOR-LANES.md) and the [canonical roadmap](../implementation/ROADMAP_V3_5_TO_V7.md).
+- No changes to issue content beyond maintainer-authored triage comments and labels.
+- Keep triage aligned with [CONTRIBUTOR-LANES.md](./CONTRIBUTOR-LANES.md) and the current [ROADMAP.md](../../ROADMAP.md).

--- a/docs/community/MAINTAINER-GUIDE.md
+++ b/docs/community/MAINTAINER-GUIDE.md
@@ -93,6 +93,8 @@ After a successful npm publish:
 
 ## Triage labels
 
+Full lifecycle taxonomy (`status:*`, `priority:*`, `difficulty:*`, `area:*`, ownership) and the claim / needs-info / stale-work flows: [ISSUE-TRIAGE.md](./ISSUE-TRIAGE.md). Response-time targets: [REVIEW-SLA.md](./REVIEW-SLA.md).
+
 | Label | Use |
 | ----- | --- |
 | `good first issue` | Safe for new contributors |

--- a/docs/community/REVIEW-SLA.md
+++ b/docs/community/REVIEW-SLA.md
@@ -1,0 +1,41 @@
+# Contributor review SLA
+
+What contributors can expect from maintainers on issues and pull requests, and what maintainers commit to as response targets. These are targets, not guarantees; this is a small-team project and complex changes can take longer. When a target will be missed, a short status comment beats silence.
+
+## Response targets
+
+| Signal | Target |
+| ------ | ------ |
+| Issue acknowledgement | 2 business days |
+| First substantive PR review | 5 business days |
+| Follow-up review (after changes pushed) | 3 business days |
+| Needs-info reminder | 14 days |
+| Potential closure | 30 days after reminder |
+
+Business days exclude weekends. Targets start when the issue or PR is opened, or when the contributor pushes changes after a review.
+
+## What each target means
+
+- **Issue acknowledgement** — a maintainer comment or triage label (`status:needs-triage` replaced with `status:ready`, `status:needs-info`, or similar) confirming the issue was seen.
+- **First substantive PR review** — an actual review pass with approve/request-changes or concrete questions, not just a "thanks, will look" note. Draft PRs are excluded until marked ready for review.
+- **Follow-up review** — the next review pass after the contributor addresses feedback and pushes.
+- **Needs-info reminder** — if an issue or PR sits in `status:needs-info` with no response, a maintainer posts one reminder after 14 days.
+- **Potential closure** — an unclaimed `status:needs-info` item with no response 30 days after the reminder may be closed manually with a note that it can be reopened.
+
+## No automatic closure of claimed work
+
+Work labeled `status:claimed` or `status:in-progress` is **never auto-closed**, by bot or by policy. During the 6.7.2 adoption freeze this matters most: a claimed issue or an open draft PR stays open until the contributor either finishes, unclaims it, or explicitly goes silent through the full needs-info cycle above (reminder, then 30 more days). Closure is always a manual maintainer action with a human-written comment.
+
+## What contributors can do to keep things moving
+
+- Comment on an issue before opening a PR so it can be labeled `status:claimed` (see the claim flow in [ISSUE-TRIAGE.md](./ISSUE-TRIAGE.md)).
+- Open a draft PR early for large changes; mark it ready only when validation passes.
+- Reply to `status:needs-info` requests even if the answer is "still working on it."
+- Keep PRs to one concern so the first review pass fits in the target window.
+
+## Related docs
+
+- [ISSUE-TRIAGE.md](./ISSUE-TRIAGE.md) — claim flow, needs-info flow, stale-work policy, label taxonomy
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — setup, boundaries, validation commands
+- [FIRST-PR-WALKTHROUGH.md](./FIRST-PR-WALKTHROUGH.md) — end-to-end first PR flow
+- [MAINTAINER-GUIDE.md](./MAINTAINER-GUIDE.md) — maintainer-side checklists


### PR DESCRIPTION
## Summary

Implements #101: publishes the contributor review SLA and refreshes the issue triage guide for 6.7.2.

- **New `docs/community/REVIEW-SLA.md`** with the exact targets from the issue (acknowledgement 2 business days, first substantive PR review 5, follow-up review 3, needs-info reminder 14 days, potential closure 30 days after the reminder), what each target means in practice (draft PRs excluded until marked ready, follow-up clock starts on push), and an explicit **no automatic closure of claimed work** section tied to the adoption freeze.
- **Rewritten `docs/community/ISSUE-TRIAGE.md`**: the old file was a one-off v3.5.6 triage task list with a stale issue table. It is now a standing guide covering the current label taxonomy (`status:*`, `priority:*`, `difficulty:*`, ownership, `area:*`, `support:*`, all verified against the live label set), the claim flow (comment before PR, `status:claimed`), the needs-info flow (14-day reminder, manual closure 30 days later, reopenable), draft PR guidance, and a stale-work policy where claimed work gets a check-in and at most an unclaim back to `status:ready`, never an auto-close. The manual-only guardrails from the old file are kept; nothing here adds or promises bots.
- **Links** added from `CONTRIBUTING.md` (where to start) and `docs/community/MAINTAINER-GUIDE.md` (triage labels section).

Per the issue's out-of-scope list: no automation, no permission changes, no staffing promises beyond the SLA numbers, no runtime changes, no Changeset.

Closes #101

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] `@agent-inspect/studio` (support:preview)

Docs only, no packages touched.

## Validation

```bash
pnpm docs:check  # OK (link + public truth checks)
pnpm public-truth:check  # OK (version 6.7.2, 18 fixed packages)
pnpm typecheck  # pass
pnpm test  # 1506/1506 pass
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed) - docs only, no behavior change
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
