### PR TITLE
feat(examples): add adpa-codebase-change-trace recipe

### DIFF
--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -64,6 +64,7 @@ Use `AGENT_INSPECT_SILENT=true` to suppress live terminal tree output during scr
 | [circuit-breaker-basic](circuit-breaker-basic) | v2.5 circuit repetition analysis | `@agent-inspect/circuit`, tool/args repetition | yes | no |
 | [read-only-mcp-server](read-only-mcp-server) | v2.6 read-only MCP trace tools | `@agent-inspect/mcp-server`, list/search/check tools | yes | no |
 | [workspace-basic](workspace-basic) | v4.0 local trace workspace | `agent-inspect/workspace`, create/status | yes | no |
+| [adpa-codebase-change-trace](adpa-codebase-change-trace) | ADPA-style intent → contract → docs → change → validation review trace | `inspectRun`, `step`, `observeOutcome`, safe governance/Langfuse references, share-safe report/bundle | yes | no |
 
 ## Multi-run sessions (v2.4)
 

--- a/examples/recipes/adpa-codebase-change-trace/README.md
+++ b/examples/recipes/adpa-codebase-change-trace/README.md
@@ -1,0 +1,88 @@
+# ADPA codebase-change trace
+
+Local, redacted review artifact for an ADPA-style codebase change. AgentInspect acts as **read-only local observability** beside Langfuse (prompt/model observability) and ADPA's governance layer (single-writer state transitions, append-only ledger). It does not duplicate those systems or write back into them.
+
+The trace shows the full change sequence a reviewer needs when something breaks:
+
+```text
+run: adpa-codebase-change
+├─ intent:rpas-declared
+├─ contract:jest-test-written
+├─ docs:skills-md-updated
+├─ implementation:codebase-adjustment
+├─ validation:isolated-contract
+├─ [outcome] isolatedContractPassed
+├─ validation:full-jest-suite
+└─ [outcome] fullSuitePassed
+```
+
+## Run
+
+```bash
+pnpm install   # once, at the repo root
+cd examples/recipes/adpa-codebase-change-trace
+pnpm start
+```
+
+The demo is deterministic (mock data only, no ADPA or Langfuse dependency, no network). It writes a trace to `./.agent-inspect-runs` and prints copy-paste commands with the generated run id.
+
+## Produce the review artifact
+
+Redacted markdown report (run id comes from the `pnpm start` output or `npx agent-inspect list --dir ./.agent-inspect-runs`):
+
+```bash
+npx agent-inspect report <run-id> --dir ./.agent-inspect-runs --redaction-profile share -o ./review-report.md
+```
+
+The report includes the what-happened summary, the step timeline in the exact intent -> contract -> docs -> change -> validation order, and an observed-outcomes table for the two validation gates.
+
+Share-safe offline bundle, by run id or by the stable session id:
+
+```bash
+npx agent-inspect bundle <run-id> --dir ./.agent-inspect-runs --profile share --out ./bundle-out
+npx agent-inspect bundle --session sess-adpa-change-demo --dir ./.agent-inspect-runs --profile share --out ./bundle-out
+```
+
+The bundle runs safety checks before packing (this recipe's trace passes them) and ships `summary.md`, `check-results.json`, `redaction-report.json`, and an HTML tree view.
+
+Search the validation outcomes:
+
+```bash
+npx agent-inspect search --dir ./.agent-inspect-runs --observation passed
+```
+
+## Metadata shape
+
+The run carries one structured metadata block covering the whole workflow:
+
+```json
+{
+  "workflow": "adpa-codebase-change",
+  "sessionId": "sess-adpa-change-demo",
+  "intent": { "source": "rpas", "id": "intent_123", "summary": "change declared before implementation" },
+  "contract": { "testFile": "__tests__/example.contract.test.ts", "mode": "jest-first" },
+  "documentation": { "skillsFile": "skills/Skills.md", "updated": true },
+  "implementation": { "changedFiles": ["src/example.ts"] },
+  "validation": { "isolatedContract": "passed", "fullSuite": "passed" },
+  "governance": { "mode": "read-only-reference", "ledgerEntryId": "ledger_abc", "captureBoundary": "write tokens and ledger contents not captured" },
+  "observability": { "langfuseTraceId": "optional-reference-only" }
+}
+```
+
+Note on `captureBoundary`: AgentInspect's share-safety gate treats metadata keys containing `token` as sensitive-looking and refuses to bundle them unredacted, by design. So instead of a `writeTokenScope: "not captured"` field, the recipe states the same boundary under a neutral key. If you need a token-named key, the bundle safety check will force you to redact it first, which is the right default.
+
+## External references: safe IDs only
+
+- **Langfuse** — record only the trace id (`observability.langfuseTraceId`) so a reviewer can pivot to Langfuse themselves. Do not copy prompts, completions, or model traces into the AgentInspect trace; Langfuse already owns those.
+- **ADPA governance** — record only the ledger entry id (`governance.ledgerEntryId`) as an opaque string reference and set `governance.mode` to `"read-only-reference"`. Do not capture ledger contents, state-transition payloads, or anything the single writer owns.
+- If ledger ids are themselves sensitive in your deployment, store a hash or a redacted placeholder instead of the raw id; the field is a reference, not evidence.
+
+## Safety note
+
+Never capture scoped write tokens, secrets, or sensitive ledger contents in trace metadata. Generate review artifacts with `--redaction-profile share` (report) or `--profile share` (bundle) and review the output before sharing, as with any trace. The bundle command independently verifies safety and refuses to pack traces with unredacted sensitive-looking fields.
+
+## Modeling choices
+
+- **RPAS intent** is a named step (`intent:rpas-declared`) plus an `intent` metadata block, so it shows up both in the sequence and in the run summary.
+- **Validation** is modeled as both a step and an observed outcome (`method: "custom"` with `runner: "jest"` in the evidence). On failure, let the Jest step throw (a failed step with the error) and record the observed outcome with `status: "failed"`; the step shows where it broke, the outcome makes it searchable (`npx agent-inspect search --dir ./.agent-inspect-runs --observation failed`).
+- This recipe is optional and independent of ADPA internals; it makes no compliance claims.

--- a/examples/recipes/adpa-codebase-change-trace/expected-output.txt
+++ b/examples/recipes/adpa-codebase-change-trace/expected-output.txt
@@ -1,0 +1,17 @@
+ADPA codebase-change trace written
+Trace directory: ./.agent-inspect-runs
+Run id: run_p2MWboavgk
+
+Sequence: intent -> contract -> docs update -> code change
+          -> isolated validation -> full validation
+
+Governance and Langfuse fields are safe references only.
+Not captured: write tokens, secrets, prompts, ledger contents.
+
+Redacted review report:
+  npx agent-inspect report run_p2MWboavgk --dir ./.agent-inspect-runs --redaction-profile share -o ./review-report.md
+Share-safe offline bundle (by run or by session):
+  npx agent-inspect bundle run_p2MWboavgk --dir ./.agent-inspect-runs --profile share --out ./bundle-out
+  npx agent-inspect bundle --session sess-adpa-change-demo --dir ./.agent-inspect-runs --profile share --out ./bundle-out
+Search validation outcomes:
+  npx agent-inspect search --dir ./.agent-inspect-runs --observation passed

--- a/examples/recipes/adpa-codebase-change-trace/package.json
+++ b/examples/recipes/adpa-codebase-change-trace/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agent-inspect-recipe-adpa-codebase-change-trace",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/recipes/adpa-codebase-change-trace/src/index.ts
+++ b/examples/recipes/adpa-codebase-change-trace/src/index.ts
@@ -1,0 +1,157 @@
+/**
+ * adpa-codebase-change-trace — local, read-only review trace for an
+ * ADPA-style codebase change: RPAS intent -> Jest contract -> Skills.md
+ * update -> codebase adjustment -> isolated validation -> full suite.
+ *
+ * AgentInspect sits BESIDE ADPA governance and Langfuse observability as
+ * read-only local observability. Only safe references are recorded:
+ * ledger entry ids and Langfuse trace ids as opaque strings. Never scoped
+ * write tokens, secrets, prompts, or ledger contents.
+ */
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { inspectRun, observeOutcome, step } from "agent-inspect";
+
+const silent = process.env.AGENT_INSPECT_SILENT !== "false";
+const traceDir = path.join(process.cwd(), ".agent-inspect-runs");
+const sessionId = "sess-adpa-change-demo";
+
+// Deterministic fake workflow context. Safe fields only: identifiers,
+// repo-relative file paths, and pass/fail summaries. writeTokenScope is
+// deliberately recorded as "not captured" so reviewers can see the
+// governance boundary was respected.
+const workflowMetadata = {
+  workflow: "adpa-codebase-change",
+  sessionId,
+  intent: {
+    source: "rpas",
+    id: "intent_123",
+    summary: "change declared before implementation",
+  },
+  contract: {
+    testFile: "__tests__/example.contract.test.ts",
+    mode: "jest-first",
+  },
+  documentation: {
+    skillsFile: "skills/Skills.md",
+    updated: true,
+  },
+  implementation: {
+    changedFiles: ["src/example.ts"],
+  },
+  validation: {
+    isolatedContract: "passed",
+    fullSuite: "passed",
+  },
+  governance: {
+    mode: "read-only-reference",
+    ledgerEntryId: "ledger_abc",
+    // Key names containing "token" trip the share-safety gate by design,
+    // so the boundary is stated under a neutral key instead of
+    // writeTokenScope: "not captured".
+    captureBoundary: "write tokens and ledger contents not captured",
+  },
+  observability: {
+    langfuseTraceId: "optional-reference-only",
+  },
+};
+
+await inspectRun(
+  "adpa-codebase-change",
+  async () => {
+    await step(
+      "intent:rpas-declared",
+      async () => ({
+        intentId: "intent_123",
+        summary: "change declared before implementation",
+      }),
+      { metadata: { source: "rpas" } },
+    );
+
+    await step(
+      "contract:jest-test-written",
+      async () => ({
+        testFile: "__tests__/example.contract.test.ts",
+        mode: "jest-first",
+      }),
+      { metadata: { intentId: "intent_123" } },
+    );
+
+    await step("docs:skills-md-updated", async () => ({
+      skillsFile: "skills/Skills.md",
+      updated: true,
+    }));
+
+    await step(
+      "implementation:codebase-adjustment",
+      async () => ({ changedFiles: ["src/example.ts"] }),
+      { metadata: { intentId: "intent_123" } },
+    );
+
+    await step("validation:isolated-contract", async () => ({
+      status: "passed",
+      tests: 1,
+    }));
+    await observeOutcome("isolatedContractPassed", {
+      expectation: "New contract test passes in isolation",
+      status: "passed",
+      method: "custom",
+      evidence: { runner: "jest", testFile: "__tests__/example.contract.test.ts" },
+    });
+
+    await step("validation:full-jest-suite", async () => ({
+      status: "passed",
+      suites: 12,
+      failures: 0,
+    }));
+    await observeOutcome("fullSuitePassed", {
+      expectation: "All Jest test contracts pass after the change",
+      status: "passed",
+      method: "custom",
+      evidence: { runner: "jest", suites: 12, failures: 0 },
+    });
+
+    return "review-ready";
+  },
+  { silent, traceDir, metadata: workflowMetadata },
+);
+
+// Run ids are generated (run_xxx). Find the newest trace so the commands
+// below are copy-paste ready.
+let runId = "<run-id>";
+let newest = -1;
+for (const file of await readdir(traceDir)) {
+  if (!file.endsWith(".jsonl")) continue;
+  const info = await stat(path.join(traceDir, file));
+  if (info.mtimeMs > newest) {
+    newest = info.mtimeMs;
+    runId = file.slice(0, -".jsonl".length);
+  }
+}
+
+console.log("ADPA codebase-change trace written");
+console.log("Trace directory: ./.agent-inspect-runs");
+console.log(`Run id: ${runId}`);
+console.log("");
+console.log("Sequence: intent -> contract -> docs update -> code change");
+console.log("          -> isolated validation -> full validation");
+console.log("");
+console.log("Governance and Langfuse fields are safe references only.");
+console.log("Not captured: write tokens, secrets, prompts, ledger contents.");
+console.log("");
+console.log("Redacted review report:");
+console.log(
+  `  npx agent-inspect report ${runId} --dir ./.agent-inspect-runs --redaction-profile share -o ./review-report.md`,
+);
+console.log("Share-safe offline bundle (by run or by session):");
+console.log(
+  `  npx agent-inspect bundle ${runId} --dir ./.agent-inspect-runs --profile share --out ./bundle-out`,
+);
+console.log(
+  `  npx agent-inspect bundle --session ${sessionId} --dir ./.agent-inspect-runs --profile share --out ./bundle-out`,
+);
+console.log("Search validation outcomes:");
+console.log(
+  "  npx agent-inspect search --dir ./.agent-inspect-runs --observation passed",
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,15 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/recipes/adpa-codebase-change-trace:
+    dependencies:
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/recipes/ai-sdk-local-telemetry:
     dependencies:
       '@agent-inspect/ai-sdk':

--- a/scripts/validate-recipes.mjs
+++ b/scripts/validate-recipes.mjs
@@ -47,6 +47,7 @@ const RECIPES = [
   "trace-suite-basic",
   "cohort-baseline-candidate",
   "github-actions-gate",
+  "adpa-codebase-change-trace",
 ];
 
 const LOG_RECIPE_FILES = {


### PR DESCRIPTION
## Summary

Implements #115: `examples/recipes/adpa-codebase-change-trace/`, a deterministic local recipe that produces a redacted review artifact for an ADPA-style codebase change, with AgentInspect as read-only observability beside Langfuse and ADPA governance.

- **Trace sequence** exactly as specified: `intent:rpas-declared` → `contract:jest-test-written` → `docs:skills-md-updated` → `implementation:codebase-adjustment` → `validation:isolated-contract` → `validation:full-jest-suite`, with the two validation gates additionally recorded as observed outcomes so they land in the report's outcomes table and are searchable (`--observation failed` when something breaks).
- **Metadata block** follows the issue's proposed shape (workflow, intent, contract, documentation, implementation, validation, governance with `mode: "read-only-reference"`, observability with a Langfuse trace id as reference only).
- **Review artifacts verified end to end**: `report --redaction-profile share` writes a markdown report with the what/timeline/outcomes sections; `bundle --profile share` (by run id or by the stable `sess-adpa-change-demo` session id) passes the safety checks and packs summary, check results, redaction report, and HTML tree. The script prints copy-paste commands with the generated run id.
- **Boundaries respected**: no ADPA or Langfuse dependency, no network, no writes into governance, mock data only, no compliance claims. Registered in `scripts/validate-recipes.mjs` and the recipes README index; standard recipe layout (private package.json with tsx, `src/index.ts`, README, non-empty expected-output.txt).

### One deliberate deviation, and answers to the open questions

The issue's example metadata has `governance.writeTokenScope: "not captured"`. Any metadata key containing `token` trips the bundle share-safety gate (`safety.redaction` error: sensitive-looking field not redacted), which is the right default but would make the recipe's own bundle command fail. The recipe states the same boundary under `governance.captureBoundary: "write tokens and ledger contents not captured"` and the README documents why. On the other open questions, the README documents the choices: `ledgerEntryId` as an opaque string reference (hash it if ids are sensitive in your deployment), RPAS intent as a named step plus an `intent` metadata block, and failed Jest validation as both a failed step and a failed observed outcome.

Closes #115

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] `@agent-inspect/studio` (support:preview)

Examples workspace only (plus the recipe registration in `scripts/validate-recipes.mjs`, the recipes README index, and the lockfile entry for the new workspace package).

## Validation

```bash
pnpm recipes:check  # OK, 38 recipes validated
pnpm docs:check  # OK
pnpm typecheck  # pass
pnpm test  # 1506/1506 pass
cd examples/recipes/adpa-codebase-change-trace && pnpm start  # deterministic, output matches expected-output.txt
# then, verified manually:
npx agent-inspect report <run-id> --dir ./.agent-inspect-runs --redaction-profile share -o ./review-report.md  # written
npx agent-inspect bundle <run-id> --dir ./.agent-inspect-runs --profile share --out ./bundle-out  # SAFE WITH WARNINGS (sessionId detector warning, same as shareable-bundle-basic)
npx agent-inspect bundle --session sess-adpa-change-demo --dir ./.agent-inspect-runs --profile share --out ./bundle-out  # same
npx agent-inspect search --dir ./.agent-inspect-runs --observation passed  # both outcomes found
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed) - recipe validated by recipes:check and run end to end; no runtime changes
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - recipe README + recipes index
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
