### PR TITLE
fix(examples): print generated run ids in recipe CLI commands

### DIFF
--- a/examples/recipes/shareable-bundle-basic/README.md
+++ b/examples/recipes/shareable-bundle-basic/README.md
@@ -19,10 +19,10 @@ pnpm install
 pnpm start
 ```
 
-Then create a bundle from the generated trace:
+Then create a bundle from the generated trace. Run ids are generated (`run_xxx`), so copy the `Run id:` the recipe prints:
 
 ```bash
-npx agent-inspect bundle bundle-recipe-run \
+npx agent-inspect bundle <run-id> \
   --dir ./.agent-inspect \
   --out ./bundle-out \
   --json

--- a/examples/recipes/shareable-bundle-basic/expected-output.txt
+++ b/examples/recipes/shareable-bundle-basic/expected-output.txt
@@ -1,9 +1,11 @@
 Shareable bundle recipe trace written
 Trace directory: ./.agent-inspect
-Run id: bundle-recipe-run
+Run id: run_jV3MRnSkTF
 
 Create a share-safe offline bundle:
-  npx agent-inspect bundle bundle-recipe-run --dir ./.agent-inspect --out ./bundle-out --json
+  npx agent-inspect bundle run_jV3MRnSkTF --dir ./.agent-inspect --out ./bundle-out --json
 
 Bundle by session:
   npx agent-inspect bundle --session sess-bundle-demo --dir ./.agent-inspect
+
+(The run id is generated per run; copy the one your run prints.)

--- a/examples/recipes/shareable-bundle-basic/src/index.ts
+++ b/examples/recipes/shareable-bundle-basic/src/index.ts
@@ -1,16 +1,17 @@
 /**
  * shareable-bundle-basic — write a local trace and print bundle commands.
  */
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { inspectRun, step } from "agent-inspect";
 
 const silent = process.env.AGENT_INSPECT_SILENT !== "false";
 const traceDir = path.join(process.cwd(), ".agent-inspect");
-const runId = "bundle-recipe-run";
+const runName = "bundle-recipe-run";
 
 await inspectRun(
-  runId,
+  runName,
   async () => {
     await step("plan", async () => ({ route: "bundle-demo" }));
     return await step.tool("lookup", async () => ({ matches: 1 }));
@@ -21,6 +22,19 @@ await inspectRun(
     metadata: { recipe: "shareable-bundle-basic", sessionId: "sess-bundle-demo" },
   },
 );
+
+// Run ids are generated (run_xxx), not the inspectRun name. Find the newest
+// trace so the commands below are copy-paste ready.
+let runId = "<run-id>";
+let newest = -1;
+for (const file of await readdir(traceDir)) {
+  if (!file.endsWith(".jsonl")) continue;
+  const info = await stat(path.join(traceDir, file));
+  if (info.mtimeMs > newest) {
+    newest = info.mtimeMs;
+    runId = file.slice(0, -".jsonl".length);
+  }
+}
 
 console.log("Shareable bundle recipe trace written");
 console.log(`Trace directory: ${traceDir}`);

--- a/examples/recipes/what-report-inspect/README.md
+++ b/examples/recipes/what-report-inspect/README.md
@@ -23,12 +23,12 @@ pnpm install
 pnpm start
 ```
 
-Then run the printed CLI commands, or:
+Then run the printed CLI commands. Run ids are generated (`run_xxx`), so copy the `Run id:` the recipe prints:
 
 ```bash
-npx agent-inspect what what-report-recipe --dir ./.agent-inspect-runs
-npx agent-inspect report what-report-recipe --dir ./.agent-inspect-runs --format markdown
-npx agent-inspect report what-report-recipe --dir ./.agent-inspect-runs \
+npx agent-inspect what <run-id> --dir ./.agent-inspect-runs
+npx agent-inspect report <run-id> --dir ./.agent-inspect-runs --format markdown
+npx agent-inspect report <run-id> --dir ./.agent-inspect-runs \
   --format html --redaction-profile share -o ./report.html
 ```
 

--- a/examples/recipes/what-report-inspect/expected-output.txt
+++ b/examples/recipes/what-report-inspect/expected-output.txt
@@ -1,7 +1,11 @@
 
 Result: Fixture answer (2 hits)
 
+Run id: run_4ekECagWbZ
+
 Inspect this run:
-  npx agent-inspect what what-report-recipe --dir /path/to/.agent-inspect-runs
-  npx agent-inspect report what-report-recipe --dir /path/to/.agent-inspect-runs --format markdown
-  npx agent-inspect report what-report-recipe --dir /path/to/.agent-inspect-runs --format html -o ./report.html
+  npx agent-inspect what run_4ekECagWbZ --dir /path/to/.agent-inspect-runs
+  npx agent-inspect report run_4ekECagWbZ --dir /path/to/.agent-inspect-runs --format markdown
+  npx agent-inspect report run_4ekECagWbZ --dir /path/to/.agent-inspect-runs --format html -o ./report.html
+
+(The run id is generated per run; copy the one your run prints.)

--- a/examples/recipes/what-report-inspect/src/index.ts
+++ b/examples/recipes/what-report-inspect/src/index.ts
@@ -2,6 +2,7 @@
  * v1.5 inspection workflow: write a trace, then summarize with what/report.
  * No network calls — CLI commands are documented for local or CI use.
  */
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { inspectRun, step } from "agent-inspect";
@@ -31,10 +32,24 @@ const answer = await inspectRun(
   },
 );
 
+// Run ids are generated (run_xxx), not the inspectRun name. Find the newest
+// trace so the commands below are copy-paste ready.
+let runId = "<run-id>";
+let newest = -1;
+for (const file of await readdir(traceDir)) {
+  if (!file.endsWith(".jsonl")) continue;
+  const info = await stat(path.join(traceDir, file));
+  if (info.mtimeMs > newest) {
+    newest = info.mtimeMs;
+    runId = file.slice(0, -".jsonl".length);
+  }
+}
+
 console.log("\nResult:", answer);
+console.log(`\nRun id: ${runId}`);
 console.log("\nInspect this run:");
-console.log(`  npx agent-inspect what ${runName} --dir ${traceDir}`);
-console.log(`  npx agent-inspect report ${runName} --dir ${traceDir} --format markdown`);
+console.log(`  npx agent-inspect what ${runId} --dir ${traceDir}`);
+console.log(`  npx agent-inspect report ${runId} --dir ${traceDir} --format markdown`);
 console.log(
-  `  npx agent-inspect report ${runName} --dir ${traceDir} --format html -o ./report.html`,
+  `  npx agent-inspect report ${runId} --dir ${traceDir} --format html -o ./report.html`,
 );


### PR DESCRIPTION
## Summary

Fixes #144: `shareable-bundle-basic` and `what-report-inspect` printed copy-paste CLI commands built from the `inspectRun` run name, but run ids are always generated (`run_xxx`) and the CLI resolves a run reference strictly as `<traceDir>/<runId>.jsonl` (`packages/cli/src/read-run.ts`), so every printed command failed with "Run not found" (exit 1). `shareable-bundle-basic` also labeled the run name as `Run id:` in its output.

Changes, examples-only:

- Both recipes now discover the generated run id from the trace directory after the run completes (newest `.jsonl` basename, the same pattern `adpa-codebase-change-trace` uses) and interpolate it into the printed `bundle` / `what` / `report` commands. `what-report-inspect` now also prints a `Run id:` line so there is something to copy.
- READMEs switch the hardcoded run name to a `<run-id>` placeholder with a note to copy the id the recipe prints.
- `expected-output.txt` files updated from actual runs, with a trailing note that the id is generated per run.

Not changed: CLI run resolution. A run-name lookup would be a real behavior change (names are not unique across runs) and does not look freeze-appropriate; noted in #144 as a possible follow-up discussion. `langgraph-callback-local` and the import/fixture recipes are unaffected because they control their persisted ids.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [ ] `@agent-inspect/studio` (support:preview)

Examples only, no packages touched.

## Validation

```bash
pnpm recipes:check  # OK — 37 recipes validated
# end-to-end, both recipes:
#   pnpm start, then every printed command run verbatim:
#   bundle <run-id> --json         -> ok:true, SAFE WITH WARNINGS, exit 0
#   bundle --session sess-bundle-demo -> exit 0
#   what <run-id>                  -> exit 0
#   report <run-id> --format markdown / --format html -o ./report.html -> exit 0, report.html written
# before the fix, the printed commands exit 1 with "Run not found"
```

## Checklist

- [x] Tests added or updated (if behavior changed) - recipe scripts are validated by recipes:check plus the end-to-end runs above; no unit-test surface
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate)
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
