### PR TITLE
fix(studio): make basic-auth password check constant-time

### DIFF
--- a/packages/studio/src/auth.ts
+++ b/packages/studio/src/auth.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 
 import type { StudioServerOptions } from "./types.js";
@@ -26,6 +27,17 @@ function parseBasicAuth(header: string | undefined): string | undefined {
   }
 }
 
+/**
+ * Constant-time password comparison. Hashing both sides first keeps the
+ * buffers equal length (required by timingSafeEqual) without leaking the
+ * expected password length.
+ */
+function timingSafePasswordEqual(provided: string, expected: string): boolean {
+  const providedDigest = createHash("sha256").update(provided, "utf8").digest();
+  const expectedDigest = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+}
+
 export function isStudioRequestAuthorized(
   req: IncomingMessage,
   options: StudioServerOptions,
@@ -35,7 +47,8 @@ export function isStudioRequestAuthorized(
   const expected = resolveStudioPassword(options);
   if (!expected) return false;
   const provided = parseBasicAuth(req.headers.authorization);
-  return provided === expected;
+  if (provided === undefined) return false;
+  return timingSafePasswordEqual(provided, expected);
 }
 
 export function studioAuthRequiredResponse(): {

--- a/packages/studio/test/auth.test.ts
+++ b/packages/studio/test/auth.test.ts
@@ -1,10 +1,12 @@
 import http from "node:http";
+import type { IncomingMessage } from "node:http";
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { isStudioRequestAuthorized } from "../src/auth.js";
 import { createStudioContext, createStudioServer } from "../src/index.js";
 
 async function getJson(baseUrl: string, route: string, headers: Record<string, string> = {}) {
@@ -64,5 +66,57 @@ describe("studio auth", () => {
     const authHeader = `Basic ${Buffer.from(`studio:secret`).toString("base64")}`;
     const allowed = await getJson(baseUrl, "/api/health", { Authorization: authHeader });
     expect(allowed.status).toBe(200);
+  });
+});
+
+describe("isStudioRequestAuthorized", () => {
+  const passwordEnv = "STUDIO_AUTH_UNIT_PASSWORD";
+  const options = { auth: "basic" as const, passwordEnv };
+
+  function fakeReq(authorization?: string): IncomingMessage {
+    return { headers: authorization ? { authorization } : {} } as IncomingMessage;
+  }
+
+  function basicHeader(user: string, password: string): string {
+    return `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+  }
+
+  beforeEach(() => {
+    process.env[passwordEnv] = "correct-password";
+  });
+
+  afterEach(() => {
+    delete process.env[passwordEnv];
+  });
+
+  it("accepts the exact password for any username", () => {
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "correct-password")), options)).toBe(true);
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("someone-else", "correct-password")), options)).toBe(true);
+  });
+
+  it("rejects a wrong password of the same length", () => {
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "correct-passwore")), options)).toBe(false);
+  });
+
+  it("rejects passwords of a different length", () => {
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "correct")), options)).toBe(false);
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "correct-password-longer")), options)).toBe(false);
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "")), options)).toBe(false);
+  });
+
+  it("rejects a missing or malformed authorization header", () => {
+    expect(isStudioRequestAuthorized(fakeReq(), options)).toBe(false);
+    expect(isStudioRequestAuthorized(fakeReq("Bearer correct-password"), options)).toBe(false);
+    const noColon = `Basic ${Buffer.from("no-colon-here").toString("base64")}`;
+    expect(isStudioRequestAuthorized(fakeReq(noColon), options)).toBe(false);
+  });
+
+  it("rejects everything when the password env var is unset", () => {
+    delete process.env[passwordEnv];
+    expect(isStudioRequestAuthorized(fakeReq(basicHeader("studio", "correct-password")), options)).toBe(false);
+  });
+
+  it("allows requests when auth mode is none", () => {
+    expect(isStudioRequestAuthorized(fakeReq(), {})).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #145: `isStudioRequestAuthorized` compared the provided basic-auth password against the expected one with plain `===` (`packages/studio/src/auth.ts`). String comparison short-circuits at the first mismatching character, so response timing leaks how many leading characters of the password are correct, and this check guards every studio route.

The fix compares sha256 digests of both values with `crypto.timingSafeEqual`. Hashing both sides first keeps the buffers equal length (a `timingSafeEqual` requirement) and avoids leaking the expected password length. `node:crypto` only, no new dependencies, no API or behavior change: every input that was accepted or rejected before is accepted or rejected the same way, including missing and malformed headers.

Practical exposure is limited since studio is `support:preview` and typically bound locally, but the fix is small and the pattern is standard.

New unit tests pin the accept/reject matrix directly against `isStudioRequestAuthorized` (no server or sqlite needed): exact match for any username, same-length wrong password, shorter/longer/empty passwords, missing/`Bearer`/no-colon headers, unset password env, and `auth` mode `none`. To be explicit: these tests pass before and after the fix by design, because the fix changes timing characteristics, not accept/reject results — they are regression pins for the behavior the fix must preserve. The existing end-to-end 401/200 test also still passes.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] `schemaVersion: "0.1"` manual traces remain compatible (or breaking change is documented for v2)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged (unless issue explicitly requested opt-out)

## Packages touched

- [ ] `agent-inspect` (root)
- [ ] `@agent-inspect/core`
- [ ] `@agent-inspect/cli`
- [ ] `@agent-inspect/langchain`
- [ ] `@agent-inspect/tui`
- [x] `@agent-inspect/studio` (support:preview)

## Validation

```bash
pnpm typecheck  # pass
pnpm test  # 1523/1523 pass (includes the 6 new auth unit tests)
git diff --check  # clean
```

## Checklist

- [x] Tests added or updated (if behavior changed) - 6 new unit tests pinning the auth accept/reject matrix
- [x] Docs updated (`docs/`, `README.md`, or community docs as appropriate) - not needed, internal hardening with no user-facing change
- [x] No new runtime dependencies without approval
- [x] No version bump in this PR (Changesets used for releases)
- [x] No secrets, production logs, or real PII in commits
