### PR TITLE
docs: add LangChain persisted trace walkthrough

### DIFF
--- a/examples/recipes/langgraph-callback-local/README.md
+++ b/examples/recipes/langgraph-callback-local/README.md
@@ -22,8 +22,15 @@ pnpm --filter agent-inspect-recipe-langgraph-callback-local start
 Then inspect the local output:
 
 ```bash
+npx agent-inspect list --dir ./examples/recipes/langgraph-callback-local/.agent-inspect-runs
 npx agent-inspect view run_langgraph_callback_recipe --dir ./examples/recipes/langgraph-callback-local/.agent-inspect-runs --summary
+npx agent-inspect report run_langgraph_callback_recipe --dir ./examples/recipes/langgraph-callback-local/.agent-inspect-runs
 ```
+
+`persist: true` writes the callback events to the configured local `traceDir`.
+The recipe uses `capture: "metadata-only"`, so prompts, tool payloads, outputs,
+stream tokens, and graph state are excluded from the persisted trace. No API
+keys, hosted service, or network access are required.
 
 ## Expected output
 
@@ -35,6 +42,12 @@ See `expected-output.txt`.
 - Parent mapping follows callback parent IDs when they are present; AgentInspect does not infer missing graph edges by timestamp.
 - `capture: "metadata-only"` keeps raw graph state, prompts, tool payloads, outputs, stream tokens, and checkpoint state out of persisted traces.
 - `stream: true` records streaming counts and timing metadata without writing per-token events.
+
+## Before sharing a trace
+
+The trace stays local unless you choose to share it. Review the exact export and
+follow the [safe trace sharing checklist](../../../docs/SAFE-TRACE-SHARING.md)
+before attaching any trace or report to an issue, PR, or support thread.
 
 ## Notes and limitations
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -51,7 +51,17 @@ const handler = new AgentInspectCallback({
 
 ## CLI
 
-`npx agent-inspect view` · `check` · `eval`
+With `persist: true`, use the same directory configured in `traceDir`:
+
+```bash
+npx agent-inspect list --dir ./.agent-inspect
+npx agent-inspect view <run-id> --dir ./.agent-inspect --summary
+npx agent-inspect report <run-id> --dir ./.agent-inspect
+```
+
+Persisted traces remain local. Before sharing an export or report, follow the
+[safe trace sharing checklist](https://github.com/rajudandigam/agent-inspect/blob/main/docs/SAFE-TRACE-SHARING.md)
+and review the generated artifact for sensitive metadata.
 
 ## Docs
 


### PR DESCRIPTION
## Summary

- extend the existing LangGraph callback recipe with the full persisted-trace `list`, `view`, and `report` flow
- explain `persist: true`, the configured local trace directory, and metadata-only capture boundaries
- link the safe trace sharing checklist from both the recipe and LangChain package README

Closes #29.

## Scope

Docs/examples only. No LangChain streaming, API, dependency, schema, or network behavior changes.

## Validation

- `node scripts/validate-recipes.mjs`
- `node scripts/validate-doc-commands.mjs`
- `node scripts/validate-doc-links.mjs`
- `node scripts/validate-public-truth.mjs`
- `tsc --noEmit`
- `git diff --check`

I also ran the full Vitest suite: 1,451 tests passed and 30 skipped. The remaining 36 failures are environment-only: the local supply-chain policy blocked the `better-sqlite3` native build, and existing path-resolution tests fail under this checkout's non-ASCII parent path. Neither failure area is touched by this Markdown-only change.
