### PR TITLE
fix(core): report completed run status from RUN lifecycle

### DIFF
--- a/packages/cli/test/explain.test.ts
+++ b/packages/cli/test/explain.test.ts
@@ -119,6 +119,19 @@ describe("explain CLI", () => {
     expect(out).toContain("Generated locally without provider or network calls.");
   });
 
+  it("reports a completed run as success, matching list/view", async () => {
+    await writeTrace();
+
+    await explainCommand("explain-run", { dir: tmpDir, json: true });
+
+    const parsed = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+    expect(parsed.explanation.status).toBe("success");
+    const statusFact = parsed.explanation.facts.find(
+      (f: { id: string }) => f.id === "run.status",
+    );
+    expect(statusFact?.value).toBe("success");
+  });
+
   it("handles unsupported input as a user-facing error", async () => {
     await explainCommand(path.join(tmpDir, "missing.jsonl"), { json: true });
 

--- a/packages/core/src/explain.ts
+++ b/packages/core/src/explain.ts
@@ -42,6 +42,18 @@ interface FlatNode {
   index: number;
 }
 
+/**
+ * Maps the reader run-tree status vocabulary ("ok"/"error"/"running") to the
+ * user-facing status vocabulary that list/view/stats report ("success"/...),
+ * so explain agrees with the other commands for the same run.
+ */
+function toDisplayStatus(status: InspectRunTree["status"] | undefined): string {
+  if (status === "ok") return "success";
+  if (status === "error") return "error";
+  if (status === "running") return "running";
+  return "unknown";
+}
+
 function flatten(nodes: InspectNode[], out: FlatNode[] = []): FlatNode[] {
   for (const node of nodes) {
     out.push({ node, index: out.length + 1 });
@@ -121,7 +133,7 @@ function buildFacts(run: InspectRunTree, redactor: Redactor): ExplainFact[] {
   const facts = [
     fact("run.id", "Run id", run.runId, redactor),
     fact("run.name", "Run name", run.name ?? run.runId, redactor),
-    fact("run.status", "Run status", run.status ?? "unknown", redactor),
+    fact("run.status", "Run status", toDisplayStatus(run.status), redactor),
     fact("run.totalEvents", "Total events", run.metadata.totalEvents, redactor),
     fact("run.stepCount", "Top-level step count", run.children.length, redactor),
     fact("run.nodeCount", "Total node count", nodes.length, redactor),
@@ -212,7 +224,7 @@ export function buildLocalExplanation(
     mode,
     runId: String(redactValue(redactor, "runId", run.runId)),
     ...(run.name !== undefined ? { name: String(redactValue(redactor, "name", run.name)) } : {}),
-    ...(run.status !== undefined ? { status: run.status } : {}),
+    ...(run.status !== undefined ? { status: toDisplayStatus(run.status) } : {}),
     redactionProfile,
     facts,
     inferences: mode === "dry-run" ? [] : buildInferences(run, facts),

--- a/packages/core/src/logs/tree-builder.ts
+++ b/packages/core/src/logs/tree-builder.ts
@@ -10,13 +10,33 @@ function inc<T extends string>(map: Record<T, number>, key: T): void {
 }
 
 function computeRunStatus(events: InspectEvent[]): InspectRunTree["status"] {
+  // Derive the run status from the RUN node lifecycle, matching
+  // manualTraceEventsToRunTree and extractMetadata: a run is "running" only
+  // until its RUN completion is recorded. The v0.1 bridge writes each node as a
+  // "started" event (status "running") followed by a "completed" event, so a
+  // finished run still carries "running" started rows; those must not force the
+  // whole run back to "running". Events arrive timestamp-sorted, so the last
+  // terminal RUN status wins.
+  let runTerminal: "ok" | "error" | undefined;
+  let sawRunEvent = false;
+  for (const e of events) {
+    if (e.kind !== "RUN") continue;
+    sawRunEvent = true;
+    if (e.status === "ok" || e.status === "error") {
+      runTerminal = e.status;
+    }
+  }
+  if (sawRunEvent) {
+    return runTerminal ?? "running";
+  }
+
+  // Fallback for traces with no RUN node (e.g. log-only ingestion).
   let hasRunning = false;
   for (const e of events) {
     if (e.status === "error") return "error";
     if (e.status === "running") hasRunning = true;
   }
-  if (hasRunning) return "running";
-  return "ok";
+  return hasRunning ? "running" : "ok";
 }
 
 export class TreeBuilder {

--- a/packages/core/test/persisted/tree-bridge.test.ts
+++ b/packages/core/test/persisted/tree-bridge.test.ts
@@ -255,10 +255,36 @@ describe("traceEventsToPersistedRunTrees", () => {
     const trees = traceEventsToPersistedRunTrees(events);
     expect(trees).toHaveLength(1);
     expect(trees[0]!.runId).toBe(runId);
-    // TreeBuilder derives status from all events; run_started rows stay "running"
-    // unlike manualTraceEventsToRunTree which uses run_completed for run status.
-    expect(trees[0]!.status).toBe("running");
+    // A completed run reports its terminal RUN status, matching
+    // manualTraceEventsToRunTree/extractMetadata, even though the bridge keeps
+    // the "running" started rows as separate events.
+    expect(trees[0]!.status).toBe("ok");
     expect(trees[0]!.children.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps a run running until its completion event is present", () => {
+    const runId = "run_incomplete";
+    const events: TraceEvent[] = [
+      rs(runId, "support-agent", TS),
+      ss(runId, "step_1", "tool-step", TS + 10, "tool"),
+      sc(runId, "step_1", "success", TS + 50, 40),
+    ];
+
+    const trees = traceEventsToPersistedRunTrees(events);
+    expect(trees[0]!.status).toBe("running");
+  });
+
+  it("reports a failed run as error from its completion status", () => {
+    const runId = "run_failed";
+    const events: TraceEvent[] = [
+      rs(runId, "support-agent", TS),
+      ss(runId, "step_1", "tool-step", TS + 10, "tool"),
+      sc(runId, "step_1", "error", TS + 50, 40),
+      rc(runId, "error", TS + 100, 100),
+    ];
+
+    const trees = traceEventsToPersistedRunTrees(events);
+    expect(trees[0]!.status).toBe("error");
   });
 
   it("legacy bridge output is broadly compatible with manualTraceEventsToRunTree", () => {


### PR DESCRIPTION
## Summary

Fixes #173: `explain` reported `run.status: "running"` for a run that had already completed successfully, while `list` and `view` showed `success` for the same run.

Root cause is in `TreeBuilder.computeRunStatus` (`packages/core/src/logs/tree-builder.ts`), which `explain` reaches through `openTrace`. It returned `"running"` whenever any event carried a `"running"` status. The v0.1 to persisted bridge (`from-trace-event.ts`) writes each node as a started event (status `"running"`) followed by a completed event, so a finished run still contains `"running"` started rows and the whole run was reported as running. `list`/`view` go through `extractMetadata`/`buildRunSummary`, which read the RUN completion status, so they were already correct.

Changes:

- `computeRunStatus` now derives the run status from the RUN node lifecycle, matching `manualTraceEventsToRunTree` and `extractMetadata`: a run is `"running"` only until its RUN completion event is present, then it takes that terminal status (`ok`/`error`). Traces with no RUN node (log-only ingestion) keep the previous any-error / any-running fallback. This also lets completed runs read through `openTrace` populate `endedAt`/`durationMs`, which were previously suppressed because the status was stuck at `"running"`.
- `explain` now maps the run-tree status vocabulary (`ok`/`error`/`running`) to the user-facing `success`/`error`/`running` vocabulary that `list`/`view`/`stats` use, so the command output and the `run.status` fact agree with the sibling commands.

## How I verified

Repro from the issue, before vs after:

```
list:          success (unchanged)
view:          Status: success (unchanged)
explain human: Status: running  ->  Status: success
explain --json status:  "running"  ->  "success"
explain run.status fact: "running"  ->  "success"
```

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan)

## Product boundaries

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] schemaVersion "0.1" manual traces remain compatible
- [x] No step_failed event introduced
- [x] inspectRun default tracing behavior unchanged

## Packages touched

- [x] `@agent-inspect/core`
- [x] `@agent-inspect/cli` (test only)

## Validation

```bash
pnpm typecheck  # pass
pnpm --filter @agent-inspect/core test -- tree-bridge tree-builder  # 17 pass
pnpm --filter @agent-inspect/cli test -- explain  # 6 pass
```

## Checklist

- [x] Tests added or updated (tree-bridge status cases + explain success assertion)
- [x] Docs updated (n/a, internal status derivation)
- [x] No new runtime dependencies
- [x] No version bump in this PR
- [x] No secrets, production logs, or real PII in commits
