### PR TITLE
fix(core): stop double-prefixing step names in stats output

### DIFF
--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -242,6 +242,17 @@ function collectCompletedSteps(
   return out;
 }
 
+/**
+ * Formats a step label for display. `step.tool`/`step.llm` already store the
+ * name with its type prefix (e.g. "tool:lookup"), while plain `step()` stores a
+ * bare name, so prefixing unconditionally would double the prefix. Add the type
+ * prefix only when the name does not already carry it, matching what list/view
+ * show for the same step.
+ */
+function formatStepLabel(stepType: string, stepName: string): string {
+  return stepName.startsWith(`${stepType}:`) ? stepName : `${stepType}:${stepName}`;
+}
+
 export function renderTraceStats(stats: TraceStats): string {
   const lines: string[] = [];
   lines.push("Trace stats (local)");
@@ -279,7 +290,7 @@ export function renderTraceStats(stats: TraceStats): string {
     lines.push("Slowest steps:");
     for (const s of stats.slowestSteps) {
       lines.push(
-        `  ${s.runId} | ${s.stepType}:${s.stepName} | ${formatDuration(s.durationMs)}`,
+        `  ${s.runId} | ${formatStepLabel(s.stepType, s.stepName)} | ${formatDuration(s.durationMs)}`,
       );
     }
   }

--- a/packages/core/test/stats.test.ts
+++ b/packages/core/test/stats.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { extractMetadata } from "../src/trace-metadata.js";
-import { buildTraceStats } from "../src/stats.js";
+import { buildTraceStats, renderTraceStats, type TraceStats } from "../src/stats.js";
 
 const fixturesDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -80,5 +80,45 @@ describe("buildTraceStats", () => {
       expect(stats.duration.avgMs).toBe(1000);
       expect(stats.slowestSteps[0]?.stepName).toBe("fixture-search");
     }
+  });
+});
+
+describe("renderTraceStats step labels", () => {
+  function baseStats(overrides: Partial<TraceStats>): TraceStats {
+    return {
+      traceDir: "./.agent-inspect",
+      totalRuns: 1,
+      successCount: 1,
+      errorCount: 0,
+      runningCount: 0,
+      unknownCount: 0,
+      errorRate: 0,
+      duration: { minMs: 1, avgMs: 1, p50Ms: 1, p95Ms: 1, maxMs: 1 },
+      totalSteps: 3,
+      avgStepsPerRun: 3,
+      totalLlmSteps: 1,
+      totalToolSteps: 1,
+      totalErrorSteps: 0,
+      slowestRuns: [],
+      slowestSteps: [],
+      ...overrides,
+    };
+  }
+
+  it("does not double-prefix step names that already carry their type", () => {
+    const stats = baseStats({
+      slowestSteps: [
+        { runId: "run_1", stepName: "tool:retrieve-policy", stepType: "tool", durationMs: 28 },
+        { runId: "run_1", stepName: "llm:generate-answer", stepType: "llm", durationMs: 13 },
+        { runId: "run_1", stepName: "plan", stepType: "logic", durationMs: 14 },
+      ],
+    });
+
+    const out = renderTraceStats(stats);
+    expect(out).toContain("run_1 | tool:retrieve-policy | ");
+    expect(out).toContain("run_1 | llm:generate-answer | ");
+    expect(out).toContain("run_1 | logic:plan | ");
+    expect(out).not.toContain("tool:tool:");
+    expect(out).not.toContain("llm:llm:");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #172: `stats` printed step names with a doubled type prefix (`tool:tool:retrieve-policy`, `llm:llm:generate-answer`) while `list`/`view` showed the correct single prefix for the same run.

Root cause is in `renderTraceStats` (`packages/core/src/stats.ts`), which formatted the "Slowest steps" rows as `${stepType}:${stepName}`. `step.tool`/`step.llm` already store the step name with its type prefix (`tool:retrieve-policy`, `llm:generate-answer`), so prepending the type again doubled it. Plain `step()` names carry no prefix, which is why `logic:plan` looked right. `list`/`view` render the stored name as-is, so they were unaffected.

Fix adds the type prefix only when the name does not already start with it. Tool/llm steps now show a single prefix and bare logic steps still get one.

## How I verified

Repro from the issue, "Slowest steps" section, before vs after:

```
tool:tool:retrieve-policy   ->  tool:retrieve-policy
llm:llm:generate-answer     ->  llm:generate-answer
logic:plan                  ->  logic:plan (unchanged)
```

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan)

## Product boundaries

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] schemaVersion "0.1" manual traces remain compatible
- [x] No step_failed event introduced
- [x] inspectRun default tracing behavior unchanged

## Packages touched

- [x] `@agent-inspect/core`

## Validation

```bash
pnpm typecheck  # pass
pnpm --filter @agent-inspect/core test -- stats  # 9 pass (incl. new render label test)
```

## Checklist

- [x] Tests added or updated (renderTraceStats label test)
- [x] Docs updated (n/a, output formatting fix)
- [x] No new runtime dependencies
- [x] No version bump in this PR
- [x] No secrets, production logs, or real PII in commits
