### PR TITLE
fix(core): order content-filtered search results newest first

### DIFF
--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -179,10 +179,15 @@ export async function searchTraces(
     }
   }
 
+  // Newest first, matching `list` and the no-content-filter branch above
+  // (both order via filterTraces). Sorting oldest first here made a filtered
+  // search disagree with a bare search and made `--limit` keep the oldest
+  // matches instead of the most recent. Ties fall back to stable ascending
+  // keys so results stay deterministic.
   results.sort((a, b) => {
     const ta = a.timestamp ?? 0;
     const tb = b.timestamp ?? 0;
-    if (ta !== tb) return ta - tb;
+    if (ta !== tb) return tb - ta;
     const runCmp = a.runId.localeCompare(b.runId);
     if (runCmp !== 0) return runCmp;
     return (a.stepName ?? "").localeCompare(b.stepName ?? "");

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -1,7 +1,9 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { extractMetadata } from "../src/trace-metadata.js";
 import { parseDurationFilter, searchTraces } from "../src/search.js";
@@ -63,6 +65,74 @@ describe("searchTraces", () => {
     const a = await searchTraces(metas, { traceDir: fixturesDir, limit: 10 });
     const b = await searchTraces(metas, { traceDir: fixturesDir, limit: 10 });
     expect(a).toEqual(b);
+  });
+
+  describe("result ordering", () => {
+    let dir: string;
+
+    const runJsonl = (runId: string, name: string, start: number): string =>
+      [
+        `{"schemaVersion":"0.1","event":"run_started","timestamp":${start},"runId":"${runId}","name":"${name}","startTime":${start}}`,
+        `{"schemaVersion":"0.1","event":"step_started","timestamp":${start + 10},"runId":"${runId}","stepId":"s1","name":"lookup","type":"tool","startTime":${start + 10}}`,
+        `{"schemaVersion":"0.1","event":"step_completed","timestamp":${start + 60},"runId":"${runId}","stepId":"s1","status":"success","endTime":${start + 60},"durationMs":50}`,
+        `{"schemaVersion":"0.1","event":"run_completed","timestamp":${start + 100},"runId":"${runId}","status":"success","endTime":${start + 100},"durationMs":100}`,
+      ].join("\n");
+
+    beforeAll(async () => {
+      dir = await mkdtemp(path.join(tmpdir(), "ai-search-order-"));
+      await writeFile(
+        path.join(dir, "run_old.jsonl"),
+        runJsonl("run_old", "old-run", 1_000_000_000_000),
+      );
+      await writeFile(
+        path.join(dir, "run_new.jsonl"),
+        runJsonl("run_new", "new-run", 2_000_000_000_000),
+      );
+    });
+
+    afterAll(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const loadMetas = async () =>
+      Promise.all(
+        ["run_old.jsonl", "run_new.jsonl"].map((f) =>
+          extractMetadata(path.join(dir, f)),
+        ),
+      );
+
+    it("orders bare and content-filtered searches newest first alike", async () => {
+      const metas = await loadMetas();
+
+      const bare = await searchTraces(metas, { traceDir: dir });
+      expect(bare.map((r) => r.runId)).toEqual(["run_new", "run_old"]);
+
+      // Any content filter previously flipped ordering to oldest first.
+      for (const filter of [
+        { status: "success" as const },
+        { name: "run" },
+        { tool: "lookup" },
+        { duration: ">10ms" },
+      ]) {
+        const results = await searchTraces(metas, { traceDir: dir, ...filter });
+        const firstIndex = results.findIndex((r) => r.runId === "run_new");
+        const lastIndex = results.map((r) => r.runId).lastIndexOf("run_old");
+        expect(firstIndex).toBeGreaterThanOrEqual(0);
+        expect(firstIndex).toBeLessThan(lastIndex);
+        expect(results[0]!.runId).toBe("run_new");
+      }
+    });
+
+    it("keeps the most recent matches when a content filter is limited", async () => {
+      const metas = await loadMetas();
+      const limited = await searchTraces(metas, {
+        traceDir: dir,
+        status: "success",
+        limit: 1,
+      });
+      expect(limited).toHaveLength(1);
+      expect(limited[0]!.runId).toBe("run_new");
+    });
   });
 
   it("matches v0.1 and v0.2 step searches using exact file paths", async () => {


### PR DESCRIPTION
## What

`searchTraces` returned results newest first for a bare query but oldest first as soon as any content filter was applied, and a filtered `--limit` kept the oldest matches. This orders the filtered branch newest first, matching `list` and the bare `search` branch.

## Root cause

`packages/core/src/search.ts` has two paths. Without a content filter, results come from `filterTraces`, which sorts newest first (same as `list`). With a content filter, results were sorted `ta - tb` (ascending, oldest first). The direction flipped purely on whether a filter was present, and because `slice(0, limit)` runs after the sort, `--limit N` on a filtered search returned the N oldest matches.

## Fix

Sort the filtered branch newest first (`tb - ta`), keeping the existing ascending tie-breaks (runId, then stepName) so results stay deterministic.

## Before / after

Two runs, `run_old` (older) and `run_new` (newer), both successful:

```
# before
search --status success           -> run_old, run_old, run_new, run_new
search --status success --limit 1 -> run_old        # oldest kept

# after
search --status success           -> run_new, run_new, run_old, run_old
search --status success --limit 1 -> run_new        # newest kept, matches list
```

## Tests

- New `result ordering` block builds two real traces with distinct timestamps and asserts bare and content-filtered searches (`--status`, `--name`, `--tool`, `--duration`) all order newest first, and that a limited filtered search keeps the most recent match.
- Existing determinism and v0.1/v0.2 parity tests unchanged.

Full core suite green (1529). `pnpm run typecheck` clean.

Fixes #178
