### PR TITLE
fix: stop double-prefixing step type labels in timeline and search

### DIFF
--- a/packages/cli/src/search.ts
+++ b/packages/cli/src/search.ts
@@ -1,6 +1,7 @@
 import {
   TraceDirectory,
   filterMetasBySessionScope,
+  formatStepTypeLabel,
   loadSessionRunRecords,
   loadTraceMetadataList,
   parseDuration,
@@ -113,7 +114,7 @@ export async function searchCommand(
     for (const r of results) {
       const step =
         r.stepName !== undefined
-          ? ` | ${r.stepType ?? "step"}:${r.stepName}`
+          ? ` | ${formatStepTypeLabel(r.stepType ?? "step", r.stepName)}`
           : "";
       const dur =
         r.durationMs !== undefined ? ` | ${r.durationMs}ms` : "";

--- a/packages/cli/test/search.test.ts
+++ b/packages/cli/test/search.test.ts
@@ -44,6 +44,20 @@ describe("search CLI", () => {
     expect(out).toContain("tool");
   });
 
+  it("does not double the type prefix in the human step label", async () => {
+    const fixtures = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../fixtures/traces",
+    );
+    await cp(path.join(fixtures, "tool-with-io.jsonl"), path.join(tmpDir, "tool-with-io.jsonl"));
+    // The tool step is stored already prefixed ("tool:search-hotels"); the human
+    // renderer must not prepend the type again.
+    await searchCommand({ dir: tmpDir, kind: "tool" });
+    const out = logSpy.mock.calls.flat().join("\n");
+    expect(out).toContain("tool:search-hotels");
+    expect(out).not.toContain("tool:tool:");
+  });
+
   it("emits valid JSON", async () => {
     const fixtures = path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/core/src/entries/advanced.ts
+++ b/packages/core/src/entries/advanced.ts
@@ -71,6 +71,7 @@ export {
   createStepId,
   formatDuration,
   formatTimestamp,
+  formatStepTypeLabel,
   getDefaultTraceDir,
   getTraceFilePath,
   ensureTraceDir,

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -2,7 +2,7 @@ import type { RunStartedEvent, TraceEvent, TraceMetadata } from "./types.js";
 import { buildRunSummary } from "./trace-metadata.js";
 import { filterTraces } from "./trace-filter.js";
 import { readTraceEventsFromFile } from "./storage.js";
-import { formatDuration } from "./utils.js";
+import { formatDuration, formatStepTypeLabel } from "./utils.js";
 
 export interface DurationStats {
   minMs?: number;
@@ -242,17 +242,6 @@ function collectCompletedSteps(
   return out;
 }
 
-/**
- * Formats a step label for display. `step.tool`/`step.llm` already store the
- * name with its type prefix (e.g. "tool:lookup"), while plain `step()` stores a
- * bare name, so prefixing unconditionally would double the prefix. Add the type
- * prefix only when the name does not already carry it, matching what list/view
- * show for the same step.
- */
-function formatStepLabel(stepType: string, stepName: string): string {
-  return stepName.startsWith(`${stepType}:`) ? stepName : `${stepType}:${stepName}`;
-}
-
 export function renderTraceStats(stats: TraceStats): string {
   const lines: string[] = [];
   lines.push("Trace stats (local)");
@@ -290,7 +279,7 @@ export function renderTraceStats(stats: TraceStats): string {
     lines.push("Slowest steps:");
     for (const s of stats.slowestSteps) {
       lines.push(
-        `  ${s.runId} | ${formatStepLabel(s.stepType, s.stepName)} | ${formatDuration(s.durationMs)}`,
+        `  ${s.runId} | ${formatStepTypeLabel(s.stepType, s.stepName)} | ${formatDuration(s.durationMs)}`,
       );
     }
   }

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -8,7 +8,7 @@ import type {
   TraceEvent,
   TraceMetadataStatus,
 } from "./types.js";
-import { formatDuration, formatTimestamp } from "./utils.js";
+import { formatDuration, formatStepTypeLabel, formatTimestamp } from "./utils.js";
 
 export type TimelineFocus = "all" | "slow";
 
@@ -285,13 +285,11 @@ export function renderTimeline(
 
   for (const e of show) {
     const prefix = e.slow ? "[slow] " : "";
-    const typeTag =
-      e.type === "llm" ? "llm" : e.type === "tool" ? "tool" : e.type;
     const dur =
       e.durationMs !== undefined ? formatDuration(e.durationMs) : "-";
     const err = e.isError ? " error" : "";
     const off = formatDuration(e.offsetMs);
-    let line = `${prefix}+${off} ${typeTag}:${e.name} (${dur})${err}`;
+    let line = `${prefix}+${off} ${formatStepTypeLabel(e.type, e.name)} (${dur})${err}`;
     if (e.streaming?.chunkCount !== undefined) {
       line += ` chunks=${e.streaming.chunkCount}`;
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -173,6 +173,22 @@ export function truncateName(name: string, maxLength = MAX_NAME_LENGTH): string 
 }
 
 /**
+ * Formats a `type:name` step label without doubling the prefix.
+ *
+ * `step.tool`/`step.llm` store the name already prefixed with its type
+ * (e.g. `"tool:lookup"`, `"llm:gpt-4"`), while a plain `step()` stores a bare
+ * name (e.g. `"plan"`). Renderers that show the type tag must therefore add the
+ * prefix only when it is not already present, otherwise tool/llm steps read as
+ * `"tool:tool:lookup"`. This keeps timeline, search, and stats output aligned
+ * with how view/list show the same step.
+ */
+export function formatStepTypeLabel(stepType: string, stepName: string): string {
+  return stepName.startsWith(`${stepType}:`)
+    ? stepName
+    : `${stepType}:${stepName}`;
+}
+
+/**
  * Instrumentation-only warning to stderr. Not a general-purpose logger.
  * Optional `error` is summarized via {@link formatError} (message only).
  */

--- a/packages/core/test/timeline.test.ts
+++ b/packages/core/test/timeline.test.ts
@@ -66,3 +66,22 @@ describe("buildRunTimeline", () => {
     expect(timeline.entries).toEqual([]);
   });
 });
+
+describe("renderTimeline step labels", () => {
+  it("does not double the type prefix for tool/llm steps", async () => {
+    const events = await loadFixture("tool-with-io.jsonl");
+    const text = renderTimeline(buildRunTimeline(events));
+    // step.tool stores the name already prefixed ("tool:search-hotels"), so the
+    // renderer must not prepend the type again.
+    expect(text).toContain("tool:search-hotels");
+    expect(text).not.toContain("tool:tool:");
+    expect(text).not.toContain("llm:llm:");
+  });
+
+  it("keeps the type tag for a plain (bare-named) step", async () => {
+    const events = await loadFixture("minimal-success.jsonl");
+    const text = renderTimeline(buildRunTimeline(events));
+    // Plain step() stores a bare name; the timeline still shows its type tag.
+    expect(text).toContain("logic:plan");
+  });
+});

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -17,6 +17,7 @@ import {
   FALLBACK_TRACE_DIR,
   formatDuration,
   formatError,
+  formatStepTypeLabel,
   formatTimestamp,
   getDefaultTraceDir,
   getTraceFilePath,
@@ -244,5 +245,21 @@ describe("warn", () => {
     warn("oops", new Error("bad"));
     expect(spy).toHaveBeenCalledWith("[AgentInspect] oops: bad");
     spy.mockRestore();
+  });
+});
+
+describe("formatStepTypeLabel", () => {
+  it("prefixes a bare step name with its type", () => {
+    expect(formatStepTypeLabel("logic", "plan")).toBe("logic:plan");
+  });
+
+  it("does not double a name that already carries the type prefix", () => {
+    expect(formatStepTypeLabel("tool", "tool:lookup")).toBe("tool:lookup");
+    expect(formatStepTypeLabel("llm", "llm:gpt-4")).toBe("llm:gpt-4");
+  });
+
+  it("only treats an exact type prefix as present", () => {
+    // "toolbox" is not the "tool:" prefix, so it is still prefixed.
+    expect(formatStepTypeLabel("tool", "toolbox")).toBe("tool:toolbox");
   });
 });


### PR DESCRIPTION
## What

`timeline` and `search` human output double the step type prefix for `step.tool`/`step.llm` steps (`tool:tool:retrieve-policy`, `llm:llm:generate-answer`). `view`, `list`, and `what` render the same steps correctly. This is the same class as #172 (stats), fixed in #177; the remaining renderers were missed.

## Root cause

`step.tool(name)` stores the name already prefixed as `tool:<name>` and `step.llm(model)` as `llm:<model>` (packages/core/src/step.ts). Renderers that also prepend the step type doubled it:

- `packages/core/src/timeline.ts`: `` `${typeTag}:${e.name}` ``
- `packages/cli/src/search.ts`: `` `${r.stepType ?? "step"}:${r.stepName}` ``

`view` uses the stored name as is (`renderStepLine` adds no prefix), which is why it was correct. `report` embeds the timeline text, so the doubling also reached exported markdown/HTML.

## Fix

Centralize the convention from #177 as `formatStepTypeLabel(type, name)` in core `utils` (prefix only when the name does not already carry it), export it from `@agent-inspect/core/advanced`, and apply it in:

- `timeline.ts` (fixes timeline and, transitively, the report timeline section)
- `cli/search.ts` human output
- `stats.ts`, which now uses the shared helper instead of its local copy so there is one source of truth

Plain steps keep their type tag (`logic:plan`); only the double prefix is removed.

## Before / after

```
# timeline before            # timeline after
+26ms tool:tool:retrieve...  +26ms tool:retrieve-policy
+59ms llm:llm:generate...    +59ms llm:generate-answer
+6ms  logic:plan             +6ms  logic:plan   (unchanged)

# search --tool retrieve
before: run_x | tool:tool:retrieve-policy | ...
after:  run_x | tool:retrieve-policy | ...
```

## Tests

- `formatStepTypeLabel` unit tests (bare name prefixed, already-prefixed name not doubled, exact-prefix match only).
- `renderTimeline` render tests: no `tool:tool:`/`llm:llm:` doubling; `logic:plan` preserved.
- CLI search render test: human step label is `tool:search-hotels`, not `tool:tool:`.
- Existing stats label test still passes against the shared helper.

Full core and cli suites green; `pnpm run typecheck` clean. (One unrelated `step.test.ts` timeout appeared only when both full suites ran concurrently under load and passes in isolation; it is untouched by this change.)

Fixes #180
