### PR TITLE
test(cli): resolve alias-test fixtures relative to the module, not cwd

### DIFF
--- a/packages/cli/test/cli-option-aliases.test.ts
+++ b/packages/cli/test/cli-option-aliases.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -10,6 +11,14 @@ import {
 } from "../src/cli-option-aliases.js";
 import { exportCommand } from "../src/export.js";
 import { redactCommand } from "../src/redact.js";
+
+// Resolve fixtures relative to this module, not process.cwd(). The rest of the
+// CLI suite does the same so `pnpm --filter @agent-inspect/cli test` (which runs
+// with cwd set to packages/cli) finds the repo-root fixtures directory.
+const fixturesTracesDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/traces",
+);
 
 describe("CLI option aliases", () => {
   let tmp: string;
@@ -32,7 +41,7 @@ describe("CLI option aliases", () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-cli-alias-export-"));
     const outPath = path.join(tmp, "export.md");
     await exportCommand("minimal-success", {
-      dir: path.resolve("fixtures/traces"),
+      dir: fixturesTracesDir,
       format: "markdown",
       out: outPath,
       profile: "share",
@@ -45,7 +54,7 @@ describe("CLI option aliases", () => {
   it("redact accepts --out and --redaction-profile aliases", async () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-cli-alias-redact-"));
     const outPath = path.join(tmp, "redacted.jsonl");
-    await redactCommand(path.resolve("fixtures/traces/minimal-success.jsonl"), {
+    await redactCommand(path.join(fixturesTracesDir, "minimal-success.jsonl"), {
       out: outPath,
       redactionProfile: "share",
       json: true,


### PR DESCRIPTION
Fixes #190.

## Problem

`packages/cli/test/cli-option-aliases.test.ts` resolves the shared fixtures with `path.resolve("fixtures/traces")`, which is relative to `process.cwd()`. Running the CLI package suite the standard way:

```
pnpm --filter @agent-inspect/cli test
```

executes `vitest run -c ../../vitest.config.ts` with cwd set to `packages/cli`, so the path resolves to the nonexistent `packages/cli/fixtures/traces`. The export alias case reads a missing run and writes nothing; the redact alias case falls back to run-id resolution against `~/.agent-inspect/runs`, giving a `minimal-success.jsonl.jsonl` miss. Both fail with ENOENT.

CI stays green only because it runs from the repo root (`vitest run --coverage`), where the cwd-relative path happens to resolve.

## Fix

Resolve the fixtures directory from `import.meta.url`, matching every other CLI test file. This is the only test in the repo using a cwd-relative fixtures path.

## Verification

Before (cwd = packages/cli): 2 failed.

```
pnpm --filter @agent-inspect/cli test
# Test Files  1 failed (234)
# Tests  2 failed | 1655 passed (1657)
```

After:

```
pnpm --filter @agent-inspect/cli test
# Test Files  234 passed (234)
# Tests  1657 passed (1657)
```

Also passes from the repo root, so both invocations agree.