### PR TITLE
fix(cli): stop double-prefixing step type labels in search output

### DIFF
--- a/packages/cli/src/search.ts
+++ b/packages/cli/src/search.ts
@@ -1,6 +1,7 @@
 import {
   TraceDirectory,
   filterMetasBySessionScope,
+  formatStepLabel,
   loadSessionRunRecords,
   loadTraceMetadataList,
   parseDuration,
@@ -113,7 +114,7 @@ export async function searchCommand(
     for (const r of results) {
       const step =
         r.stepName !== undefined
-          ? ` | ${r.stepType ?? "step"}:${r.stepName}`
+          ? ` | ${formatStepLabel(r.stepType ?? "step", r.stepName)}`
           : "";
       const dur =
         r.durationMs !== undefined ? ` | ${r.durationMs}ms` : "";

--- a/packages/cli/test/search.test.ts
+++ b/packages/cli/test/search.test.ts
@@ -44,6 +44,20 @@ describe("search CLI", () => {
     expect(out).toContain("tool");
   });
 
+  it("does not double-prefix typed step labels in human output", async () => {
+    const fixtures = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../fixtures/traces",
+    );
+    await cp(path.join(fixtures, "tool-with-io.jsonl"), path.join(tmpDir, "tool-with-io.jsonl"));
+    await searchCommand({ dir: tmpDir, tool: "search" });
+    const out = logSpy.mock.calls.flat().join("\n");
+    // The stored name already carries its type ("tool:search-hotels"), so the
+    // label must not be prefixed again into "tool:tool:search-hotels".
+    expect(out).toContain("tool:search-hotels");
+    expect(out).not.toContain("tool:tool:");
+  });
+
   it("emits valid JSON", async () => {
     const fixtures = path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/core/src/entries/advanced.ts
+++ b/packages/core/src/entries/advanced.ts
@@ -185,7 +185,7 @@ export type {
   TraceStats,
   TraceStatsOptions,
 } from "../stats.js";
-export { buildTraceStats, renderTraceStats } from "../stats.js";
+export { buildTraceStats, formatStepLabel, renderTraceStats } from "../stats.js";
 
 export type {
   TraceSearchOptions,


### PR DESCRIPTION
Addresses the remaining part of #180.

## Context

f361ec4 (shared step labels and newest-first search) routed `timeline` through the guarded `formatStepLabel` and moved the shared helper into `stats`. That fixed the timeline and stats sites. The CLI search renderer was the one place it did not reach.

## Problem

`packages/cli/src/search.ts` builds its step label as `${stepType}:${stepName}` unconditionally. Because `step.tool` and `step.llm` persist the name already carrying its type (for example `"tool:search-hotels"`), the human output double-prefixes:

```
$ agent-inspect search --tool search --dir <dir>
tool-with-io | tool:tool:search-hotels | success | 300ms | step match: step.tool
```

while `timeline` prints the same step correctly after f361ec4:

```
$ agent-inspect timeline tool-with-io --dir <dir>
+10ms tool:search-hotels (300ms)
```

## Fix

Export the existing `formatStepLabel` from the `@agent-inspect/core/advanced` barrel (f361ec4 already made it a public export from `stats`, but only for the internal `./stats.js` import path, so the CLI could not reach it) and use it in the search renderer. The prefix is added only when the stored name does not already carry it, so plain logic steps still get their type prefix.

After:

```
$ agent-inspect search --tool search --dir <dir>
tool-with-io | tool:search-hotels | success | 300ms | step match: step.tool
```

## Tests

Adds a CLI test asserting the label is `tool:search-hotels` and never `tool:tool:`. The existing "finds tool steps" assertion only checked for the substring `tool`, which a double prefix also satisfies. `pnpm typecheck` and the core and cli suites pass.

Supersedes #181, which I closed since its timeline and stats changes are already merged via f361ec4.