### PR TITLE
fix(checks): treat empty usage allowlists as no restriction

### DIFF
--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -1768,9 +1768,12 @@ export function createLlmUsageRule(options: LlmUsageRuleOptions): TraceCheckRule
     evaluate(context) {
       const llms = finishedEvents(context, "LLM");
       const findings: TraceCheckFinding[] = [];
-      const allowedModels = options.allowedModels ? new Set(options.allowedModels) : undefined;
-      const allowedProviders = options.allowedProviders ? new Set(options.allowedProviders) : undefined;
-      const finishReasons = options.finishReasons ? new Set(options.finishReasons) : undefined;
+      // An empty allowlist means "no restriction", not "reject everything".
+      // Callers (CLI --max-total-tokens with no --allowed-model, config, or
+      // contract) may pass [], and an empty array is truthy, so guard on length.
+      const allowedModels = options.allowedModels?.length ? new Set(options.allowedModels) : undefined;
+      const allowedProviders = options.allowedProviders?.length ? new Set(options.allowedProviders) : undefined;
+      const finishReasons = options.finishReasons?.length ? new Set(options.finishReasons) : undefined;
 
       if (options.maxCalls !== undefined && llms.length > options.maxCalls) {
         findings.push(

--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -1640,7 +1640,8 @@ export function createToolUsageRule(options: ToolUsageRuleOptions): TraceCheckRu
       }
 
       const forbidden = new Set(options.forbidden ?? []);
-      const allowed = options.allowed ? new Set(options.allowed) : undefined;
+      // Empty allowlist means "no restriction", not "reject everything".
+      const allowed = options.allowed?.length ? new Set(options.allowed) : undefined;
       for (const event of tools) {
         const name = toolName(event);
         if (forbidden.has(name)) {
@@ -2199,7 +2200,8 @@ function createSignalRule(
       }
 
       const forbidden = new Set(options.forbidden ?? []);
-      const allowed = options.allowed ? new Set(options.allowed) : undefined;
+      // Empty allowlist means "no restriction", not "reject everything".
+      const allowed = options.allowed?.length ? new Set(options.allowed) : undefined;
       for (const event of events) {
         const name = nameForEvent(event);
         if (forbidden.has(name)) {

--- a/packages/core/test/checks.test.ts
+++ b/packages/core/test/checks.test.ts
@@ -426,6 +426,35 @@ describe("built-in run, tool, and LLM checks", () => {
     ]);
     expect(JSON.stringify(result.findings)).not.toContain("raw prompt should not leak");
   });
+
+  it("treats empty allowlists as no restriction so a token-only budget passes", () => {
+    const llm = persisted("event-a", {
+      kind: "LLM",
+      name: "llm:generate-answer",
+      attributes: { model: "gpt-4o", provider: "openai", finishReason: "stop" },
+      tokenUsage: { input: 100, output: 50, total: 150 },
+    });
+    const read = readResult([llm]);
+
+    // Mirrors `check --max-total-tokens N` with no --allowed-model: the CLI
+    // passes empty allowlists. These must not reject every model/provider.
+    const result = runTraceChecks(
+      { read },
+      {
+        rules: [
+          createLlmUsageRule({
+            allowedModels: [],
+            allowedProviders: [],
+            finishReasons: [],
+            maxTotalTokens: 1000,
+          }),
+        ],
+      },
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.findings).toHaveLength(0);
+  });
 });
 
 describe("built-in structure and safety checks", () => {

--- a/packages/core/test/checks.test.ts
+++ b/packages/core/test/checks.test.ts
@@ -371,6 +371,24 @@ describe("built-in run, tool, and LLM checks", () => {
     });
   });
 
+  it("treats an empty tool allowlist as no restriction", () => {
+    const tool = persisted("event-a", {
+      kind: "TOOL",
+      name: "tool:search",
+      attributes: { toolName: "search" },
+    });
+    const read = readResult([tool]);
+
+    // allowed: [] must not reject every tool; the required tool is present.
+    const result = runTraceChecks(
+      { read },
+      { rules: [createToolUsageRule({ required: ["search"], allowed: [] })] },
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.findings).toHaveLength(0);
+  });
+
   it("reports LLM model, provider, finish reason, call count, and token-budget violations", () => {
     const first = persisted("event-a", {
       kind: "LLM",


### PR DESCRIPTION
Fixes #197.

## Problem

The usage rules guarded their allowlists with `options.X ? new Set(options.X) : undefined`. An empty array is truthy, so an empty allowlist became an empty `Set` and every event was rejected as "not allowed". This affected three sites in `packages/core/src/checks/index.ts`:

- `createLlmUsageRule`: `allowedModels`, `allowedProviders`, `finishReasons`
- `createToolUsageRule`: `allowed`
- the shared retrieval/guardrail/decision signal rule: `allowed`

The llm.usage case is reachable straight from the CLI. `agent-inspect check <run> --max-total-tokens N` with no `--allowed-model` builds the rule with `allowedModels: []` (the CLI always spreads the flag arrays), so a token-only budget gate failed with a phantom model rejection and exited nonzero:

```
$ agent-inspect check llm-with-tokens --dir fixtures/traces --max-total-tokens 5000
Check status: fail
- [llm-with-tokens] llm.usage: LLM model generate-answer is not allowed. (attributes.model)
```

The tool.usage and signal `allowed` cases are the same defect, reachable through a config or contract that sets `tool.allowed: []`.

## Fix

Guard on length so an empty allowlist means "no restriction", matching an absent one, across all three rules. A populated allowlist still rejects out-of-list values.

After:

```
$ agent-inspect check llm-with-tokens --dir fixtures/traces --max-total-tokens 5000
Check status: pass

$ agent-inspect check llm-with-tokens --dir fixtures/traces --max-total-tokens 1000
Check status: fail
- [llm-with-tokens] llm.usage: LLM total token count 1556 exceeded 1000. (tokenUsage.total)   # token finding only

$ agent-inspect check llm-with-tokens --dir fixtures/traces --allowed-model foo
- [llm-with-tokens] llm.usage: LLM model generate-answer is not allowed.   # real allowlist still enforced
```

## Tests

Adds two regression tests: empty llm.usage allowlists plus a satisfied token budget pass with zero findings, and an empty tool.usage allowlist does not reject a present tool. `pnpm typecheck` and the full core check suite pass; existing populated-allowlist tests are unchanged.