### PR TITLE
test(core): resolve semantic-parity fixture relative to the module, not cwd

### DIFF
--- a/packages/core/test/semantic-parity.test.ts
+++ b/packages/core/test/semantic-parity.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -14,9 +15,12 @@ import {
 } from "../src/checks/index.js";
 import { openTrace } from "../src/readers/index.js";
 
+// Resolve the fixture relative to this module, not process.cwd(). Running the
+// package suite (`pnpm --filter @agent-inspect/core test`) sets cwd to
+// packages/core, where a cwd-relative path misses the repo-root fixtures.
 const fixturePath = path.resolve(
-  process.cwd(),
-  "fixtures/langgraph/pilot-shaped-bridged-tool.jsonl",
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/langgraph/pilot-shaped-bridged-tool.jsonl",
 );
 
 describe("semantic parity (6.12.3)", () => {


### PR DESCRIPTION
Same cwd-relative fixtures class as #190 (and #191), in a second test file that landed with the 6.13 TraceFacts train.

## Problem

`packages/core/test/semantic-parity.test.ts` loads its fixture via:

```ts
const fixturePath = path.resolve(
  process.cwd(),
  "fixtures/langgraph/pilot-shaped-bridged-tool.jsonl",
);
```

`process.cwd()` is the repo root only when the whole suite is launched from there (root `vitest run`, CI `test:coverage`). Running the package suite the standard way:

```
pnpm --filter @agent-inspect/core test
```

executes `vitest run -c ../../vitest.config.ts` with cwd set to `packages/core`, so the path resolves to the nonexistent `packages/core/fixtures/langgraph/...` and the test fails with ENOENT.

## Fix

Resolve the fixture from `import.meta.url`, matching the rest of the suite.

## Verification

Before (cwd = packages/core), `semantic-parity` fails with ENOENT. After, it passes from both the package directory and the repo root. A grep for cwd-relative fixture paths across `packages/**/test` now returns only `cli-option-aliases.test.ts`, which #191 fixes; together they close the class.