### PR TITLE
fix(checks): resolve LLM model, provider, finish reason from nested metadata

### DIFF
--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -938,6 +938,28 @@ function stringAttr(event: PersistedInspectEvent, keys: readonly string[]): stri
   return undefined;
 }
 
+/**
+ * Reads a string from `attributes.metadata`. v0.1 traces carry LLM identity
+ * (model/provider/finishReason) under nested `metadata`, which the bridge keeps
+ * at `attributes.metadata.*` rather than promoting to a top-level attribute the
+ * way it promotes tokens to `tokenUsage`. Checks must look there too.
+ */
+function metadataStringAttr(
+  event: PersistedInspectEvent,
+  keys: readonly string[],
+): string | undefined {
+  const metadata = event.attributes?.metadata;
+  if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const record = metadata as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return undefined;
+}
+
 function numericAttr(event: PersistedInspectEvent, keys: readonly string[]): number | undefined {
   for (const key of keys) {
     const value = event.attributes?.[key];
@@ -1026,18 +1048,22 @@ function semanticEvents(
 }
 
 function llmModel(event: PersistedInspectEvent): string | undefined {
+  const keys = ["model", "modelId", "responseModelId", "modelName", "model_name"];
   return (
-    stringAttr(event, ["model", "modelId", "responseModelId", "modelName", "model_name"]) ??
+    stringAttr(event, keys) ??
+    metadataStringAttr(event, keys) ??
     stripPrefix(event.name, ["llm:", "generation:", "transcription:", "speech:"])
   );
 }
 
 function llmProvider(event: PersistedInspectEvent): string | undefined {
-  return stringAttr(event, ["provider", "providerName", "provider_name"]);
+  const keys = ["provider", "providerName", "provider_name"];
+  return stringAttr(event, keys) ?? metadataStringAttr(event, keys);
 }
 
 function llmFinishReason(event: PersistedInspectEvent): string | undefined {
-  return stringAttr(event, ["finishReason", "rawFinishReason", "finish_reason"]);
+  const keys = ["finishReason", "rawFinishReason", "finish_reason"];
+  return stringAttr(event, keys) ?? metadataStringAttr(event, keys);
 }
 
 function retryCount(event: PersistedInspectEvent): number | undefined {

--- a/packages/core/test/checks.test.ts
+++ b/packages/core/test/checks.test.ts
@@ -474,6 +474,36 @@ describe("built-in run, tool, and LLM checks", () => {
     expect(result.status).toBe("pass");
     expect(result.findings).toHaveLength(0);
   });
+
+  it("resolves LLM model, provider, and finish reason from nested metadata", () => {
+    // v0.1 traces bridge LLM identity under attributes.metadata rather than
+    // promoting it to top-level attributes, so the checks must look there.
+    const llm = persisted("event-a", {
+      kind: "LLM",
+      name: "llm:generate-answer",
+      attributes: {
+        metadata: { model: "gpt-4o", provider: "openai", finishReason: "stop" },
+      },
+      tokenUsage: { input: 10, output: 5, total: 15 },
+    });
+    const read = readResult([llm]);
+
+    const result = runTraceChecks(
+      { read },
+      {
+        rules: [
+          createLlmUsageRule({
+            allowedModels: ["gpt-4o"],
+            allowedProviders: ["openai"],
+            finishReasons: ["stop"],
+          }),
+        ],
+      },
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.findings).toHaveLength(0);
+  });
 });
 
 describe("built-in structure and safety checks", () => {


### PR DESCRIPTION
Fixes #200.

## Problem

`llmModel` / `llmProvider` / `llmFinishReason` read only top-level attributes via `stringAttr`. v0.1 traces carry LLM identity under nested `metadata`, which the reader keeps at `attributes.metadata.*` (it promotes `metadata.tokens` to `tokenUsage`, but not model/provider/finishReason). So on a v0.1 trace, the model allowlist could not see the real model and fell back to the step name.

```
$ agent-inspect check llm-with-tokens --dir fixtures/traces --allowed-model fixture-model
Check status: fail
- [llm-with-tokens] llm.usage: LLM model generate-answer is not allowed. (attributes.model)
```

`generate-answer` is the step name; the real model (`fixture-model`) lives at `attributes.metadata.model`. The token-budget check on the same trace works because tokens are promoted. Tool checks already read nested metadata via `resolveCanonicalToolName`; the LLM resolvers did not.

## Fix

Add `metadataStringAttr` and fall back to it in the three LLM resolvers, after top-level attributes and before the name-prefix heuristic. Native v0.2 traces (model at `attributes.model`) are unaffected.

After:

```
$ agent-inspect check llm-with-tokens --dir fixtures/traces --allowed-model fixture-model
Check status: pass

$ agent-inspect check llm-with-tokens --dir fixtures/traces --allowed-model gpt-4o
Check status: fail
- [llm-with-tokens] llm.usage: LLM model fixture-model is not allowed.   # real model now reported
```

## Tests

Adds a regression test using an LLM event whose model/provider/finishReason live under `attributes.metadata`, asserting the allowlists resolve them. `pnpm typecheck` passes and the core check suite is green (the only failing tests in a `pnpm --filter core test` run are the pre-existing cwd-relative fixture tests fixed separately in #191 and #199).