### PR TITLE
test(tracefacts): assert parity across public surfaces

### DIFF
--- a/packages/mcp-server/test/trace-facts-surface-parity.test.ts
+++ b/packages/mcp-server/test/trace-facts-surface-parity.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildTraceFacts } from "agent-inspect/checks";
+import { openTraceFile } from "agent-inspect/readers";
+
+import { artifactsCommand } from "../../cli/src/artifacts.js";
+import { callReadOnlyTool, createMcpServerContext } from "../src/tools.js";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.resolve(
+  testDir,
+  "../../../fixtures/langgraph/pilot-shaped-bridged-tool.jsonl",
+);
+
+type ParitySummary = {
+  rawEventCount: number;
+  logicalEventCount: number;
+  runningLogicalCount: number;
+  finishedToolNames: readonly string[];
+  finishedToolCount: number;
+  pairedCount: number;
+  parentRemapCount: number;
+};
+
+function paritySummary(value: ParitySummary): ParitySummary {
+  return {
+    rawEventCount: value.rawEventCount,
+    logicalEventCount: value.logicalEventCount,
+    runningLogicalCount: value.runningLogicalCount,
+    finishedToolNames: [...value.finishedToolNames],
+    finishedToolCount: value.finishedToolCount,
+    pairedCount: value.pairedCount,
+    parentRemapCount: value.parentRemapCount,
+  };
+}
+
+function expectSurfaceParity(
+  surface: "CLI" | "MCP",
+  actual: ParitySummary,
+  expected: ParitySummary,
+): void {
+  expect(
+    paritySummary(actual),
+    `${surface} TraceFacts semantic fields differ from the TypeScript API`,
+  ).toEqual(expected);
+}
+
+describe("TraceFacts public-surface parity", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("agrees across TypeScript API, CLI evidence, and read-only MCP", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "agent-inspect-trace-facts-parity-"),
+    );
+    tempDirs.push(tempRoot);
+    const traceDir = path.join(tempRoot, "traces");
+    const outputDir = path.join(tempRoot, "artifacts");
+    await mkdir(traceDir, { recursive: true });
+    const fixtureBytes = await readFile(fixture);
+    await writeFile(path.join(traceDir, "parity.jsonl"), fixtureBytes);
+
+    const read = await openTraceFile(fixture);
+    const apiFacts = buildTraceFacts(read);
+    const expected = paritySummary(apiFacts.summary);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await artifactsCommand(fixture, {
+      outputDir,
+      alwaysEvidence: true,
+      json: true,
+    });
+    expect(process.exitCode ?? 0).toBe(0);
+    const evidence = JSON.parse(
+      await readFile(path.join(outputDir, "evidence.json"), "utf8"),
+    ) as { semantics?: ParitySummary };
+    expect(evidence.semantics).toBeDefined();
+    expectSurfaceParity("CLI", evidence.semantics!, expected);
+
+    const beforeMcpRead = await readdir(traceDir);
+    const beforeMcpBytes = await readFile(path.join(traceDir, "parity.jsonl"));
+    const mcpResult = await callReadOnlyTool(
+      createMcpServerContext({ traceDir }),
+      "get_trace_facts",
+      { runId: read.runs[0]!.runId },
+    );
+    expect(mcpResult.isError).toBe(false);
+    const mcp = JSON.parse(mcpResult.content[0]!.text as string) as {
+      summary: ParitySummary;
+      toolNames: string[];
+      llmCount: number;
+      outcomeCount: number;
+    };
+    expectSurfaceParity("MCP", mcp.summary, expected);
+    expect(mcp.toolNames).toEqual([...apiFacts.toolsByName.keys()].sort());
+    expect(mcp.llmCount).toBe(apiFacts.llmEvents.length);
+    expect(mcp.outcomeCount).toBe(apiFacts.outcomeEvents.length);
+    expect(await readdir(traceDir)).toEqual(beforeMcpRead);
+    expect(await readFile(path.join(traceDir, "parity.jsonl"))).toEqual(
+      beforeMcpBytes,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the small-fixture first slice requested in #222. One existing synthetic local trace now drives the TypeScript API, CLI evidence, and read-only MCP `get_trace_facts` path in the same test.

The test normalizes only the shared semantic fields, so presentation-only differences do not fail parity. A divergence reports the named surface and Vitest field diff. It also verifies the MCP read leaves both the trace directory entries and source bytes unchanged.

**Linked issue (required):** #222

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Reproduction / evidence

Before this PR, TraceFacts had internal parity coverage but no single assertion spanning the actual CLI, TypeScript API, and read-only MCP surfaces. This test will fail with a surface-labelled structural diff if any shared count, finished tool name, pairing count, or parent-remap count drifts.

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [x] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli` — ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm typecheck
# TypeScript: No errors found

pnpm exec vitest run packages/mcp-server/test/trace-facts-surface-parity.test.ts --reporter verbose
# 1 passed

pnpm build
# passed

pnpm test
# 247 files passed; 1,728 tests passed

git diff --check
# clean
```

The final build/full-suite run used a no-space temporary worktree. In the original `Application Support/...` workspace, six unchanged Vite dynamic-import tests percent-encoded the space and failed module resolution; the same exact commit passed all 1,728 tests at `/private/tmp/agent-inspect-222-e358f5a`.

## Data safety

- [x] Synthetic data only — no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were generated from the existing fixture corpus

## Release hygiene

- [x] No version bumps and **no Changesets** — maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why; claim/scope comment posted before implementation
- [x] Tests added for the requested parity contract
- [x] No docs update needed: behavior and public APIs are unchanged
- [x] `git diff --check` clean