### PR TITLE
fix: union CLI check shorthands with preset select

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -322,6 +322,7 @@ Options:
   - `trajectory`: completion/structure/relationship focus; excludes share-safety findings
   - `safety`: raw-content / secret / redaction focus
   - `comprehensive`: union of trajectory and safety
+  - Presets are a base select set. CLI shorthands on the same invocation (`--fail-on-observation`, `--required-tool`, `--forbidden-tool`, `--allowed-model`, `--max-total-tokens`, `--max-duration-ms`, `--max-step-duration`, `--detect-stalls`) extend that set; they are not dropped because the preset already selected rules. Config `checks.select` is not silently expanded with unrelated configured rules.
 - `--evidence-on <fail|always|never>`: write local Evidence v2 (no upload); omitted = never
 - `--evidence-dir <path>`: Evidence output directory or base path
 - `--evidence-profile <local|share|strict>`: redaction profile for Evidence (default `share`)

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -104,6 +104,84 @@ export interface ResolvedPreset {
   select: string[];
 }
 
+const DEFAULT_SELECT = ["run.status"];
+
+/**
+ * Preserve first-seen order while dropping empty and duplicate rule ids.
+ */
+export function uniqueSelectIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    const trimmed = id.trim();
+    if (trimmed === "" || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Rule ids implied by CLI shorthand flags on this invocation.
+ * Does not include config-only constructed rules.
+ */
+export function cliShorthandSelectIds(options: CheckCommandOptions): string[] {
+  const ids: string[] = [];
+  if (options.failOnObservation !== undefined && options.failOnObservation.trim() !== "") {
+    ids.push("outcome.status");
+  }
+  if ((options.requiredTool?.length ?? 0) > 0 || (options.forbiddenTool?.length ?? 0) > 0) {
+    ids.push("tool.usage");
+  }
+  if ((options.allowedModel?.length ?? 0) > 0 || options.maxTotalTokens !== undefined) {
+    ids.push("llm.usage");
+  }
+  if (options.maxDurationMs !== undefined) {
+    ids.push("run.duration");
+  }
+  if (options.maxStepDuration !== undefined) {
+    ids.push("run.maxStepDuration");
+  }
+  if (options.detectStalls === true) {
+    ids.push("run.stall");
+  }
+  return ids;
+}
+
+/**
+ * Canonical check select union:
+ * 1. Preset base ids
+ * 2. Explicit `--rule`
+ * 3. Config `checks.select` (no silent expansion of unrelated configured rules)
+ * 4. CLI shorthand ids used on this invocation
+ * Empty explicit select (no preset / `--rule` / config select) keeps auto-select
+ * of constructed rules plus default `run.status`.
+ */
+export function unionCheckSelect(input: {
+  presetSelect?: readonly string[];
+  explicitRules?: readonly string[];
+  configSelect?: readonly string[];
+  shorthandIds?: readonly string[];
+  constructedRuleIds?: readonly string[];
+}): string[] {
+  const explicit = uniqueSelectIds([
+    ...(input.presetSelect ?? []),
+    ...(input.explicitRules ?? []),
+    ...(input.configSelect ?? []),
+  ]);
+  if (explicit.length === 0) {
+    return uniqueSelectIds([
+      ...DEFAULT_SELECT,
+      ...(input.constructedRuleIds ?? []).filter((id) => id !== "run.status"),
+    ]);
+  }
+  const constructed = new Set(input.constructedRuleIds ?? []);
+  const shorthand = (input.shorthandIds ?? []).filter(
+    (id) => constructed.size === 0 || constructed.has(id),
+  );
+  return uniqueSelectIds([...explicit, ...shorthand]);
+}
+
 /**
  * Resolve an additive check preset into option/select patches.
  * Omitting preset returns undefined and leaves default check behavior unchanged.
@@ -194,7 +272,6 @@ type RuleBuildResult = {
   diagnostics: TraceCheckDiagnostic[];
 };
 
-const DEFAULT_SELECT = ["run.status"];
 const CONFIG_EXTENSIONS = new Set([".json", ".js", ".mjs", ".cjs"]);
 const TS_CONFIG_EXTENSIONS = new Set([".ts", ".mts", ".cts"]);
 
@@ -325,7 +402,6 @@ function applyResolvedPreset(
     options: {
       ...options,
       ...(resolved.requireCompleted ? { requireCompleted: true } : {}),
-      rule: [...resolved.select, ...(options.rule ?? [])],
     },
   };
 }
@@ -333,6 +409,7 @@ function applyResolvedPreset(
 function buildRules(
   config: CheckConfig,
   options: CheckCommandOptions,
+  presetSelect: readonly string[] = [],
 ): RuleBuildResult {
   const diagnostics: TraceCheckDiagnostic[] = [];
   const checks = normalizeConfig(config);
@@ -458,24 +535,15 @@ function buildRules(
     rules.push(createSafetyOversizedAttributeRule(safety));
   }
 
-  const select = [
-    ...(asStringArray(checks.select) ?? []),
-    ...(options.rule ?? []),
-  ];
-
-  // Shorthand flags construct rules; auto-select those rule ids so they are
-  // not silently dropped when the user did not pass --rule / config select.
-  if (select.length === 0) {
-    const auto = new Set<string>(DEFAULT_SELECT);
-    for (const rule of rules) {
-      if (rule.id !== "run.status") auto.add(rule.id);
-    }
-    return {
-      rules,
-      select: [...auto],
-      diagnostics,
-    };
-  }
+  const constructedRuleIds = rules.map((rule) => rule.id);
+  const shorthandIds = cliShorthandSelectIds(options);
+  const select = unionCheckSelect({
+    presetSelect,
+    explicitRules: options.rule ?? [],
+    configSelect: asStringArray(checks.select) ?? [],
+    shorthandIds,
+    constructedRuleIds,
+  });
 
   return {
     rules,
@@ -654,7 +722,7 @@ export async function checkCommand(
       config = applied.config;
       effectiveOptions = applied.options;
     }
-    const built = buildRules(config, effectiveOptions);
+    const built = buildRules(config, effectiveOptions, resolved?.select ?? []);
     if (built.diagnostics.some((item) => item.severity === "error")) {
       result = errorResult("AI_CHECK_INVALID_CONFIG", "Invalid check configuration.");
       result.diagnostics = [...built.diagnostics];

--- a/packages/cli/test/check-preset.test.ts
+++ b/packages/cli/test/check-preset.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { resolvePreset } from "../src/check.js";
+import {
+  cliShorthandSelectIds,
+  resolvePreset,
+  unionCheckSelect,
+  uniqueSelectIds,
+} from "../src/check.js";
 import {
   parseEvidenceFormat,
   parseEvidenceProfile,
@@ -72,6 +77,81 @@ describe("resolvePreset", () => {
 
   it("rejects unknown preset names", () => {
     expect(() => resolvePreset("mystery")).toThrow(/Unknown --preset/);
+  });
+});
+
+describe("unionCheckSelect", () => {
+  it("preserves first-seen order and drops duplicates", () => {
+    expect(uniqueSelectIds([" run.status ", "tool.usage", "run.status", ""])).toEqual([
+      "run.status",
+      "tool.usage",
+    ]);
+  });
+
+  it("maps CLI shorthands to constructed rule ids", () => {
+    expect(
+      cliShorthandSelectIds({
+        failOnObservation: "failed",
+        requiredTool: ["search_docs"],
+        allowedModel: ["gpt-4.1-mini"],
+        maxDurationMs: "1",
+        maxStepDuration: "1ms",
+        detectStalls: true,
+      }),
+    ).toEqual([
+      "outcome.status",
+      "tool.usage",
+      "llm.usage",
+      "run.duration",
+      "run.maxStepDuration",
+      "run.stall",
+    ]);
+  });
+
+  it("keeps auto-select when preset, --rule, and config select are empty", () => {
+    expect(
+      unionCheckSelect({
+        constructedRuleIds: ["run.status", "tool.usage", "llm.usage"],
+        shorthandIds: ["tool.usage"],
+      }),
+    ).toEqual(["run.status", "tool.usage", "llm.usage"]);
+  });
+
+  it("unions preset, explicit --rule, config select, then shorthands without expanding other constructed rules", () => {
+    expect(
+      unionCheckSelect({
+        presetSelect: ["run.status", "run.requireCompleted"],
+        explicitRules: ["safety.rawPrompt"],
+        configSelect: ["structure.orphan"],
+        shorthandIds: ["outcome.status", "run.duration"],
+        constructedRuleIds: [
+          "run.status",
+          "run.requireCompleted",
+          "safety.rawPrompt",
+          "structure.orphan",
+          "outcome.status",
+          "run.duration",
+          "llm.usage",
+        ],
+      }),
+    ).toEqual([
+      "run.status",
+      "run.requireCompleted",
+      "safety.rawPrompt",
+      "structure.orphan",
+      "outcome.status",
+      "run.duration",
+    ]);
+  });
+
+  it("does not select a shorthand whose rule was not constructed", () => {
+    expect(
+      unionCheckSelect({
+        presetSelect: ["run.status"],
+        shorthandIds: ["outcome.status"],
+        constructedRuleIds: ["run.status"],
+      }),
+    ).toEqual(["run.status"]);
   });
 });
 

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -240,6 +240,164 @@ describe("check command", () => {
     expect(serialized).not.toContain("should-not-leak");
   });
 
+  it("does not silently expand config select with unrelated configured rules", async () => {
+    const file = await writeTrace(tmp, "long.jsonl", [
+      event("event-a", {
+        timestamp: "2026-06-26T00:00:00.000Z",
+        durationMs: 5000,
+      }),
+    ]);
+    const config = path.join(tmp, "select-only-status.json");
+    await writeFile(
+      config,
+      JSON.stringify({
+        checks: {
+          select: ["run.status"],
+          run: { maxDurationMs: 1 },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runCheck(file, { config });
+
+    expect(process.exitCode).toBe(0);
+    expect(result.status).toBe("pass");
+    expect(result.findings?.some((item) => item.ruleId === "run.duration")).toBeFalsy();
+  });
+
+  it("executes --fail-on-observation with --preset trajectory", async () => {
+    const file = await writeTrace(tmp, "failed-outcome.jsonl", [
+      event("event-run"),
+      event("event-outcome", {
+        eventId: "outcome-1",
+        kind: "OUTCOME",
+        name: "policyShown",
+        attributes: {
+          outcomeStatus: "failed",
+          expectation: "Refund policy visible",
+        },
+      }),
+    ]);
+
+    const result = await runCheck(file, {
+      preset: "trajectory",
+      failOnObservation: "failed",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+    expect(result.findings?.some((item) => item.ruleId === "outcome.status")).toBe(true);
+  });
+
+  it("executes --required-tool with --preset safety", async () => {
+    const file = await writeTrace(tmp, "no-tool.jsonl", [
+      event("event-a", {
+        kind: "LLM",
+        name: "llm:gpt-4.1-mini",
+      }),
+    ]);
+
+    const result = await runCheck(file, {
+      preset: "safety",
+      requiredTool: ["search_docs"],
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+    expect(result.findings?.some((item) => item.ruleId === "tool.usage")).toBe(true);
+  });
+
+  it("executes --allowed-model and --max-total-tokens with --preset trajectory", async () => {
+    const file = await writeTrace(tmp, "llm.jsonl", [
+      event("event-run"),
+      event("event-llm", {
+        kind: "LLM",
+        name: "llm:gpt-4.1-mini",
+        attributes: { model: "gpt-4.1-mini" },
+        tokenUsage: { input: 10, output: 10, total: 20 },
+      }),
+    ]);
+
+    const modelResult = await runCheck(file, {
+      preset: "trajectory",
+      allowedModel: ["gpt-4o-mini"],
+    });
+    expect(process.exitCode).toBe(1);
+    expect(modelResult.findings?.some((item) => item.ruleId === "llm.usage")).toBe(true);
+
+    process.exitCode = 0;
+    const tokenResult = await runCheck(file, {
+      preset: "trajectory",
+      maxTotalTokens: "1",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(tokenResult.findings?.some((item) => item.ruleId === "llm.usage")).toBe(true);
+  });
+
+  it("executes --max-duration-ms with --preset trajectory", async () => {
+    const file = await writeTrace(tmp, "slow.jsonl", [
+      event("event-a", {
+        timestamp: "2026-06-26T00:00:00.000Z",
+        durationMs: 5000,
+      }),
+      event("event-b", {
+        eventId: "event-b",
+        timestamp: "2026-06-26T00:00:05.000Z",
+        durationMs: 1,
+      }),
+    ]);
+
+    const result = await runCheck(file, {
+      preset: "trajectory",
+      maxDurationMs: "1",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+    expect(result.findings?.some((item) => item.ruleId === "run.duration")).toBe(true);
+  });
+
+  it("executes --max-step-duration with --preset trajectory", async () => {
+    const file = await writeTrace(tmp, "slow-step.jsonl", [
+      event("event-run"),
+      event("event-llm", {
+        kind: "LLM",
+        name: "llm:gpt-4.1-mini",
+        durationMs: 5000,
+      }),
+    ]);
+
+    const result = await runCheck(file, {
+      preset: "trajectory",
+      maxStepDuration: "1ms",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+    expect(result.findings?.some((item) => item.ruleId === "run.maxStepDuration")).toBe(true);
+  });
+
+  it("executes --detect-stalls with --preset trajectory", async () => {
+    const file = await writeTrace(tmp, "stall.jsonl", [
+      event("event-run"),
+      event("event-llm", {
+        kind: "LLM",
+        name: "llm:gpt-4.1-mini",
+        status: "running",
+      }),
+    ]);
+
+    const result = await runCheck(file, {
+      preset: "trajectory",
+      detectStalls: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+    expect(result.findings?.some((item) => item.ruleId === "run.stall")).toBe(true);
+  });
+
   it("writes local evidence on failure when --evidence-on fail", async () => {
     const cwd = process.cwd();
     process.chdir(tmp);
@@ -290,5 +448,53 @@ describe.skipIf(!builtCliHasCheckCommand)("built check CLI", () => {
     expect(result.stdout).toContain("--format");
     expect(result.stdout).toContain("--config");
     expect(result.stdout).toContain("--rule");
+  });
+
+  it("executes trajectory plus --fail-on-observation from the packed CLI", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-packed-check-"));
+    try {
+      const file = path.join(tmp, "failed-outcome.jsonl");
+      await writeFile(
+        file,
+        jsonl(
+          event("event-run"),
+          event("event-outcome", {
+            eventId: "outcome-1",
+            kind: "OUTCOME",
+            name: "policyShown",
+            attributes: {
+              outcomeStatus: "failed",
+              expectation: "Refund policy visible",
+            },
+          }),
+        ),
+        "utf-8",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          cliDist,
+          "check",
+          file,
+          "--preset",
+          "trajectory",
+          "--fail-on-observation",
+          "failed",
+          "--json",
+        ],
+        { encoding: "utf-8" },
+      );
+
+      expect(result.status).toBe(1);
+      const parsed = JSON.parse(result.stdout) as {
+        status?: string;
+        findings?: { ruleId?: string }[];
+      };
+      expect(parsed.status).toBe("fail");
+      expect(parsed.findings?.some((item) => item.ruleId === "outcome.status")).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `check --preset` previously filled `select`, so constructed CLI shorthand rules (`--fail-on-observation`, `--required-tool`, `--allowed-model` / `--max-total-tokens`, `--max-duration-ms`, `--max-step-duration`, `--detect-stalls`) were built but never executed.
- Select is now a deterministic union of preset base ids, explicit `--rule`, config `checks.select`, and shorthands used on this invocation. Empty select still auto-selects constructed rules plus `run.status`. Config select is not silently expanded with unrelated configured rules.
- Guardrail/circuit stay on the existing post-`runTraceChecks` path. Docs: one CLI paragraph that presets are a base set and shorthands extend them.

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/check-preset.test.ts packages/cli/test/check.test.ts`
- [x] Built CLI packed regression: `--preset trajectory --fail-on-observation failed --json` reports `outcome.status`
- [ ] Do not merge this PR as part of the 6.17.2 presentation train until PR B is ready; no tag / publish