### PR TITLE
docs: add anonymized case-study template

### DIFF
--- a/docs/community/ANONYMIZED-CASE-STUDY-TEMPLATE.md
+++ b/docs/community/ANONYMIZED-CASE-STUDY-TEMPLATE.md
@@ -1,0 +1,81 @@
+# Anonymized technical case-study template
+
+Use this template when contributing a public-safe AgentInspect case study. Keep
+it technical, reproducible, and anonymized. Prefer synthetic or minimized data
+over raw production traces.
+
+## Submission metadata
+
+- **Title:**
+- **Contributor / organization:**
+- **GitHub handle:**
+- **Date:**
+- **AgentInspect version:**
+- **Package or surface used:** `agent-inspect` / adapter / reporter / MCP / other
+- **Stack:** framework, runtime, test runner, CI, and operating system
+- **Support level:** stable / preview / experimental
+
+## Scenario
+
+Describe the agent workflow in neutral terms.
+
+- **Agent type:** coding agent / support agent / workflow agent / other
+- **Primary task:**
+- **Tools or integrations involved:**
+- **Local-only or CI:**
+- **Synthetic fixture or minimized reproduction used:** yes / no
+
+Do not include customer names, private repository names, internal hostnames, raw
+prompts, raw completions, API responses, or production log excerpts unless they
+have been explicitly approved for public disclosure.
+
+## What broke
+
+Summarize the failure mode.
+
+- **Symptom:**
+- **Where it appeared:** local run / CI / PR review / support report
+- **Expected behavior:**
+- **Actual behavior:**
+- **Why normal logs were insufficient:**
+
+Use placeholders such as `example.test`, `user@example.test`,
+`CUSTOMER_ID_REDACTED`, and `TOKEN_REDACTED` for anything sensitive.
+
+## What AgentInspect captured
+
+Explain the evidence surface without attaching unsafe raw traces.
+
+- **Evidence or TraceContract surface:**
+- **Important step / tool / assertion:**
+- **First causal failure identified:**
+- **Relevant command:**
+
+```bash
+# Example only; replace with the exact command you ran.
+npx agent-inspect report <run-id>
+```
+
+If you attach an artifact, attach the smallest useful redacted excerpt. Prefer a
+Markdown summary, selected snippet, or synthetic fixture over a full trace.
+
+## Outcome
+
+- **Fix or mitigation:**
+- **Verification command:**
+- **Result after fix:**
+- **Remaining limitation or follow-up:**
+
+## Public-safe evidence checklist
+
+Before submitting, confirm:
+
+- [ ] The case study uses synthetic, minimized, or approved-for-public data.
+- [ ] No API keys, bearer tokens, cookies, credentials, or webhook secrets appear.
+- [ ] No customer names, tenant IDs, account IDs, internal hostnames, private paths, or proprietary prompts appear.
+- [ ] Raw prompts, completions, tool inputs, and tool outputs are omitted or explicitly approved for public disclosure.
+- [ ] Any attached trace/export was generated with a share-safe redaction profile and then manually reviewed.
+- [ ] Screenshots do not expose terminal history, environment variables, account details, or private repository names.
+- [ ] The write-up states the AgentInspect version and exact validation command.
+
+See also [Safe trace sharing checklist](../SAFE-TRACE-SHARING.md).

--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -34,6 +34,11 @@ For community extension or adapter registry proposals, start from the
 package metadata, maintainer contact, privacy defaults, conformance evidence,
 and known gaps before a registry entry is reviewed.
 
+For public proof narratives, start from the
+[anonymized technical case-study template](ANONYMIZED-CASE-STUDY-TEMPLATE.md).
+It keeps submissions focused on version, stack, scenario, Evidence/TraceContract
+findings, outcome, and explicit public-safety checks rather than raw traces.
+
 ## Package boundaries (detailed)
 
 ### Root `agent-inspect`


### PR DESCRIPTION
## Summary
- add an anonymized technical case-study contribution template under `docs/community/`
- include required fields for version, stack, scenario, Evidence/TraceContract surface, outcome, and validation
- add an explicit public-safe evidence checklist and link the template from the expanded contributor guide

**Linked issue (required):** #228

## Type of change

- [x] Documentation only
- [ ] Bug fix (non-breaking)
- [ ] Example / recipe / fixture
- [ ] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Reproduction / evidence

Docs-only contribution. The new template gives partners and contributors a structured, share-safe way to write public technical case studies without attaching raw traces, secrets, customer identifiers, prompts, or production logs.

Closes #228

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm install --frozen-lockfile
pnpm typecheck
pnpm build
pnpm test -- packages/mcp-server/test/cli.test.ts
pnpm test
pnpm docs:check
git diff --check
```

Note: an initial `pnpm test` before `pnpm build` failed because `packages/mcp-server/test/cli.test.ts` expects built CLI wrapper artifacts. After running `pnpm build`, the focused CLI test and the full test suite passed.

## Data safety

- [x] Synthetic data only — no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets** — maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean
