### PR TITLE
docs: center README logo and restore the packed loop diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rajudandigam/agent-inspect/main/docs/assets/agent-inspect-logo-dark.svg?sanitize=true">
-    <img src="https://raw.githubusercontent.com/rajudandigam/agent-inspect/main/docs/assets/agent-inspect-logo.svg?sanitize=true" width="240" alt="AgentInspect">
-  </picture>
+  <img src="https://raw.githubusercontent.com/rajudandigam/agent-inspect/main/docs/assets/agent-inspect-logo-mark.svg?sanitize=true" width="56" height="56" alt="AgentInspect">
 </p>
-
-<p align="center"><strong>Local-first evidence for TypeScript AI agents</strong></p>
+<p align="center"><strong>agent-inspect</strong></p>
+<p align="center">Local-first evidence for TypeScript AI agents</p>
 
 <h1 align="center">
   See what your agent did.<br>
@@ -47,7 +44,7 @@ npm install agent-inspect
 Agent code rarely fails as one function call. It plans, retrieves, calls tools, invokes a model, retries, and produces side effects. Flat logs show fragments. AgentInspect keeps the run as local JSONL and gives you one evidence loop from the same trace.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rajudandigam/agent-inspect/main/docs/assets/showcase/diagrams/value-loop.svg" alt="Capture or import one local trace, then debug the run, prevent trajectory regressions, and prepare share-checked evidence" width="900">
+  <img src="https://raw.githubusercontent.com/rajudandigam/agent-inspect/main/docs/assets/readme-product-loop.svg?sanitize=true" alt="Capture one local trace, then debug, prevent, and share from the same evidence loop" width="900">
 </p>
 
 ## One trace. Three jobs.

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -21,7 +21,8 @@ Curated terminal recordings and diagrams for AgentInspect **6.17.x**. They show 
 | [debug-tree.gif](assets/showcase/gif/debug-tree.gif) | Debug — `list` then inspect a local run |
 | [check-pass-fail.gif](assets/showcase/gif/check-pass-fail.gif) | Prevent — `check --preset trajectory` plus shorthands, pass then fail |
 | [evidence-bundle.gif](assets/showcase/gif/evidence-bundle.gif) | Share — `bundle --profile share` then `bundle verify` (relative `./evidence`) |
-| [value-loop.svg](assets/showcase/diagrams/value-loop.svg) | Capture once → debug, prevent, share |
+| [readme-product-loop.svg](assets/readme-product-loop.svg) | README loop: one local trace → debug → prevent → share |
+| [value-loop.svg](assets/showcase/diagrams/value-loop.svg) | Alternate stacked Debug / Prevent / Share diagram |
 
 The check tape is named for the `check` command, not `gate`.
 

--- a/docs/assets/agent-inspect-logo-mark.svg
+++ b/docs/assets/agent-inspect-logo-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="AgentInspect">
+  <defs>
+    <linearGradient id="ai-mark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f46e5"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="48" height="48" rx="12" fill="url(#ai-mark)"/>
+  <path d="M16 16h16M16 24h12M16 32h16" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="36" cy="24" r="5" fill="none" stroke="#fff" stroke-width="2"/>
+  <path d="M39.5 27.5L44 32" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/docs/assets/readme-product-loop.svg
+++ b/docs/assets/readme-product-loop.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="150" viewBox="0 0 900 150" role="img" aria-label="AgentInspect evidence loop: capture or import, understand causality, enforce expectations, verify and bundle, review locally or in customer-owned Studio">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="150" viewBox="0 0 900 150" role="img" aria-label="Capture one local trace, then debug the run, prevent trajectory regressions, and share-checked evidence">
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
       <path d="M0,0 L6,3 L0,6 Z" fill="#64748b"/>
@@ -6,30 +6,21 @@
   </defs>
   <rect width="900" height="150" fill="#ffffff"/>
   <g font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
-    <rect x="10" y="24" width="150" height="78" rx="12" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
-    <text x="85" y="52" text-anchor="middle" font-size="13" font-weight="600" fill="#312e81">Capture / import</text>
-    <text x="85" y="72" text-anchor="middle" font-size="10" fill="#475569">JSONL, adapters,</text>
-    <text x="85" y="86" text-anchor="middle" font-size="10" fill="#475569">logs, standards</text>
-    <path d="M168 63h22" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
-    <rect x="198" y="24" width="150" height="78" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
-    <text x="273" y="52" text-anchor="middle" font-size="13" font-weight="600" fill="#064e3b">Understand</text>
-    <text x="273" y="72" text-anchor="middle" font-size="10" fill="#475569">tree, timeline,</text>
-    <text x="273" y="86" text-anchor="middle" font-size="10" fill="#475569">report, diff</text>
-    <path d="M356 63h22" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
-    <rect x="386" y="24" width="150" height="78" rx="12" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="461" y="52" text-anchor="middle" font-size="13" font-weight="600" fill="#78350f">Enforce</text>
-    <text x="461" y="72" text-anchor="middle" font-size="10" fill="#475569">checks, contracts,</text>
-    <text x="461" y="86" text-anchor="middle" font-size="10" fill="#475569">suites, CI gates</text>
-    <path d="M544 63h22" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
-    <rect x="574" y="24" width="150" height="78" rx="12" fill="#f8fafc" stroke="#64748b" stroke-width="1.5"/>
-    <text x="649" y="52" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Verify / bundle</text>
-    <text x="649" y="72" text-anchor="middle" font-size="10" fill="#475569">redact, verify-safe,</text>
-    <text x="649" y="86" text-anchor="middle" font-size="10" fill="#475569">offline bundle</text>
-    <path d="M732 63h22" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
-    <rect x="762" y="24" width="128" height="78" rx="12" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
-    <text x="826" y="52" text-anchor="middle" font-size="13" font-weight="600" fill="#4c1d95">Review</text>
-    <text x="826" y="72" text-anchor="middle" font-size="10" fill="#475569">local or Studio</text>
-    <text x="826" y="86" text-anchor="middle" font-size="10" fill="#475569">Beta (yours)</text>
-    <text x="450" y="132" text-anchor="middle" font-size="12" fill="#64748b">No account · no default upload · metadata-only by default · optional customer-owned Studio</text>
+    <rect x="16" y="28" width="188" height="78" rx="12" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="110" y="58" text-anchor="middle" font-size="13" font-weight="600" fill="#312e81">One local trace</text>
+    <text x="110" y="78" text-anchor="middle" font-size="11" fill="#475569">JSONL you own</text>
+    <path d="M212 67h28" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
+    <rect x="248" y="28" width="188" height="78" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
+    <text x="342" y="58" text-anchor="middle" font-size="13" font-weight="600" fill="#064e3b">Debug</text>
+    <text x="342" y="78" text-anchor="middle" font-size="11" fill="#475569">view · report · explain</text>
+    <path d="M444 67h28" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
+    <rect x="480" y="28" width="188" height="78" rx="12" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="574" y="58" text-anchor="middle" font-size="13" font-weight="600" fill="#78350f">Prevent</text>
+    <text x="574" y="78" text-anchor="middle" font-size="11" fill="#475569">check · contract · CI</text>
+    <path d="M676 67h28" stroke="#64748b" stroke-width="2" marker-end="url(#arr)"/>
+    <rect x="712" y="28" width="172" height="78" rx="12" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+    <text x="798" y="58" text-anchor="middle" font-size="13" font-weight="600" fill="#4c1d95">Share</text>
+    <text x="798" y="78" text-anchor="middle" font-size="11" fill="#475569">redact · bundle · verify</text>
+    <text x="450" y="132" text-anchor="middle" font-size="12" fill="#64748b">Capture once. Debug, prevent, and share from the same local trace.</text>
   </g>
 </svg>

--- a/docs/product/PACKAGE-DOCS-MANIFEST.json
+++ b/docs/product/PACKAGE-DOCS-MANIFEST.json
@@ -46,6 +46,7 @@
     "docs/WORKSPACE.md",
     "docs/assets/agent-inspect-logo-dark.svg",
     "docs/assets/agent-inspect-logo.svg",
+    "docs/assets/agent-inspect-logo-mark.svg",
     "docs/assets/readme-product-loop.svg"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "docs/VSCODE.md",
     "docs/assets/agent-inspect-logo.svg",
     "docs/assets/agent-inspect-logo-dark.svg",
+    "docs/assets/agent-inspect-logo-mark.svg",
     "docs/assets/readme-product-loop.svg"
   ],
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Replace the combined light/dark wordmark SVG (invisible in dark editor preview, optically left-shifted) with a square mark plus HTML `agent-inspect` text so the header is centered and theme-visible.
- Point the loop image at packed `docs/assets/readme-product-loop.svg?sanitize=true` (Debug → Prevent → Share). The showcase `value-loop.svg` is not in the npm tarball and was not rendering.

## Test plan
- [x] `pnpm repo:health`
- [ ] Confirm GitHub README preview: icon centered, wordmark readable in dark/light
- [ ] Confirm the loop diagram renders on GitHub after merge (`?sanitize=true`)