### PR TITLE
fix(explain): exclude the RUN boundary from run.slowestNode

### DIFF
--- a/packages/core/src/explain.ts
+++ b/packages/core/src/explain.ts
@@ -102,7 +102,14 @@ function countErrorNodes(nodes: FlatNode[]): number {
 
 function slowestNode(nodes: FlatNode[]): FlatNode | undefined {
   return nodes
-    .filter((entry) => entry.node.event.durationMs !== undefined)
+    .filter(
+      (entry) =>
+        entry.node.event.durationMs !== undefined &&
+        // The RUN boundary spans the whole run, so its duration always dominates
+        // and shadows every real step. Rank actual work nodes only, matching the
+        // stats slowest-step ranking, which never counts the run envelope.
+        entry.node.event.kind !== "RUN",
+    )
     .sort((a, b) => {
       const delta = (b.node.event.durationMs ?? 0) - (a.node.event.durationMs ?? 0);
       return delta !== 0 ? delta : a.index - b.index;

--- a/packages/core/test/explain-slowest-node.test.ts
+++ b/packages/core/test/explain-slowest-node.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: explain's run.slowestNode must name the slowest actual step, not
+ * the RUN boundary. The run envelope spans the whole run, so ranking it as a
+ * node always shadows real work and disagrees with stats' slowest-step ranking.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { buildLocalExplanation } from "../src/explain.js";
+import { openTrace } from "../src/readers/index.js";
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/traces",
+);
+
+describe("explain run.slowestNode", () => {
+  it("reports the slowest step rather than the RUN boundary", async () => {
+    // llm-with-tokens has one step (llm:generate-answer, 2044ms) and a
+    // run_completed boundary at 2100ms. The boundary must not win.
+    const opened = await openTrace({
+      type: "file",
+      path: path.join(fixturesDir, "llm-with-tokens.jsonl"),
+    });
+    const explained = buildLocalExplanation(opened.runs[0]!);
+
+    const slowest = explained.facts.find((f) => f.id === "run.slowestNode");
+    expect(slowest).toBeDefined();
+    const value = slowest!.value as {
+      name: string;
+      kind: string;
+      durationMs: number;
+    };
+    expect(value.kind).not.toBe("RUN");
+    expect(value.name).toBe("llm_001");
+    expect(value.durationMs).toBe(2044);
+  });
+
+  it("omits run.slowestNode when a run has only boundary nodes", async () => {
+    // A run with no step-level nodes has nothing to rank; falling back to the
+    // run envelope would be the same bug in a different shape.
+    const content = [
+      JSON.stringify({
+        schemaVersion: "0.1",
+        event: "run_started",
+        runId: "boundary-only",
+        name: "boundary-only",
+        timestamp: 1_700_000_000_000,
+        startTime: 1_700_000_000_000,
+      }),
+      JSON.stringify({
+        schemaVersion: "0.1",
+        event: "run_completed",
+        runId: "boundary-only",
+        status: "success",
+        durationMs: 1234,
+        timestamp: 1_700_000_001_234,
+        endTime: 1_700_000_001_234,
+      }),
+    ].join("\n");
+    const opened = await openTrace(
+      { type: "string", content },
+      { format: "agent-inspect-jsonl" },
+    );
+    const explained = buildLocalExplanation(opened.runs[0]!);
+    expect(explained.facts.find((f) => f.id === "run.slowestNode")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`explain` reported the RUN boundary as `run.slowestNode` for every trace, so the fact never surfaced the slowest actual step.

Before:

```
nested-3-levels     {"name":"run","kind":"RUN","durationMs":150}
llm-with-tokens     {"name":"run","kind":"RUN","durationMs":2100}
tool-timeout-stall  {"name":"run","kind":"RUN","durationMs":200000}
```

After:

```
nested-3-levels     {"name":"step_outer","kind":"LOGIC","durationMs":120}
llm-with-tokens     {"name":"llm_001","kind":"LOGIC","durationMs":2044}
tool-timeout-stall  {"name":"slow_fetch","kind":"LOGIC","durationMs":75000}
```

## Why

`slowestNode()` in `packages/core/src/explain.ts` flattens the whole run tree, which includes the RUN boundary node. The boundary spans the entire run, so its `durationMs` always dominates and shadows every real step. `stats` avoids this because `collectCompletedSteps()` only walks `step_started` / `step_completed` rows, never the run envelope. The two surfaces disagreed on the same concept.

## Fix

Exclude `kind === "RUN"` from the ranking so `run.slowestNode` names the slowest actual work node, matching `stats.slowestSteps`. When a run has only boundary nodes, the fact is omitted rather than falling back to the run envelope.

## Tests

Added `packages/core/test/explain-slowest-node.test.ts`:
- the slowest step is reported instead of the RUN boundary (llm-with-tokens: `llm_001` at 2044ms, not the 2100ms envelope)
- `run.slowestNode` is omitted for a boundary-only run

`tsc --noEmit` clean. Existing cross-command and semantic-parity explain tests still pass.

Fixes #237
