### PR TITLE
test(matchers): pin golden diagnostics for Vitest and Jest matchers

### DIFF
--- a/packages/jest/test/matchers-diagnostics.test.ts
+++ b/packages/jest/test/matchers-diagnostics.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Golden failure diagnostics for the Jest TraceContract / TraceFacts matchers.
+ *
+ * Contributors rely on these messages in CI, so their wording and shape must
+ * not drift silently. Pins the passing outcome plus the mismatch and
+ * insufficient-input (missing { read }) failure messages. Run under Vitest like
+ * the rest of the repo suite; asserts the shared matcher object directly.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import { openTrace } from "agent-inspect/readers";
+import type { TraceReadResult } from "agent-inspect/readers";
+
+import { agentInspectJestMatchers } from "../src/matchers.js";
+
+const fixturePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/traces/tool-with-io.jsonl",
+);
+
+async function openFixture(): Promise<TraceReadResult> {
+  return openTrace({ type: "string", content: readFileSync(fixturePath, "utf8") });
+}
+
+describe("Jest matcher golden diagnostics", () => {
+  it("passes toHaveRequiredTool for a present tool", async () => {
+    const read = await openFixture();
+    const result = agentInspectJestMatchers.toHaveRequiredTool(read.events, "fixture-search");
+    expect(result.pass).toBe(true);
+  });
+
+  it("reports the missing tool and the observed tools on failure", async () => {
+    const read = await openFixture();
+    const result = agentInspectJestMatchers.toHaveRequiredTool(read.events, "charge_card");
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      'expected required tool charge_card; found=["fixture-search"]',
+    );
+  });
+
+  it("passes toPassTraceContract when the required tool is present", async () => {
+    const read = await openFixture();
+    const result = agentInspectJestMatchers.toPassTraceContract(
+      { read },
+      { tools: { requiredTools: ["fixture-search"] } },
+    );
+    expect(result.pass).toBe(true);
+  });
+
+  it("names the failing rule ids when a contract fails", async () => {
+    const read = await openFixture();
+    const result = agentInspectJestMatchers.toPassTraceContract(
+      { read },
+      { tools: { requiredTools: ["charge_card"] } },
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      'expected trace contract to pass; findings=["tool.usage"]',
+    );
+  });
+
+  it("explains the required { read } input when given bare events", async () => {
+    const read = await openFixture();
+    const result = agentInspectJestMatchers.toPassTraceContract(
+      read.events as never,
+      { tools: { requiredTools: ["fixture-search"] } },
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      "toPassTraceContract expects TraceCheckInput ({ read }) so evaluateTraceContract can run.",
+    );
+  });
+});

--- a/packages/vitest/test/matchers-diagnostics.test.ts
+++ b/packages/vitest/test/matchers-diagnostics.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Golden failure diagnostics for the Vitest TraceContract / TraceFacts matchers.
+ *
+ * Contributors rely on these messages in CI, so their wording and shape must
+ * not drift silently. Pins the passing outcome plus the mismatch and
+ * insufficient-input (missing { read }) failure messages.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import { openTrace } from "agent-inspect/readers";
+import type { TraceReadResult } from "agent-inspect/readers";
+
+import { agentInspectVitestMatchers } from "../src/matchers.js";
+
+const fixturePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/traces/tool-with-io.jsonl",
+);
+
+async function openFixture(): Promise<TraceReadResult> {
+  return openTrace({ type: "string", content: readFileSync(fixturePath, "utf8") });
+}
+
+describe("Vitest matcher golden diagnostics", () => {
+  it("passes toHaveRequiredTool for a present tool", async () => {
+    const read = await openFixture();
+    const result = agentInspectVitestMatchers.toHaveRequiredTool(read.events, "fixture-search");
+    expect(result.pass).toBe(true);
+  });
+
+  it("reports the missing tool and the observed tools on failure", async () => {
+    const read = await openFixture();
+    const result = agentInspectVitestMatchers.toHaveRequiredTool(read.events, "charge_card");
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      'expected required tool charge_card; found=["fixture-search"]',
+    );
+  });
+
+  it("passes toPassTraceContract when the required tool is present", async () => {
+    const read = await openFixture();
+    const result = agentInspectVitestMatchers.toPassTraceContract(
+      { read },
+      { tools: { requiredTools: ["fixture-search"] } },
+    );
+    expect(result.pass).toBe(true);
+  });
+
+  it("names the failing rule ids when a contract fails", async () => {
+    const read = await openFixture();
+    const result = agentInspectVitestMatchers.toPassTraceContract(
+      { read },
+      { tools: { requiredTools: ["charge_card"] } },
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      'expected trace contract to pass; findings=["tool.usage"]',
+    );
+  });
+
+  it("explains the required { read } input when given bare events", async () => {
+    const read = await openFixture();
+    const result = agentInspectVitestMatchers.toPassTraceContract(
+      read.events as never,
+      { tools: { requiredTools: ["fixture-search"] } },
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toBe(
+      "toPassTraceContract expects TraceCheckInput ({ read }) so evaluateTraceContract can run.",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds golden failure-diagnostic tests for the Vitest and Jest TraceContract / TraceFacts matchers so their CI-facing messages do not drift silently.

## Coverage (both packages)

- `toHaveRequiredTool` mismatch pins `expected required tool <name>; found=[...]`
- `toPassTraceContract` contract failure pins `expected trace contract to pass; findings=["tool.usage"]` (the failing rule ids)
- the insufficient-input case (bare events array instead of `{ read }`) pins the `expects TraceCheckInput ({ read })` message
- the passing outcomes for both matchers

## Notes

Uses the synthetic `fixtures/traces/tool-with-io.jsonl` fixture, resolved module-relative. No network. Both files run under the repo's Vitest suite and assert the shared matcher objects directly.

Closes #220