### PR TITLE
test(core): add broken -> fixed TraceContract golden path

### DIFF
--- a/fixtures/traces/README.md
+++ b/fixtures/traces/README.md
@@ -25,6 +25,8 @@ Small **manual trace** files consumed by list/view/export/diff and compatibility
 | `repeated-tool-args.jsonl` | Same tool called 5x with identical `arguments` metadata (circuit signal); run ends in loop-guard error |
 | `tool-timeout-stall.jsonl` | Tool exceeds its `timeoutMs` metadata, then a long stall before the run aborts |
 | `dual-format-parity.jsonl` | v0.1 half of list/stats/search parity coverage; embedded run id differs from filename |
+| `contract-broken.jsonl` | Refund agent that errors without calling the required tool; fails a TraceContract on `run.status` and `tool.usage` |
+| `contract-fixed.jsonl` | Same refund agent that calls `refund_order` and completes; passes the same TraceContract |
 
 ## Feature mapping
 

--- a/fixtures/traces/contract-broken.jsonl
+++ b/fixtures/traces/contract-broken.jsonl
@@ -1,0 +1,4 @@
+{"schemaVersion":"0.1","event":"run_started","timestamp":1700000002000,"runId":"contract-broken","name":"refund-agent","startTime":1700000002000}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000002010,"runId":"contract-broken","stepId":"llm_001","name":"llm:plan-refund","type":"llm","startTime":1700000002010,"metadata":{"model":"fixture-model"}}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000002110,"runId":"contract-broken","stepId":"llm_001","status":"success","endTime":1700000002110,"durationMs":100}
+{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000002120,"runId":"contract-broken","status":"error","endTime":1700000002120,"durationMs":120}

--- a/fixtures/traces/contract-fixed.jsonl
+++ b/fixtures/traces/contract-fixed.jsonl
@@ -1,0 +1,6 @@
+{"schemaVersion":"0.1","event":"run_started","timestamp":1700000003000,"runId":"contract-fixed","name":"refund-agent","startTime":1700000003000}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000003010,"runId":"contract-fixed","stepId":"llm_001","name":"llm:plan-refund","type":"llm","startTime":1700000003010,"metadata":{"model":"fixture-model"}}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000003110,"runId":"contract-fixed","stepId":"llm_001","status":"success","endTime":1700000003110,"durationMs":100}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000003120,"runId":"contract-fixed","stepId":"tool_001","name":"tool:refund-order","type":"tool","startTime":1700000003120,"metadata":{"toolName":"refund_order","inputPreview":"{\"orderId\":\"A-1\"}","outputPreview":"{\"refunded\":true}"}}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000003320,"runId":"contract-fixed","stepId":"tool_001","status":"success","endTime":1700000003320,"durationMs":200}
+{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000003330,"runId":"contract-fixed","status":"success","endTime":1700000003330,"durationMs":330}

--- a/packages/core/test/contract-broken-fixed-golden.test.ts
+++ b/packages/core/test/contract-broken-fixed-golden.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Golden broken -> fail -> fixed -> pass path for TraceContract.
+ *
+ * First-use proof and CI teaching both need one deterministic path that shows a
+ * contract catching a real trajectory failure and then passing once the run is
+ * fixed. The broken run errors out without calling the required tool; the fixed
+ * run calls it and completes. Failure reasons are pinned so the diagnostics stay
+ * actionable.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  defineTraceContract,
+  evaluateTraceContract,
+  type TraceContractInput,
+} from "../src/checks/index.js";
+import { openTrace } from "../src/readers/index.js";
+
+const tracesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/traces",
+);
+
+// A refund agent must call refund_order and finish cleanly.
+const refundContract: TraceContractInput = {
+  tools: { requiredTools: ["refund_order"] },
+  run: { allowedStatuses: ["ok"] },
+};
+
+async function evaluate(fixture: string) {
+  const read = await openTrace({
+    type: "string",
+    content: readFileSync(path.join(tracesDir, fixture), "utf8"),
+  });
+  const result = evaluateTraceContract({ read }, defineTraceContract(refundContract));
+  return {
+    status: result.status,
+    failedRules: result.findings.filter((f) => f.status === "fail").map((f) => f.ruleId),
+  };
+}
+
+describe("TraceContract broken -> fixed golden path", () => {
+  it("fails the broken run with actionable, stable reasons", async () => {
+    const broken = await evaluate("contract-broken.jsonl");
+    expect(broken.status).toBe("fail");
+    // The run errored AND the required tool was never called.
+    expect([...broken.failedRules].sort()).toEqual(["run.status", "tool.usage"]);
+  });
+
+  it("passes the fixed run", async () => {
+    const fixed = await evaluate("contract-fixed.jsonl");
+    expect(fixed.status).toBe("pass");
+    expect(fixed.failedRules).toEqual([]);
+  });
+});

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -35,6 +35,8 @@ const REQUIRED = {
     "fixtures/traces/tool-timeout-stall.jsonl",
     "fixtures/traces/dual-format-parity.jsonl",
     "fixtures/traces/outcome-pass.jsonl",
+    "fixtures/traces/contract-broken.jsonl",
+    "fixtures/traces/contract-fixed.jsonl",
   ],
   langgraph: [
     "fixtures/langgraph/plain-root.jsonl",


### PR DESCRIPTION
## What

Adds a single deterministic **broken -> fail -> fixed -> pass** path so first-use proof and CI teaching have one example of a TraceContract catching a real trajectory failure.

## Fixtures (synthetic v0.1)

- `contract-broken.jsonl`: a refund agent that errors out without ever calling the required tool.
- `contract-fixed.jsonl`: the same agent that calls `refund_order` and completes.

Both are registered in `validate-fixtures.mjs` and listed in the traces README (`fixtures:check` passes).

## Test

Against the contract `{ tools: { requiredTools: ["refund_order"] }, run: { allowedStatuses: ["ok"] } }`:

- the broken run fails on stable, actionable rule ids: `run.status` (errored) and `tool.usage` (missing tool)
- the fixed run passes with no failed rules

## Notes

Synthetic data only, no network.

Closes #159