### PR TITLE
docs: add safe support reproduction workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ Optional Preview: [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) · [MCP.md](./M
 | --- | ----- |
 | [EVIDENCE-FORMAT.md](./EVIDENCE-FORMAT.md) · [BUNDLES.md](./BUNDLES.md) | Evidence v2 |
 | [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md) | Redaction and share checks |
+| [SUPPORT-REPRODUCTION.md](./SUPPORT-REPRODUCTION.md) | Safe, minimized support reproduction workflow |
 | [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) | Local MCP coding-agent loop |
 | [SELF-HOSTING.md](./SELF-HOSTING.md) | Customer-owned Studio |
 

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -28,6 +28,8 @@ Manual traces redact common sensitive keys **before disk** by default. Pass `red
 
 ## Before sharing
 
+When a maintainer or support responder needs reproducible evidence, follow the [safe support reproduction workflow](./SUPPORT-REPRODUCTION.md) to create and review a minimized Evidence bundle. Do not attach a raw trace directory.
+
 - Use **`--redaction-profile share`** for PR/issue attachments; use **`strict`** when sharing outside your team.
 - **Review** the exported file — profiles do not detect all sensitive data.
 - Treat traces written with `redact: false` as sensitive. Review every event before sharing them outside your team.

--- a/docs/SUPPORT-REPRODUCTION.md
+++ b/docs/SUPPORT-REPRODUCTION.md
@@ -1,0 +1,103 @@
+# Safe support reproduction
+
+Use this workflow when a maintainer or support responder asks for a reproduction that preserves enough local evidence to investigate an AgentInspect issue.
+
+The `share` profile and bundle checks reduce disclosure risk. They do not certify that a bundle is safe to publish. Review the exact bundle you intend to attach.
+
+## When to use this
+
+Use a support reproduction when the issue depends on a trace, execution tree, check result, or generated Evidence artifact that cannot be explained with minimal steps alone.
+
+Do not use a public GitHub issue to share production or customer data. If the issue cannot be reproduced without that data, stop and use an approved private support or security channel.
+
+## Prefer a synthetic or minimized reproduction
+
+Use these sources in order of preference:
+
+1. Synthetic data that demonstrates the same behavior.
+2. A minimized reproduction containing only the failing steps.
+3. A local development reproduction instead of production data.
+4. A reviewed Evidence bundle instead of raw trace directories or terminal output.
+
+Remove unrelated runs, prompts, tool calls, and metadata before creating the bundle. The existing [shareable bundle recipe](../examples/recipes/shareable-bundle-basic/README.md) demonstrates the same Evidence v2 workflow; no separate support script is required.
+
+## Create the reproduction bundle
+
+List local runs and identify the minimized reproduction:
+
+```bash
+npx agent-inspect list --dir .agent-inspect
+```
+
+Create a bundle with the explicit `share` profile, then verify its Evidence v2 structure and file hashes:
+
+```bash
+npx agent-inspect bundle <run-id> \
+  --dir .agent-inspect \
+  --profile share
+
+npx agent-inspect bundle verify \
+  .agent-inspect/bundles/<run-id>
+```
+
+Bundle creation writes a redacted derived copy and runs safety checks against that copy. It does not modify the source trace or upload the bundle. A successful `bundle verify` confirms integrity, not that every sensitive value was detected.
+
+## Review before attaching
+
+Manually open the generated bundle and inspect the exact files you will share. Review at least:
+
+- `evidence.html` for rendered trace content and copied snippets.
+- `summary.md` for identifiers, paths, and failure details.
+- `check-results.json` for safety-check findings and unresolved results.
+- `redaction-report.json` for what detectors changed or reported.
+
+Search all included files for sensitive strings and values, not only familiar metadata keys. Remove the sensitive content, reproduce again with synthetic placeholders, rebuild the bundle, and rerun `bundle verify` after any change.
+
+## Redaction checklist
+
+Review for and remove:
+
+- API keys, bearer tokens, cookies, JWTs, passwords, and private keys.
+- Database URLs, internal hostnames, and private service URLs.
+- Email addresses, phone numbers, and customer identifiers.
+- Ticket, order, tenant, and account identifiers.
+- Proprietary prompts and system instructions.
+- Raw model outputs containing sensitive content.
+- Retrieved private documents.
+- Tool request or response payloads containing sensitive values.
+- Private filesystem paths.
+
+See [Safe trace sharing](./SAFE-TRACE-SHARING.md) for the repository's complete review guidance and limitations. Do not treat this checklist as a new privacy or security policy.
+
+## What to attach
+
+Attach only the reviewed reproduction bundle and the minimum environment context needed to reproduce the issue:
+
+- AgentInspect version.
+- Node.js version.
+- Operating system.
+- Minimal reproduction steps.
+- Expected behavior.
+- Actual behavior.
+
+## What not to attach
+
+Do not attach:
+
+- `.env` files, API keys, or credentials.
+- Raw production traces, customer logs, or unredacted original traces.
+- Proprietary prompts or full sensitive tool request and response payloads.
+- Database dumps or terminal history.
+- Screenshots containing account, credential, or session information.
+- An entire `.agent-inspect` directory that has not been reviewed.
+
+## Retention and production-observability boundary
+
+AgentInspect is a local, inner-loop evidence and debugging tool. It is not a hosted long-term retention or fleet-observability platform. Use dedicated observability systems alongside AgentInspect for production retention, monitoring, dashboards, and organization-wide telemetry. See [Compare AgentInspect](./COMPARE.md) for the current product boundary.
+
+## Related guidance
+
+- [Shareable trace bundles](./BUNDLES.md)
+- [Safe trace sharing checklist](./SAFE-TRACE-SHARING.md)
+- [Security policy](../SECURITY.md)
+- [Evidence v2 format](./EVIDENCE-FORMAT.md)


### PR DESCRIPTION
## Summary

Adds a copyable support reproduction workflow for creating and reviewing shareable AgentInspect Evidence bundles.

This PR adds `docs/SUPPORT-REPRODUCTION.md` and links it from the docs index and safe sharing guidance.

The workflow:

- uses the existing shareable Evidence bundle and redaction behavior
- recommends synthetic or minimized reproductions before using real data
- adds a review and redaction checklist
- documents what users should and should not attach to public support issues
- points to the existing retention and production observability guidance

No runtime behavior, schema, bundle behavior, redaction behavior, upload behavior, or telemetry behavior is changed.

**Linked issue (required):** #227

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [ ] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

This is a docs only change and reuses the existing Evidence bundle, sharing, and redaction paths.

The PR only changes:

- `docs/SUPPORT-REPRODUCTION.md`
- `docs/README.md`
- `docs/SAFE-TRACE-SHARING.md`

No CLI, MCP, fixture, schema, package, or runtime code is modified.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm install --frozen-lockfile
# PASS

pnpm build
# PASS

pnpm typecheck
# PASS

pnpm exec vitest run packages/mcp-server/test/cli.test.ts
# PASS, 5/5 tests

pnpm test
# PASS, 247 test files and 1741 tests

git diff --check
# PASS

pnpm docs:check
# PARTIAL, 5 of 6 sub-gates pass
```

`pnpm docs:check` passes:

- `docs:commands`
- `docs:links`
- `public-truth:check`
- `ai-assets:check`
- `repo:health`

`demo:verify` fails on three existing Evidence fixtures:

- `moderate-agent`
- `langgraph-swarm`
- `debug-prevent-share`

The stored fixture files use CRLF bytes while the SHA-256 values recorded in `evidence.json` correspond to LF normalized content. Normalizing the affected files to LF makes the recorded hashes match exactly.

I also verified that `core.autocrlf=false` does not change the result and that the relevant Git attributes are unspecified. The fixture files, hashing behavior, CLI, MCP, and production code are not modified by this PR.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (commented on the issue before opening the PR)
- [ ] Tests added or updated for behavior changes
- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean

Closes #227