### PR TITLE
test(core): add Evidence v2 malformed-bundle corpus

### DIFF
--- a/fixtures/evidence/README.md
+++ b/fixtures/evidence/README.md
@@ -3,5 +3,6 @@
 - `evidence.v1.example.json` — Evidence format contract example (6.10-0)
 - `xss-corpus.json` — synthetic XSS payloads for HTML escaping regression (6.10-9)
 - `demo/` — broken/fixed deterministic Evidence workflow fixtures (6.10-11)
+- `malformed/` — tiny synthetic malformed `evidence.json` manifests that `bundle verify` must reject with a stable diagnostic (`manifest_invalid` / `file_missing`)
 
 These fixtures contain no real secrets. XSS strings are intentional attack samples for escaping tests only.

--- a/fixtures/evidence/malformed/empty-run-ids.evidence.json
+++ b/fixtures/evidence/malformed/empty-run-ids.evidence.json
@@ -1,0 +1,36 @@
+{
+  "evidenceFormatVersion": "1.0",
+  "generator": {
+    "name": "agent-inspect",
+    "version": "6.17.2"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "assessment": {
+    "status": "SAFE",
+    "note": "Best-effort local safety verification only; not a compliance certification."
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    }
+  ]
+}

--- a/fixtures/evidence/malformed/file-missing.evidence.json
+++ b/fixtures/evidence/malformed/file-missing.evidence.json
@@ -1,0 +1,38 @@
+{
+  "evidenceFormatVersion": "1.0",
+  "generator": {
+    "name": "agent-inspect",
+    "version": "6.17.2"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [
+      "run-a"
+    ],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "assessment": {
+    "status": "SAFE",
+    "note": "Best-effort local safety verification only; not a compliance certification."
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    }
+  ]
+}

--- a/fixtures/evidence/malformed/missing-assessment.evidence.json
+++ b/fixtures/evidence/malformed/missing-assessment.evidence.json
@@ -1,0 +1,34 @@
+{
+  "evidenceFormatVersion": "1.0",
+  "generator": {
+    "name": "agent-inspect",
+    "version": "6.17.2"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [
+      "run-a"
+    ],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    }
+  ]
+}

--- a/fixtures/evidence/malformed/missing-generator.evidence.json
+++ b/fixtures/evidence/malformed/missing-generator.evidence.json
@@ -1,0 +1,34 @@
+{
+  "evidenceFormatVersion": "1.0",
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [
+      "run-a"
+    ],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "assessment": {
+    "status": "SAFE",
+    "note": "Best-effort local safety verification only; not a compliance certification."
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    }
+  ]
+}

--- a/fixtures/evidence/malformed/not-json.evidence.json
+++ b/fixtures/evidence/malformed/not-json.evidence.json
@@ -1,0 +1,1 @@
+{ this is not valid json

--- a/fixtures/evidence/malformed/self-listed-manifest.evidence.json
+++ b/fixtures/evidence/malformed/self-listed-manifest.evidence.json
@@ -1,0 +1,42 @@
+{
+  "evidenceFormatVersion": "1.0",
+  "generator": {
+    "name": "agent-inspect",
+    "version": "6.17.2"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [
+      "run-a"
+    ],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "assessment": {
+    "status": "SAFE",
+    "note": "Best-effort local safety verification only; not a compliance certification."
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    },
+    {
+      "path": "evidence.json",
+      "sha256": "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881"
+    }
+  ]
+}

--- a/fixtures/evidence/malformed/unsupported-version.evidence.json
+++ b/fixtures/evidence/malformed/unsupported-version.evidence.json
@@ -1,0 +1,38 @@
+{
+  "evidenceFormatVersion": "9.9",
+  "generator": {
+    "name": "agent-inspect",
+    "version": "6.17.2"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "source": {
+    "runIds": [
+      "run-a"
+    ],
+    "traceSchemaVersions": [
+      "0.2"
+    ],
+    "sourceHashes": [
+      {
+        "runId": "run-a",
+        "algorithm": "sha256",
+        "hash": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6"
+      }
+    ]
+  },
+  "policy": {
+    "redactionProfile": "share",
+    "verificationPolicy": "share"
+  },
+  "assessment": {
+    "status": "SAFE",
+    "note": "Best-effort local safety verification only; not a compliance certification."
+  },
+  "files": [
+    {
+      "path": "trace.jsonl",
+      "sha256": "ea4f8e5663bf24ef621b5f3bfe0f251e1f9d63d25cfdab35a3ff33ac277d8cc6",
+      "role": "redacted-trace"
+    }
+  ]
+}

--- a/packages/core/test/evidence/evidence-malformed-corpus.test.ts
+++ b/packages/core/test/evidence/evidence-malformed-corpus.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Evidence v2 malformed-bundle corpus.
+ *
+ * CI and support flows must fail closed on tampered or malformed bundles
+ * without crashing. Each fixture under fixtures/evidence/malformed is a tiny
+ * synthetic evidence.json that verify must reject with a stable diagnostic.
+ */
+import { cp, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { verifyEvidenceDirectory } from "../../src/entries/advanced.js";
+
+const corpusDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../fixtures/evidence/malformed",
+);
+
+interface Case {
+  fixture: string;
+  /** Whether a companion trace.jsonl (matching the valid manifest) is present. */
+  withTrace: boolean;
+  expectCode: string;
+}
+
+// Strict manifest validation collapses most structural defects to
+// manifest_invalid; file_missing is the distinct missing-payload case.
+const cases: Case[] = [
+  { fixture: "not-json.evidence.json", withTrace: false, expectCode: "manifest_invalid" },
+  { fixture: "unsupported-version.evidence.json", withTrace: true, expectCode: "manifest_invalid" },
+  { fixture: "missing-generator.evidence.json", withTrace: true, expectCode: "manifest_invalid" },
+  { fixture: "empty-run-ids.evidence.json", withTrace: true, expectCode: "manifest_invalid" },
+  { fixture: "missing-assessment.evidence.json", withTrace: true, expectCode: "manifest_invalid" },
+  { fixture: "self-listed-manifest.evidence.json", withTrace: true, expectCode: "manifest_invalid" },
+  { fixture: "file-missing.evidence.json", withTrace: false, expectCode: "file_missing" },
+];
+
+describe("Evidence v2 malformed-bundle corpus", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-evidence-malformed-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  for (const { fixture, withTrace, expectCode } of cases) {
+    it(`fails closed on ${fixture} with ${expectCode}`, async () => {
+      await cp(path.join(corpusDir, fixture), path.join(tmp, "evidence.json"));
+      if (withTrace) {
+        // Matches the sha256 baked into the valid manifest baseline.
+        await writeFile(path.join(tmp, "trace.jsonl"), "trace\n", "utf-8");
+      }
+
+      const result = await verifyEvidenceDirectory(tmp);
+
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe("fail");
+      expect(result.issues.map((issue) => issue.code)).toContain(expectCode);
+      // Fail closed: every reported issue that blocks is an error, and the
+      // verifier returned a structured result rather than throwing.
+      expect(result.issues.every((issue) => typeof issue.code === "string")).toBe(true);
+    });
+  }
+
+  it("does not throw on an empty directory (missing manifest)", async () => {
+    const result = await verifyEvidenceDirectory(tmp);
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]?.code).toBe("manifest_missing");
+  });
+});


### PR DESCRIPTION
## What

Adds a tiny synthetic corpus of malformed Evidence v2 manifests plus a test asserting `verifyEvidenceDirectory` fails closed on each with a stable diagnostic.

## Corpus (`fixtures/evidence/malformed/`)

| Fixture | Expected code |
|---------|---------------|
| `not-json.evidence.json` | `manifest_invalid` |
| `unsupported-version.evidence.json` | `manifest_invalid` |
| `missing-generator.evidence.json` | `manifest_invalid` |
| `empty-run-ids.evidence.json` | `manifest_invalid` |
| `missing-assessment.evidence.json` | `manifest_invalid` |
| `self-listed-manifest.evidence.json` | `manifest_invalid` |
| `file-missing.evidence.json` | `file_missing` |

Strict manifest validation collapses the structural defects to `manifest_invalid`; `file_missing` is the distinct missing-payload case. The verifier returns a structured result (never throws), and an empty directory reports `manifest_missing`.

## Notes

Complements #218 (which pinned the `verify --json` contract and the tamper / unexpected-file / missing-manifest paths). Synthetic fixtures only, no network. Registered in the evidence fixtures README; `fixtures:check` passes.

Closes #214