### PR TITLE
test(core): add OTLP preservation and known-loss corpus

### DIFF
--- a/fixtures/standards/otlp-preservation-corpus.json
+++ b/fixtures/standards/otlp-preservation-corpus.json
@@ -1,0 +1,45 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "agent-inspect-fixture" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "agent-inspect-preservation-scope",
+            "version": "3.1-fixture"
+          },
+          "spans": [
+            {
+              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+              "spanId": "00f067aa0ba902b7",
+              "name": "agent step",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1700000000000000000",
+              "endTimeUnixNano": "1700000005000000000",
+              "attributes": [
+                { "key": "gen_ai.system", "value": { "stringValue": "fixture-provider" } }
+              ],
+              "events": [
+                {
+                  "name": "gen_ai.content.completion",
+                  "timeUnixNano": "1700000001000000000",
+                  "attributes": [
+                    { "key": "gen_ai.completion", "value": { "stringValue": "synthetic completion text" } }
+                  ]
+                }
+              ],
+              "links": [
+                { "traceId": "4bf92f3577b34da6a3ce929d0e0e4737", "spanId": "00f067aa0ba902b8" }
+              ],
+              "vendorExtensionField": { "foo": "bar" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/otlp-preservation-corpus.test.ts
+++ b/packages/core/test/otlp-preservation-corpus.test.ts
@@ -1,0 +1,45 @@
+/**
+ * OTLP preservation and known-loss boundaries.
+ *
+ * The OTLP reader preserves instrumentation scope while reporting the span
+ * shapes it cannot map (events, links, vendor extensions) as unsupportedFields
+ * rather than dropping them silently. This pins both sides of that boundary so
+ * a reader change cannot quietly lose data or overclaim lossless import.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { openTrace } from "../src/readers/index.js";
+
+const fixturePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/standards/otlp-preservation-corpus.json",
+);
+
+describe("OTLP preservation corpus", () => {
+  it("preserves instrumentation scope and known-loses events, links, and extensions", async () => {
+    const read = await openTrace({
+      type: "string",
+      content: readFileSync(fixturePath, "utf8"),
+    });
+
+    expect(read.format).toBe("otlp-json");
+
+    // Scope is preserved onto event attributes.
+    const scoped = read.events.find(
+      (event) => event.attributes?.["scope.name"] !== undefined,
+    );
+    expect(scoped).toBeDefined();
+    expect(scoped!.attributes?.["scope.name"]).toBe("agent-inspect-preservation-scope");
+    expect(scoped!.attributes?.["scope.version"]).toBe("3.1-fixture");
+
+    // Known-loss boundaries are reported, not silently dropped.
+    const unsupported = read.unsupportedFields;
+    expect(unsupported.some((field) => field.endsWith(".links"))).toBe(true);
+    expect(unsupported.some((field) => field.endsWith(".vendorExtensionField"))).toBe(true);
+    expect(unsupported.some((field) => field.includes(".events["))).toBe(true);
+  });
+});

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -105,6 +105,7 @@ const REQUIRED = {
     "fixtures/standards/openinference-basic.json",
     "fixtures/standards/otlp-basic.json",
     "fixtures/standards/openinference-export-golden.json",
+    "fixtures/standards/otlp-preservation-corpus.json",
   ],
 };
 


### PR DESCRIPTION
## What

Pins both sides of the OTLP import boundary for the span shapes the issue names — scope, links, events, and extensions — so a reader change cannot quietly lose data or overclaim lossless import.

## Fixture

`fixtures/standards/otlp-preservation-corpus.json`: one span with instrumentation **scope**, an **event** carrying a `gen_ai.completion` attribute, a **link**, and a **vendor extension** field.

## Assertions

- **Preserved**: `scope.name` (`agent-inspect-preservation-scope`) and `scope.version` (`3.1-fixture`) land on the mapped event's attributes.
- **Known-loss (reported, not dropped)**: `read.unsupportedFields` contains the `.links` path, the `.vendorExtensionField` path, and an `.events[...]` path.

## Notes

Registered in `validate-fixtures.mjs` (`fixtures:check` passes). Synthetic fixture only; no network collector. Complements the existing OpenInference export-golden coverage.

Closes #162