### PR TITLE
chore: add 6.17.3 patch Changeset for publish.yml

### DIFF
--- a/.changeset/v6173-docs-tests-patch.md
+++ b/.changeset/v6173-docs-tests-patch.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": patch
+"@agent-inspect/adapter-sdk": patch
+"@agent-inspect/ai-sdk": patch
+"@agent-inspect/circuit": patch
+"@agent-inspect/eval": patch
+"@agent-inspect/guardrails": patch
+"@agent-inspect/harness": patch
+"@agent-inspect/index-sqlite": patch
+"@agent-inspect/jest": patch
+"@agent-inspect/langchain": patch
+"@agent-inspect/mcp": patch
+"@agent-inspect/mcp-server": patch
+"@agent-inspect/openai-agents": patch
+"@agent-inspect/redact": patch
+"@agent-inspect/studio": patch
+"@agent-inspect/tui": patch
+"@agent-inspect/viewer": patch
+"@agent-inspect/vitest": patch
+---
+
+Docs updates (README mark/loop, case-study template, Evidence retention guidance, support reproduction), TraceFacts/Evidence/OTLP/CLI regression tests, and exclude the RUN boundary from `run.slowestNode`.


### PR DESCRIPTION
## Summary
- Add a fixed-package patch Changeset so `publish.yml` can open the Version Packages PR for **6.17.3**.
- Covers docs updates since `6.17.2` (README mark/loop, case-study template, Evidence retention, support reproduction), regression test corpora, and the `run.slowestNode` RUN-boundary fix.

## Test plan
- [ ] CI typecheck / unit / size green
- [ ] After merge, `publish.yml` opens Version Packages PR for 6.17.3
- [ ] Merge Version Packages → Trusted Publishing publishes to npm