### PR TITLE
docs: sync public truth to 6.17.3 after Version Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The root package is enough for custom capture, the CLI, checks, and Evidence wor
 
 ## Status and documentation
 
-**Current published baseline:** **6.17.2** · persisted schema `1.0` · Node.js `>=20` · MIT.
+**Current published baseline:** **6.17.3** · persisted schema `1.0` · Node.js `>=20` · MIT.
 
 Legacy v0.1 and v0.2 traces remain readable. Check the npm badge and [changelog](CHANGELOG.md) for the current published version.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ This public roadmap describes direction — not a delivery guarantee. See [docs/
 
 ## Current — repository health and evidence UX (`6.17.1` → `6.18.x`)
 
-**Current release on npm:** **6.17.2** (eighteen fixed-group public packages). Persisted schema **1.0**. Node.js **≥ 20**. **MIT**. Actively maintained.
+**Current release on npm:** **6.17.3** (eighteen fixed-group public packages). Persisted schema **1.0**. Node.js **≥ 20**. **MIT**. Actively maintained.
 
 Active maintainer program: repository health and public-truth cleanup, single-source docs, trajectory/Evidence CI UX, public technical proof, and stable niche packaging — before any conditional v7 assessment.
 

--- a/apps/website/lib/product.ts
+++ b/apps/website/lib/product.ts
@@ -3,7 +3,7 @@
  * Keep in sync with docs/product/PUBLIC-PRODUCT-FACTS.json and root package.json.
  */
 export const product = {
-  version: "6.17.2",
+  version: "6.17.3",
   publicPackageCount: 18,
   releaseStatus: "Actively maintained · schema 1.0 · Node.js 20+ · MIT",
   v7Scheduled: false,

--- a/apps/website/public/ai/packages.json
+++ b/apps/website/public/ai/packages.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.17.2",
+  "version": "6.17.3",
   "fixedGroupCount": 18,
   "packages": [
     {

--- a/apps/website/public/ai/product.json
+++ b/apps/website/public/ai/product.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-inspect",
-  "version": "6.17.2",
+  "version": "6.17.3",
   "schemaVersion": "1.0",
   "category": "Local-first evidence for TypeScript AI agents",
   "headline": "See what your agent did. Catch the wrong path in CI. Keep the evidence local.",
   "supportingSentence": "AgentInspect turns TypeScript agent runs into readable execution trees, deterministic trajectory checks, and portable Evidence v2\u2014without requiring an account, collector, or default upload.",
   "outcome": "Capture once. Debug, prevent, and share from the same local trace.",
-  "statusLine": "Current release: 6.17.2 \u00b7 schema 1.0 \u00b7 Node.js 20+ \u00b7 MIT \u00b7 actively maintained",
+  "statusLine": "Current release: 6.17.3 \u00b7 schema 1.0 \u00b7 Node.js 20+ \u00b7 MIT \u00b7 actively maintained",
   "pillars": [
     {
       "id": "debug",

--- a/apps/website/public/llms-full.txt
+++ b/apps/website/public/llms-full.txt
@@ -1,6 +1,6 @@
 # AgentInspect — llms-full
 
-Curated public guides. Version 6.17.2.
+Curated public guides. Version 6.17.3.
 
 
 

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -6,7 +6,7 @@ AgentInspect turns TypeScript agent runs into readable execution trees, determin
 
 - Category: Local-first evidence for TypeScript AI agents
 - Outcome: Capture once. Debug, prevent, and share from the same local trace.
-- Status: Current release: 6.17.2 · schema 1.0 · Node.js 20+ · MIT · actively maintained
+- Status: Current release: 6.17.3 · schema 1.0 · Node.js 20+ · MIT · actively maintained
 - Site: https://agentinspect.vercel.app
 - Docs: https://agentinspect.vercel.app/docs/
 - GitHub: https://github.com/rajudandigam/agent-inspect

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Local-first TypeScript AI agent toolkit: **debug, regression-test, and safely share** agent behavior on your machine.
 
-**Current release:** [agent-inspect@6.17.2](https://www.npmjs.com/package/agent-inspect) (eighteen linked packages) · schema **1.0** · Node.js **≥ 20** · **MIT** · **actively maintained**.
+**Current release:** [agent-inspect@6.17.3](https://www.npmjs.com/package/agent-inspect) (eighteen linked packages) · schema **1.0** · Node.js **≥ 20** · **MIT** · **actively maintained**.
 
 **Website:** [https://agentinspect.vercel.app/](https://agentinspect.vercel.app/)
 **Docs site:** [https://agentinspect.vercel.app/docs/](https://agentinspect.vercel.app/docs/)

--- a/docs/assets/showcase/provenance.json
+++ b/docs/assets/showcase/provenance.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "1970-01-01T00:00:00.000Z",
-  "packageVersion": "6.17.2",
+  "packageVersion": "6.17.3",
   "rejected": [
     {
       "path": "docs/demo-kit/b77a3f11-0728-4ddc-89ea-e27049ddd2e4.gif",

--- a/docs/implementation/CURRENT-TASK.md
+++ b/docs/implementation/CURRENT-TASK.md
@@ -16,4 +16,4 @@ pendingManualGate: 6.18.0-external-acceptance
 
 ## Published baseline
 
-**6.17.2** (all 18 packages; Version Packages in flight / npm Trusted Publishing)
+**6.17.3** (all 18 packages; Version Packages in flight / npm Trusted Publishing)

--- a/docs/implementation/RELEASE-TRAIN-STATE.md
+++ b/docs/implementation/RELEASE-TRAIN-STATE.md
@@ -5,8 +5,8 @@
 > **Canonical roadmap:** [ROADMAP.md](./ROADMAP.md)
 
 ```yaml
-baselineVersion: "6.17.2"
-publishedVersion: "6.17.2"
+baselineVersion: "6.17.3"
+publishedVersion: "6.17.3"
 currentTrain: "v6.18.0-niche-launch"
 trainStatus: "stopped-before-changeset"
 executionMode: "autonomous-release-train"

--- a/docs/product/PUBLIC-CLAIM-LEDGER.json
+++ b/docs/product/PUBLIC-CLAIM-LEDGER.json
@@ -1,11 +1,11 @@
 {
-  "lastReviewedVersion": "6.17.2",
-  "lastReviewedCommit": "71beb34",
+  "lastReviewedVersion": "6.17.3",
+  "lastReviewedCommit": "4ab20cf",
   "allowedClaims": [
     "Local-first evidence for TypeScript AI agents",
     "Capture once. Debug, prevent, and share from the same local trace.",
     "No account · no collector · no default upload · metadata-only by default",
-    "Current published baseline 6.17.2, schema 1.0, Node.js >=20, MIT",
+    "Current published baseline 6.17.3, schema 1.0, Node.js >=20, MIT",
     "18-package fixed release group",
     "Zero open pilot findings at the 6.16.0 moderate + deep-swarm gates",
     "Evidence v2 is a Supported workflow, not compliance certification",

--- a/docs/product/PUBLIC-PRODUCT-FACTS.json
+++ b/docs/product/PUBLIC-PRODUCT-FACTS.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-inspect",
-  "version": "6.17.2",
+  "version": "6.17.3",
   "schemaVersion": "1.0",
   "node": ">=20",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "headline": "See what your agent did. Catch the wrong path in CI. Keep the evidence local.",
   "supportingSentence": "AgentInspect turns TypeScript agent runs into readable execution trees, deterministic trajectory checks, and portable Evidence v2\u2014without requiring an account, collector, or default upload.",
   "outcome": "Capture once. Debug, prevent, and share from the same local trace.",
-  "statusLine": "Current release: 6.17.2 \u00b7 schema 1.0 \u00b7 Node.js 20+ \u00b7 MIT \u00b7 actively maintained",
+  "statusLine": "Current release: 6.17.3 \u00b7 schema 1.0 \u00b7 Node.js 20+ \u00b7 MIT \u00b7 actively maintained",
   "releaseStatus": "Actively maintained \u00b7 schema 1.0 \u00b7 Node.js 20+ \u00b7 MIT",
   "maintenanceLine": "The 6.17 line is actively maintained for correctness, compatibility, documentation, security, and framework evolution.",
   "trustLine": "No account \u00b7 no collector \u00b7 no default upload \u00b7 metadata-only by default",

--- a/docs/product/PUBLIC-PRODUCT-FACTS.md
+++ b/docs/product/PUBLIC-PRODUCT-FACTS.md
@@ -12,12 +12,12 @@ Single source of public product truth for README, website, npm descriptions, AI 
 | Category | Local-first evidence for TypeScript AI agents |
 | Headline | See what your agent did. Catch the wrong path in CI. Keep the evidence local. |
 | Outcome | Capture once. Debug, prevent, and share from the same local trace. |
-| Version | 6.17.2 |
+| Version | 6.17.3 |
 | Schema | 1.0 |
 | Node | >=20 |
 | License | MIT |
 | Public packages | 18 (Changesets fixed group) |
-| Status line | Current release: 6.17.2 · schema 1.0 · Node.js 20+ · MIT · actively maintained |
+| Status line | Current release: 6.17.3 · schema 1.0 · Node.js 20+ · MIT · actively maintained |
 | Maintenance | The 6.17 line is actively maintained for correctness, compatibility, documentation, security, and framework evolution |
 
 ## Supporting sentence

--- a/examples/evidence/demo-manifest.json
+++ b/examples/evidence/demo-manifest.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "1970-01-01T00:00:00.000Z",
   "generator": "scripts/demo-generate.mjs",
-  "packageVersion": "6.17.2",
+  "packageVersion": "6.17.3",
   "samples": [
     {
       "id": "moderate-agent",


### PR DESCRIPTION
## Summary
- Align public-truth surfaces with published **6.17.3** so `public-truth:check` / main CI pass after Trusted Publishing.

## Test plan
- [x] `pnpm run public-truth:check`
- [ ] CI green on this PR
- [ ] Merge restores green `main`