### PR TITLE
docs: add TypeScript Evidence v2 consumer example

### DIFF
--- a/docs/EVIDENCE-FORMAT.md
+++ b/docs/EVIDENCE-FORMAT.md
@@ -6,6 +6,8 @@
 
 **Operating guidance:** [EVIDENCE-RETENTION.md](./EVIDENCE-RETENTION.md) covers retention, size, and PR-attachment.
 
+**TypeScript consumer:** [Build, read, and verify Evidence v2 with published APIs](../examples/evidence-v2-typescript/README.md).
+
 AgentInspect **evidence** is a local, share-checked, integrity-verifiable artifact for reviewing one or more agent runs offline — the “Playwright report for an agent run,” not a compliance certification.
 
 ## Relationship to existing bundles

--- a/examples/evidence-v2-typescript/README.md
+++ b/examples/evidence-v2-typescript/README.md
@@ -1,0 +1,58 @@
+# Evidence v2 TypeScript consumer
+
+This minimal TypeScript example uses the published `agent-inspect/advanced` entry point to:
+
+1. build an Evidence v2 manifest for synthetic local files;
+2. serialize, read, and parse `evidence.json`;
+3. verify the Evidence directory and its SHA-256 hashes.
+
+It uses only Node.js built-ins and AgentInspect. It needs no API key, performs no network I/O, and removes its temporary Evidence directory after verification.
+
+## Run from this repository
+
+From the repository root:
+
+```bash
+pnpm build
+pnpm exec tsc -p examples/evidence-v2-typescript/tsconfig.json
+node examples/evidence-v2-typescript/dist/index.js
+```
+
+Expected output:
+
+```text
+Evidence v2 verification: pass
+Run: example-run
+Files checked: 2
+```
+
+## Verify the packed package
+
+Build a consumer tarball from the repository root:
+
+```bash
+pnpm build
+npm pack
+```
+
+In an empty consumer directory, install that tarball and the TypeScript compiler:
+
+```bash
+npm init -y
+npm pkg set type=module
+npm install /absolute/path/to/agent-inspect-<version>.tgz
+npm install --save-dev typescript @types/node
+```
+
+Use this directory's `index.ts` and `tsconfig.json`, then run:
+
+```bash
+npx tsc -p tsconfig.json
+node dist/index.js
+```
+
+The same published subpath is covered by the repository's full tarball gate:
+
+```bash
+pnpm pack:smoke
+```

--- a/examples/evidence-v2-typescript/index.ts
+++ b/examples/evidence-v2-typescript/index.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  EVIDENCE_MANIFEST_FILENAME,
+  buildEvidenceManifest,
+  parseEvidenceManifestJson,
+  serializeEvidenceManifest,
+  sha256Hex,
+  verifyEvidenceDirectory,
+} from "agent-inspect/advanced";
+
+const runId = "example-run";
+const timestamp = 1_720_000_000_000;
+const trace = `${JSON.stringify({
+  schemaVersion: "0.1",
+  event: "run_started",
+  timestamp,
+  runId,
+  name: "Evidence consumer example",
+  startTime: timestamp,
+  metadata: { tool: "example-tool", result: "synthetic success" },
+})}\n`;
+
+const files = [
+  { path: "trace.jsonl", content: trace },
+  { path: "summary.md", content: "# Synthetic success\n" },
+] as const;
+
+const evidenceDir = await mkdtemp(path.join(tmpdir(), "agent-inspect-evidence-"));
+
+try {
+  await Promise.all(
+    files.map((file) => writeFile(path.join(evidenceDir, file.path), file.content, "utf8")),
+  );
+
+  const manifest = buildEvidenceManifest({
+    generatorName: "evidence-v2-typescript-example",
+    generatorVersion: "1.0.0",
+    runIds: [runId],
+    traceSchemaVersions: ["0.1"],
+    sourceHashes: [{ runId, algorithm: "sha256", hash: sha256Hex(trace) }],
+    redactionProfile: "share",
+    assessmentStatus: "SAFE WITH WARNINGS",
+    files,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  const manifestPath = path.join(evidenceDir, EVIDENCE_MANIFEST_FILENAME);
+  await writeFile(manifestPath, serializeEvidenceManifest(manifest), "utf8");
+
+  const parsed = parseEvidenceManifestJson(await readFile(manifestPath, "utf8"));
+  if (!parsed.source.runIds.includes(runId)) {
+    throw new Error(`Parsed manifest does not contain run id ${runId}.`);
+  }
+
+  const verification = await verifyEvidenceDirectory(evidenceDir);
+  if (!verification.ok) {
+    console.error("Evidence verification failed:");
+    for (const issue of verification.issues) {
+      console.error(`- ${issue.code}: ${issue.message}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log("Evidence v2 verification: pass");
+    console.log(`Run: ${runId}`);
+    console.log(`Files checked: ${verification.checkedFiles}`);
+  }
+} finally {
+  await rm(evidenceDir, { recursive: true, force: true });
+}

--- a/examples/evidence-v2-typescript/tsconfig.json
+++ b/examples/evidence-v2-typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary

- Add a minimal TypeScript example that builds, reads, and verifies Evidence v2 using the published `agent-inspect/advanced` API.

- Document the packed consumer path and link the example from the Evidence format guide.

- No Evidence API, export, dependency, schema, or runtime behavior is changed.

**Linked issue (required):** #216

## Type of change

- [x] Documentation only
- [x] Example / recipe / fixture

## Reproduction / evidence

- The example compiles and runs successfully using synthetic local data.

- Evidence v2 build, read, parse, hash, and verification all complete successfully through the published `agent-inspect/advanced` API.

- Final verification passes with 2 files checked.

## Product boundaries

- [x] Local-first only
- [x] No network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm build
pnpm typecheck
pnpm test
pnpm pack:smoke
pnpm docs:commands
pnpm docs:links
git diff --check
```

Results:

- Example TypeScript compile: pass
- Example execution: pass
- Evidence v2 verification: pass, 2 files checked
- `pnpm build`: pass
- `pnpm typecheck`: pass
- `pnpm test`: pass, 261 files and 1,868 tests
- `pnpm pack:smoke`: pass
- `pnpm docs:commands`: pass
- `pnpm docs:links`: pass
- `git diff --check`: pass

`pnpm docs:check` and `repo:health` remain blocked by the existing 6.17.2 and 6.17.3 public version drift present at starting commit `4ab20cf`. This PR does not modify unrelated release or version documentation.

## Data safety

- [x] Synthetic data only
- [x] No real prompts, logs, tokens, or PII

## Release hygiene

- [x] No version bumps and no Changesets
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] `git diff --check` clean

Closes #216