### PR TITLE
test(cli): pin bundle verify JSON failure contract

### DIFF
--- a/packages/cli/test/bundle-verify-json-contract.test.ts
+++ b/packages/cli/test/bundle-verify-json-contract.test.ts
@@ -27,9 +27,11 @@ interface VerifyPayload {
   root: string;
   checkedFiles: number;
   issues: VerifyIssue[];
-  assessment: { note: string; sourceStatus: string; status: string };
-  generator: { name: string; version: string };
+  assessment?: { note: string; sourceStatus: string; status: string };
+  generator?: { name: string; version: string };
 }
+
+const failurePayloadKeys = ["checkedFiles", "issues", "ok", "root", "status"];
 
 function jsonl(...rows: unknown[]): string {
   return `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
@@ -98,13 +100,13 @@ describe("bundle verify --json contract", () => {
     expect(typeof payload.checkedFiles).toBe("number");
     expect(payload.checkedFiles).toBeGreaterThan(0);
     expect(payload.issues).toEqual([]);
-    expect(Object.keys(payload.assessment).sort()).toEqual([
+    expect(Object.keys(payload.assessment!).sort()).toEqual([
       "note",
       "sourceStatus",
       "status",
     ]);
-    expect(payload.generator.name).toBe("agent-inspect");
-    expect(typeof payload.generator.version).toBe("string");
+    expect(payload.generator!.name).toBe("agent-inspect");
+    expect(typeof payload.generator!.version).toBe("string");
     expect(process.exitCode ?? 0).toBe(0);
   });
 
@@ -147,18 +149,36 @@ describe("bundle verify --json contract", () => {
   });
 
   it("reports a missing manifest deterministically", async () => {
-    const empty = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-verify-empty-"));
-    try {
-      await bundleVerifyCommand(empty, { json: true });
-      const payload = lastPayload();
-      expect(payload.ok).toBe(false);
-      expect(payload.status).toBe("fail");
-      expect(payload.checkedFiles).toBe(0);
-      expect(payload.issues[0]?.code).toBe("manifest_missing");
-      expect(payload.issues[0]?.path).toBe("evidence.json");
-      expect(process.exitCode).toBe(1);
-    } finally {
-      await rm(empty, { recursive: true, force: true });
-    }
+    const out = await bundleOut("missing-manifest-bundle");
+    await rm(path.join(out, "evidence.json"));
+
+    await bundleVerifyCommand(out, { json: true });
+    const payload = lastPayload();
+    expect(Object.keys(payload).sort()).toEqual(failurePayloadKeys);
+    expect(payload.ok).toBe(false);
+    expect(payload.status).toBe("fail");
+    expect(typeof payload.root).toBe("string");
+    expect(payload.checkedFiles).toBe(0);
+    expect(Array.isArray(payload.issues)).toBe(true);
+    expect(payload.issues[0]?.code).toBe("manifest_missing");
+    expect(payload.issues[0]?.path).toBe("evidence.json");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports a malformed manifest deterministically", async () => {
+    const out = await bundleOut("malformed-manifest-bundle");
+    await writeFile(path.join(out, "evidence.json"), "{invalid json\n", "utf-8");
+
+    await bundleVerifyCommand(out, { json: true });
+    const payload = lastPayload();
+    expect(Object.keys(payload).sort()).toEqual(failurePayloadKeys);
+    expect(payload.ok).toBe(false);
+    expect(payload.status).toBe("fail");
+    expect(typeof payload.root).toBe("string");
+    expect(payload.checkedFiles).toBe(0);
+    expect(Array.isArray(payload.issues)).toBe(true);
+    expect(payload.issues[0]?.code).toBe("manifest_invalid");
+    expect(payload.issues[0]?.path).toBe("evidence.json");
+    expect(process.exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
Pin the existing `bundle verify --json` failure payload shape when manifest metadata is unavailable.
Cover missing and invalid manifests, including omitted metadata fields, stable top level keys, and exit code behavior.
This is a test only follow up. The only file changed is `packages/cli/test/bundle-verify-json-contract.test.ts`.
No runtime, CLI output, Evidence schema, or verifier behavior is changed.

The success JSON contract is already pinned, but failure paths did not fully define the top level payload shape when manifest metadata is unavailable.

This change locks the existing behavior for missing and invalid manifests. When manifest metadata cannot be read, `assessment` and `generator` remain absent from the serialized response. The tests now explicitly cover that shape instead of leaving it implicit.

The malformed manifest case also verifies `manifest_invalid`, exit code `1`, and the same stable failure shape.

**Linked issue (required):** #260 

## Type of change

* [ ] Bug fix (non breaking)
* [ ] Documentation only
* [ ] Example / recipe / fixture
* [x] Test / regression coverage
* [ ] Feature or enhancement (scoped)
* [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

The gap can be reproduced by creating a valid Evidence bundle, removing `evidence.json`, and running:

```bash
agent-inspect bundle verify <bundle-path> --json
```

The same failure contract can be exercised with an `evidence.json` file containing invalid JSON.

Before this change, the failure tests asserted selected values such as `ok`, `status`, `issues`, and exit code behavior, but did not pin the complete top level key set when manifest metadata was unavailable.

This PR adds focused regression coverage for both missing and invalid manifests and explicitly locks the existing omission of `assessment` and `generator`.

Only `packages/cli/test/bundle-verify-json-contract.test.ts` is changed.

### Focused regression coverage

The focused contract suite passes all five cases, including the missing and malformed manifest regressions added by this change.

<img width="1065" height="269" alt="2026-08-25-185527" src="https://github.com/user-attachments/assets/dee7a7fb-728c-4abc-aacd-dd83d9b64797" />

## Product boundaries

* [x] Local first only, no network upload added
* [x] No new vendor sinks
* [x] No SaaS / dashboard scope added
* [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
* [x] No `step_failed` event introduced
* [x] `inspectRun` default tracing behavior unchanged
* [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

* [ ] `agent-inspect` (root: core + CLI, published)
* [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
* [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
* [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
* [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
* [ ] Docs / fixtures / recipes / community only

## Validation

```text
pnpm build
PASS

pnpm typecheck
PASS

pnpm exec vitest run packages/cli/test/bundle-verify-json-contract.test.ts
5/5 passed

pnpm test
261 test files passed
1869 tests passed

git diff --check
PASS
```

`pnpm docs:check` was not run because this PR does not change documentation.

## Data safety

* [x] Synthetic data only, no real prompts, logs, tokens, or PII
* [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

* [x] No version bumps and no Changesets, maintainers own Changesets and releases
* [x] No new runtime dependencies without prior maintainer approval
* [x] No publish, tag, or workflow changes

## Checklist

* [x] Linked issue explains the why and was opened before this PR
* [x] Tests added or updated for behavior coverage
* [ ] Docs updated when behavior or public API changes, not applicable because no behavior or public API changes
* [x] `git diff --check` clean

Closes #260 