### PR TITLE
fix(cli): reject unsupported cohort metrics

### DIFF
--- a/packages/cli/src/cohort.ts
+++ b/packages/cli/src/cohort.ts
@@ -27,10 +27,17 @@ export interface CohortCommandOptions {
 function normalizeMetrics(raw: string | undefined): CohortMetricId[] | undefined {
   const parsed = parseCohortMetricList(raw);
   if (parsed.length === 0) return undefined;
-  const allowed = new Set(COHORT_METRIC_IDS);
-  return parsed.filter((item): item is CohortMetricId =>
-    allowed.has(item as CohortMetricId),
-  );
+  const allowed = new Set<string>(COHORT_METRIC_IDS);
+  const invalid = parsed.filter((metric) => !allowed.has(metric));
+  if (invalid.length > 0) {
+    const valueLabel = invalid.length === 1 ? "value" : "values";
+    const invalidList = invalid.map((metric) => `"${metric}"`).join(", ");
+    throw new Error(
+        `Unsupported cohort --metric ${valueLabel}: ${invalidList}. Valid metrics: ${COHORT_METRIC_IDS.join(", ")}.`,
+    );
+  }
+
+  return parsed as CohortMetricId[];
 }
 
 async function writeArtifacts(
@@ -53,6 +60,7 @@ async function writeArtifacts(
 
 export async function cohortCommand(options: CohortCommandOptions = {}): Promise<void> {
   try {
+    const metrics = normalizeMetrics(options.metric);
     const traceDir = resolveTraceDir({ dir: options.dir });
     const { runs } = await loadSessionRuns(traceDir);
     const result = await analyzeCohort(runs, {
@@ -61,7 +69,7 @@ export async function cohortCommand(options: CohortCommandOptions = {}): Promise
       candidate: options.candidate,
       cohortKey: options.cohortKey,
       groupBy: options.groupBy,
-      metrics: normalizeMetrics(options.metric),
+      metrics,
     });
 
     const format = options.format ?? (options.json ? "json" : "markdown");

--- a/packages/cli/test/cohort.test.ts
+++ b/packages/cli/test/cohort.test.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { cohortCommand } from "../src/cohort.js";
+
+const fixtureDir = path.resolve(import.meta.dirname, "../../../fixtures/cohorts/before-after");
+
+describe("cohort command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects an unsupported explicit metric without running the cohort", async () => {
+    await cohortCommand({ dir: fixtureDir, metric: "totally-wrong" });
+
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.flat().join(" ")).toContain(
+      'Unsupported cohort --metric value: "totally-wrong"',
+    );
+  });
+
+  it("rejects mixed valid and unsupported explicit metrics", async () => {
+    await cohortCommand({ dir: fixtureDir, metric: "errorRate,totally-wrong" });
+
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.flat().join(" ")).toContain('"totally-wrong"');
+  });
+
+  it("preserves valid explicit metrics", async () => {
+    await cohortCommand({
+      dir: fixtureDir,
+      baseline: "before",
+      candidate: "after",
+      metric: "errorRate,duration",
+      json: true,
+    });
+
+    const result = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      error?: string;
+      metrics?: string[];
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.metrics).toEqual(["errorRate", "duration"]);
+  });
+
+  it("preserves default metrics when --metric is omitted", async () => {
+    await cohortCommand({
+      dir: fixtureDir,
+      baseline: "before",
+      candidate: "after",
+      json: true,
+    });
+
+    const result = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      error?: string;
+      metrics?: string[];
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.metrics).toEqual([
+      "errorRate",
+      "duration",
+      "toolChoice",
+      "observationFailure",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`cohort --metric` currently drops unknown metric names before running the comparison. If every supplied metric is invalid, that leaves an empty selection and cohort analysis falls back to the default metrics. With a mixed list, the invalid values are silently ignored and the valid ones continue.

This change validates explicit metric selections at the CLI boundary and returns a clear error when any unsupported metric is provided.

Leaving out `--metric` still keeps the existing default behavior.

The regression tests cover invalid-only, mixed, valid, and omitted metric selections.

**Linked issue (required):** #264 

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

An invalid metric is currently filtered out before cohort analysis:

```bash
agent-inspect cohort ... --metric totally-wrong
```

If no valid metrics remain, the empty selection is treated like no explicit metric selection and the command runs the default metric set.

A mixed selection has the same problem:

```bash
agent-inspect cohort ... --metric errorRate,totally-wrong
```

In this case, `totally-wrong` is silently ignored and the command continues with `errorRate`.

That means a typo in a regression configuration can change which metrics are evaluated without surfacing an error.

With this change, both cases fail with a clear diagnostic. Valid explicit metrics continue to work, and omitting `--metric` still uses the existing defaults.

Focused regression coverage:

```text
invalid-only metric        PASS
mixed valid/invalid        PASS
valid explicit metrics     PASS
omitted --metric           PASS
```

## Product boundaries

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

```text
Focused cohort regression tests: 4/4 passed

pnpm test:all ✅
  Typecheck ✅
  Linked versions ✅ 18 packages @ 6.17.3
  Build ✅
  Tests ✅ 262 files / 1872 tests
  Size ✅ 12.02 kB / 120 kB

git diff --check ✅
```

`pnpm docs:check` passes the command, link, public-truth, AI asset, and repo-health checks.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [ ] Trace/log samples in the PR were redacted or generated from fixtures

No trace or log samples are added by this PR.

## Release hygiene

- [x] No version bumps and no Changesets
- [x] No new runtime dependencies
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes
- [x] `git diff --check` clean

Closes #264 