### PR TITLE
feat(community): add design-partner feedback form and synthetic example

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_partner_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/design_partner_feedback.yml
@@ -1,0 +1,110 @@
+name: Design-partner / public-proof feedback
+description: Share design-partner or public-proof findings against the AgentInspect golden path
+title: "[feedback] "
+labels: ["area:community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for trialing AgentInspect. This form captures design-partner / public-proof findings.
+
+        AgentInspect is local-first — **use synthetic or redacted data everywhere in this form**. Do **not** attach production traces, secrets, tokens, or customer data. See [SAFE-TRACE-SHARING](https://github.com/rajudandigam/agent-inspect/blob/main/docs/SAFE-TRACE-SHARING.md), the [Design partner guide](https://github.com/rajudandigam/agent-inspect/blob/main/docs/DESIGN-PARTNER-GUIDE.md), and an [anonymized synthetic example](https://github.com/rajudandigam/agent-inspect/blob/main/docs/community/DESIGN-PARTNER-FEEDBACK-EXAMPLE.md).
+  - type: input
+    id: version
+    attributes:
+      label: AgentInspect version
+      description: Package version or commit SHA (6.17.1 or newer).
+      placeholder: agent-inspect@6.17.3
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Node / OS
+      description: Node version and operating system.
+      placeholder: Node 20.x on Ubuntu 22.04
+    validations:
+      required: true
+  - type: input
+    id: stack
+    attributes:
+      label: Stack
+      description: Framework / adapter under trial (ai-sdk, openai-agents, langchain, mcp, manual, ...).
+      placeholder: langchain / LangGraph
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: Scenario
+      description: What agent workflow you traced, described with synthetic detail only.
+    validations:
+      required: true
+  - type: textarea
+    id: golden-path
+    attributes:
+      label: Golden-path steps
+      description: |
+        Which golden-path milestones you reached and how long each took.
+      value: |
+        - First trace (< 30 min from install):
+        - First CI check on a trace:
+        - Share-checked evidence bundle attached to an issue/PR:
+    validations:
+      required: true
+  - type: dropdown
+    id: retained-ci
+    attributes:
+      label: Retained CI workflow
+      description: Did you wire a retained TraceContract / suite / gate into CI?
+      options:
+        - "Yes — running in CI"
+        - "Prototype only, not retained"
+        - "No"
+    validations:
+      required: true
+  - type: dropdown
+    id: studio-status
+    attributes:
+      label: Studio trial status
+      description: Self-hosted read-only Studio analyzer.
+      options:
+        - "Tried it"
+        - "Plan to try"
+        - "Not applicable"
+    validations:
+      required: true
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Blockers
+      description: What stopped you or slowed you down. Synthetic detail only.
+    validations:
+      required: false
+  - type: dropdown
+    id: keep-using
+    attributes:
+      label: Keep-using decision
+      description: Would you keep using AgentInspect after the trial?
+      options:
+        - "Yes"
+        - "Maybe — depends on the blockers above"
+        - "No"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Safe summary
+      description: A short shareable summary of the outcome. Synthetic / redacted only.
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: This report contains synthetic or redacted data only — no real prompts, production logs, tokens, or PII.
+          required: true
+        - label: I did not attach production traces, secrets, tokens, or customer data.
+          required: true

--- a/docs/community/DESIGN-PARTNER-FEEDBACK-EXAMPLE.md
+++ b/docs/community/DESIGN-PARTNER-FEEDBACK-EXAMPLE.md
@@ -1,0 +1,33 @@
+# Design-partner feedback — anonymized synthetic example
+
+**This is a fully synthetic example. It describes no real user, company, or production system.** It shows how to fill the [design-partner / public-proof feedback form](../../.github/ISSUE_TEMPLATE/design_partner_feedback.yml) with safe, shareable content.
+
+See also: [Design partner guide](../DESIGN-PARTNER-GUIDE.md) · [Safe trace sharing](../SAFE-TRACE-SHARING.md) · [Anonymized case-study template](./ANONYMIZED-CASE-STUDY-TEMPLATE.md).
+
+---
+
+**AgentInspect version:** `agent-inspect@6.17.3`
+
+**Node / OS:** Node 20.x on Ubuntu 22.04
+
+**Stack:** langchain / LangGraph (synthetic support-triage agent)
+
+**Scenario:** A synthetic two-node LangGraph agent that plans a refund and calls a `refund_order` tool. Traced locally with the LangChain callback; no external services involved.
+
+**Golden-path steps:**
+
+- First trace (< 30 min from install): ~12 minutes, using `agent-inspect init` plus the langchain starter.
+- First CI check on a trace: passed a `requiredTools: ["refund_order"]` TraceContract on the fixture run.
+- Share-checked evidence bundle attached to an issue/PR: built with `--profile share`, verified with `bundle verify`, attached as a CI artifact.
+
+**Retained CI workflow:** Yes — running in CI. A retained TraceContract gate runs on each PR against a synthetic fixture.
+
+**Studio trial status:** Tried it (read-only, local).
+
+**Blockers:** None blocking. One paper cut: remembering to pass `--profile share` before attaching a bundle; solved by scripting the bundle step.
+
+**Keep-using decision:** Yes.
+
+**Safe summary:** A synthetic LangGraph refund agent went from install to a retained CI TraceContract gate in under half an hour, with a share-checked evidence bundle attached to the PR. All data synthetic.
+
+**Privacy confirmation:** Synthetic data only; no production traces, secrets, tokens, or customer data attached.


### PR DESCRIPTION
## What

Adds a structured way to collect design-partner / public-proof feedback.

## Deliverables

- **`.github/ISSUE_TEMPLATE/design_partner_feedback.yml`** — a GitHub issue form capturing AgentInspect version (6.17.1+), Node/OS, stack, scenario, golden-path milestones (first trace < 30 min, first CI check, share-checked evidence bundle), retained CI workflow, Studio trial status, blockers, keep-using decision, and a safe summary. Two **required** privacy-confirmation checkboxes and a lead-in warning against attaching production traces/secrets/tokens/customer data, with links to `SAFE-TRACE-SHARING` and `DESIGN-PARTNER-GUIDE`.
- **`docs/community/DESIGN-PARTNER-FEEDBACK-EXAMPLE.md`** — a clearly labeled, fully synthetic filled example (no real user, company, or system).

## Notes

Links point at current pilot/proof docs. No production data, no telemetry, no hosted backend. YAML validated; `docs:links` and `repo:health` pass locally.

Closes #151