### PR TITLE
docs(adapters): add third-party conformance CI template

### DIFF
--- a/docs/ADAPTER-CONFORMANCE.md
+++ b/docs/ADAPTER-CONFORMANCE.md
@@ -58,6 +58,30 @@ This is an internal official-adapter gate, not a third-party certification progr
 
 An adapter can be documented as supported only after no-network fixtures cover run, step, tool, LLM, error, streaming, and metadata-bound expectations for that framework path.
 
+## Third-party adapter conformance CI
+
+The gate above is the internal official-adapter gate, not a third-party certification program. Third-party adapter authors run the **public** conformance helper from [`@agent-inspect/adapter-sdk`](https://www.npmjs.com/package/@agent-inspect/adapter-sdk) in their own CI:
+
+```ts
+import { runAdapterConformance } from "@agent-inspect/adapter-sdk";
+
+const result = await runAdapterConformance({
+  adapterId: "my-adapter",
+  events, // PersistedInspectEvent[] your adapter emits
+  expectedKinds: ["RUN", "LLM"],
+  forbiddenRawStrings: ["super-secret-key"], // must not leak into events
+});
+// assert result.ok in your test runner
+```
+
+A copyable GitHub Actions template lives at [`examples/adapter-sdk/third-party-conformance-ci.yml`](../examples/adapter-sdk/third-party-conformance-ci.yml). Copy it to `.github/workflows/agent-inspect-conformance.yml` in your adapter repo and adjust the install/build/test commands. The template:
+
+- runs on a Node LTS matrix (18 / 20 / 22),
+- requires **no provider keys** and makes **no network calls** (conformance is metadata-only),
+- keeps the framework SDK as a peer dependency of your adapter, never of AgentInspect core.
+
+See the runnable examples under [`examples/adapter-sdk/`](../examples/adapter-sdk/) for adapters that call `runAdapterConformance` end to end.
+
 ## v3.2 adoption evidence refresh
 
 - [AI-SDK-ADOPTION.md](./AI-SDK-ADOPTION.md) — blessed AI SDK path (`generateText`, `streamText`, Next.js recipe, troubleshooting)

--- a/examples/adapter-sdk/third-party-conformance-ci.yml
+++ b/examples/adapter-sdk/third-party-conformance-ci.yml
@@ -1,0 +1,56 @@
+# Third-party AgentInspect adapter conformance CI (template)
+#
+# Copy this file into your adapter repository at
+# .github/workflows/agent-inspect-conformance.yml and adjust the install/build/
+# test commands to your toolchain. It runs your adapter's conformance suite on a
+# Node LTS matrix with no provider keys and no network calls.
+#
+# Your test suite should build persisted events from your adapter and assert
+# runAdapterConformance(...) from @agent-inspect/adapter-sdk reports ok, e.g.:
+#
+#   import { runAdapterConformance } from "@agent-inspect/adapter-sdk";
+#   const result = await runAdapterConformance({
+#     adapterId: "my-adapter",
+#     events,                       // PersistedInspectEvent[] your adapter emits
+#     expectedKinds: ["RUN", "LLM"],
+#     forbiddenRawStrings: ["super-secret-key"], // must not leak into events
+#   });
+#   expect(result.ok).toBe(true);
+#
+# See docs/ADAPTER-CONFORMANCE.md for the shared expectations.
+
+name: agent-inspect conformance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      # Use whatever your repo uses (npm ci / pnpm i --frozen-lockfile / yarn).
+      - name: Install
+        run: npm ci
+
+      # Build the adapter if your package needs a build step.
+      - name: Build
+        run: npm run build --if-present
+
+      # Run the conformance suite. Keep it offline: no provider keys, no network.
+      - name: Conformance
+        run: npm test
+        env:
+          # Adapter conformance is metadata-only and must not require secrets.
+          CI: "true"


### PR DESCRIPTION
## What

Gives third-party adapter authors a copyable CI template for the public conformance helper, distinct from the internal official-adapter gate.

## Deliverables

- **`examples/adapter-sdk/third-party-conformance-ci.yml`** — a copyable GitHub Actions workflow (kept under `examples/`, not `.github/workflows/`, so it does not run in this repo). Runs install → build → conformance on a Node LTS matrix (18 / 20 / 22), with **no provider keys** and **no network calls**.
- **`docs/ADAPTER-CONFORMANCE.md`** — a new "Third-party adapter conformance CI" section showing the public `runAdapterConformance` API from `@agent-inspect/adapter-sdk`, pointing at the template and the runnable `examples/adapter-sdk/` adapters, and stating the framework SDK stays a peer dependency of the adapter, never of AgentInspect core.

## Notes

Grounded in the existing `runAdapterConformance` helper and example adapters. YAML validated; `docs:links` and `repo:health` pass locally. Optional integrations do not leak into root/core.

Closes #167