### PR TITLE
test(docs): validate API maturity annotations against SUPPORT-LEVELS

### DIFF
--- a/docs/SUPPORT-LEVELS.md
+++ b/docs/SUPPORT-LEVELS.md
@@ -37,6 +37,8 @@ Canonical maturity labels for AgentInspect public packages and major surfaces (6
 
 Part of the fixed AgentInspect release line — see the npm badge for the current version.
 
+> Every level in this matrix must be one of the Definitions levels above, and `docs/product/PUBLIC-PRODUCT-FACTS.json` `matchers.status` must match the matchers row here. `pnpm public-truth:check` enforces both; update the doc and the facts file together.
+
 ## Public package groups (presentation only)
 
 Physical packages stay the fixed group of 18. Outreach/install kits group them as:

--- a/scripts/validate-public-truth.mjs
+++ b/scripts/validate-public-truth.mjs
@@ -171,6 +171,64 @@ if (!existsSync(ledgerPath)) {
   }
 }
 
+// API maturity annotations must stay consistent with SUPPORT-LEVELS.md.
+const supportLevelsPath = path.join(root, "docs/SUPPORT-LEVELS.md");
+if (!existsSync(supportLevelsPath)) {
+  failures.push("docs/SUPPORT-LEVELS.md is required");
+} else {
+  const supportLines = readFileSync(supportLevelsPath, "utf8").split(/\r?\n/);
+
+  // Canonical levels come from the Definitions table (| **Level** | ... |).
+  const canonicalLevels = new Set();
+  for (const line of supportLines) {
+    const m = /^\|\s*\*\*([A-Za-z]+)\*\*\s*\|/.exec(line);
+    if (m) canonicalLevels.add(m[1]);
+  }
+  if (canonicalLevels.size === 0) {
+    failures.push("SUPPORT-LEVELS.md: no canonical levels found in the Definitions table");
+  }
+
+  // Every level used in the Package matrix must be one of the canonical levels.
+  let inMatrix = false;
+  let matchersLevel;
+  for (const line of supportLines) {
+    if (/^##\s+Package matrix/.test(line)) {
+      inMatrix = true;
+      continue;
+    }
+    if (inMatrix && /^##\s+/.test(line)) break;
+    if (!inMatrix || !line.trim().startsWith("|")) continue;
+    const cells = line.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length < 2) continue;
+    const surface = cells[0];
+    const level = cells[cells.length - 1];
+    if (surface === "Package / surface" || /^-+$/.test(level)) continue; // header / separator
+    if (!canonicalLevels.has(level)) {
+      failures.push(
+        `SUPPORT-LEVELS.md: package matrix uses non-canonical level "${level}" for "${surface}"`,
+      );
+    }
+    if (/toPassTraceContract/.test(surface)) matchersLevel = level;
+  }
+
+  // PUBLIC-PRODUCT-FACTS.json matchers.status must agree with the matchers matrix row.
+  if (factsPath && existsSync(factsPath)) {
+    const status = JSON.parse(readFileSync(factsPath, "utf8")).matchers?.status;
+    if (typeof status === "string") {
+      const normalized = status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+      if (!canonicalLevels.has(normalized)) {
+        failures.push(
+          `PUBLIC-PRODUCT-FACTS.json matchers.status "${status}" is not a SUPPORT-LEVELS level`,
+        );
+      } else if (matchersLevel && normalized !== matchersLevel) {
+        failures.push(
+          `PUBLIC-PRODUCT-FACTS.json matchers.status "${status}" must match the SUPPORT-LEVELS matchers level "${matchersLevel}"`,
+        );
+      }
+    }
+  }
+}
+
 if (failures.length > 0) {
   console.error("[public-truth:check] failures:\n" + failures.map((f) => `  - ${f}`).join("\n"));
   process.exit(1);


### PR DESCRIPTION
## What

Extends `public-truth:check` so maturity annotations can't silently drift from `docs/SUPPORT-LEVELS.md`.

## Checks added (in `scripts/validate-public-truth.mjs`)

1. **Canonical vocabulary**: parses the levels from the Definitions table and fails if the Package matrix uses any level outside that set (e.g. a typo like `GA`).
2. **Product-facts agreement**: `docs/product/PUBLIC-PRODUCT-FACTS.json` `matchers.status` must be a canonical level and must match the matchers row in the matrix (currently `Experimental`).

Both fail with actionable messages naming the offending surface/value.

## Verification

Confirmed the check catches a non-canonical matrix level and a `matchers.status` mismatch, then passes again once reverted. Documented the update path with a note in `SUPPORT-LEVELS.md`.

## Notes

Runs under `pnpm public-truth:check` / `pnpm docs:check`. Docs-only consistency; no runtime behavior changes.

Closes #212