### PR TITLE
docs(standards): validate tested provenance and known-loss consistency

### DIFF
--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -21,6 +21,8 @@ Shape validation is **compatible**; semantic checks add field-level warnings for
 
 Fixture: [fixtures/standards/openinference-basic.json](../fixtures/standards/openinference-basic.json)
 
+The fixture's top-level `version` is an **AgentInspect reference fixture revision**, not an upstream OpenInference version.
+
 ## OTLP JSON (experimental)
 
 ```bash
@@ -31,9 +33,22 @@ GenAI attribute mapping follows `OTEL_GEN_AI_SEMCONV_PIN` (see exporters API). N
 
 Fixture: [fixtures/standards/otlp-basic.json](../fixtures/standards/otlp-basic.json)
 
+The fixture's `scope.version` is an **AgentInspect test-scope fixture revision**, not the `OTEL_GEN_AI_SEMCONV_PIN` and not an upstream OpenTelemetry version.
+
 ## Graduation guide
 
 Full path from local export through review to optional customer-owned import: [STANDARDS-GRADUATION.md](./STANDARDS-GRADUATION.md).
+
+That guide is the canonical source for standards known-loss boundaries, including kind degradation, bounded metadata, no chain-of-thought capture, and snapshot limitations.
+
+## Maintaining tested provenance
+
+- When the OTLP mapping changes, update `OTEL_GEN_AI_SEMCONV_PIN` in [`packages/core/src/exporters/semconv.ts`](../packages/core/src/exporters/semconv.ts) and any explicit tested-version claims together.
+- When the OTLP reference shape changes, update its test-scope fixture revision in [`fixtures/standards/otlp-basic.json`](../fixtures/standards/otlp-basic.json) and any repeated fixture revision together.
+- When the OpenInference reference shape changes, update the top-level fixture revision in [`fixtures/standards/openinference-basic.json`](../fixtures/standards/openinference-basic.json) and any repeated fixture revision together. The value remains an AgentInspect fixture revision, not an upstream version.
+- Keep known-loss behavior canonical in [`STANDARDS-GRADUATION.md`](./STANDARDS-GRADUATION.md) and update its validation alongside any intentional exporter behavior change.
+
+Run `pnpm public-truth:check` and `pnpm docs:check` after changing these sources.
 
 ## Import recipes
 

--- a/packages/core/test/docs/standards-provenance-rule.test.ts
+++ b/packages/core/test/docs/standards-provenance-rule.test.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const rulePath = new URL(
+  "../../../../scripts/lib/standards-provenance-rule.mjs",
+  import.meta.url,
+).href;
+
+const { validateStandardsProvenance } = (await import(rulePath)) as {
+  validateStandardsProvenance(input: {
+    standardsText: string;
+    graduationText: string;
+    openInferenceFixture: unknown;
+    otlpFixture: unknown;
+    semconvSource: string;
+  }): string[];
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const baseline = {
+  standardsText: readFileSync(path.join(repoRoot, "docs/STANDARDS.md"), "utf8"),
+  graduationText: readFileSync(path.join(repoRoot, "docs/STANDARDS-GRADUATION.md"), "utf8"),
+  openInferenceFixture: JSON.parse(
+    readFileSync(path.join(repoRoot, "fixtures/standards/openinference-basic.json"), "utf8"),
+  ) as unknown,
+  otlpFixture: JSON.parse(
+    readFileSync(path.join(repoRoot, "fixtures/standards/otlp-basic.json"), "utf8"),
+  ) as unknown,
+  semconvSource: readFileSync(
+    path.join(repoRoot, "packages/core/src/exporters/semconv.ts"),
+    "utf8",
+  ),
+};
+
+function validate(overrides: Partial<typeof baseline> = {}): string[] {
+  return validateStandardsProvenance({ ...baseline, ...overrides });
+}
+
+describe("standards provenance public-truth rule", () => {
+  it("accepts current repository provenance and known-loss claims", () => {
+    expect(validate()).toEqual([]);
+  });
+
+  it("rejects a missing OTLP pin reference", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "GenAI attribute mapping follows `OTEL_GEN_AI_SEMCONV_PIN`",
+        "GenAI attribute mapping follows the exporter mapping",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS.md: OTLP tested provenance must reference OTEL_GEN_AI_SEMCONV_PIN from packages/core/src/exporters/semconv.ts",
+    );
+  });
+
+  it("rejects an OTLP version that contradicts the repository pin", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "No gRPC collector included.",
+        "Tested mapping version: 9.9.9. No gRPC collector included.",
+      ),
+    });
+
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^docs\/STANDARDS\.md: OTLP tested version 9\.9\.9 contradicts OTEL_GEN_AI_SEMCONV_PIN .+ in packages\/core\/src\/exporters\/semconv\.ts$/,
+        ),
+      ]),
+    );
+  });
+
+  it("rejects missing OTLP fixture provenance", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "Fixture: [fixtures/standards/otlp-basic.json](../fixtures/standards/otlp-basic.json)",
+        "Fixture: an untracked local sample",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS.md: OTLP tested provenance must reference fixtures/standards/otlp-basic.json",
+    );
+  });
+
+  it("rejects an OTLP fixture without a test-scope revision", () => {
+    const failures = validate({
+      otlpFixture: {
+        resourceSpans: [{ scopeSpans: [{ scope: { name: "agent-inspect-test-scope" } }] }],
+      },
+    });
+
+    expect(failures).toContain(
+      "fixtures/standards/otlp-basic.json: scopeSpans[].scope.version must declare an AgentInspect test-scope fixture revision",
+    );
+  });
+
+  it("rejects a documented OTLP fixture revision that contradicts its scope", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "The fixture's `scope.version`",
+        "AgentInspect test-scope fixture revision `9.9-fixture`; its `scope.version`",
+      ),
+    });
+
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^docs\/STANDARDS\.md: OTLP fixture revision 9\.9-fixture must match a scope\.version in fixtures\/standards\/otlp-basic\.json \(.+\)$/,
+        ),
+      ]),
+    );
+  });
+
+  it("rejects missing OpenInference fixture provenance", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replaceAll(
+        "fixtures/standards/openinference-basic.json",
+        "fixtures/standards/other.json",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS.md: OpenInference tested provenance must reference fixtures/standards/openinference-basic.json",
+    );
+  });
+
+  it("rejects a documented fixture revision that contradicts the fixture", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "The fixture's top-level `version`",
+        "AgentInspect reference fixture revision `9.9-fixture`; its top-level `version`",
+      ),
+    });
+
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^docs\/STANDARDS\.md: OpenInference fixture revision 9\.9-fixture must match fixtures\/standards\/openinference-basic\.json .+$/,
+        ),
+      ]),
+    );
+  });
+
+  it("rejects a fabricated upstream OpenInference version", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "Shape validation is **compatible**;",
+        "OpenInference version 1.6 is tested. Shape validation is **compatible**;",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS.md: OpenInference tested provenance is fixture-backed; do not claim an upstream OpenInference version",
+    );
+  });
+
+  it("rejects removal of a canonical known-loss mapping", () => {
+    const failures = validate({
+      graduationText: baseline.graduationText.replace(
+        "- Kinds without an OpenInference equivalent degrade (`RUN`, `LOGIC`, `ERROR` map to `CHAIN`; `RESULT` to `UNKNOWN`) and every degradation is listed in the export's `warnings`",
+        "- Kinds without an OpenInference equivalent degrade and are listed in warnings",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS-GRADUATION.md: Known loss must retain RUN / LOGIC / ERROR -> CHAIN degradation",
+    );
+    expect(failures).toContain(
+      "docs/STANDARDS-GRADUATION.md: Known loss must retain RESULT -> UNKNOWN degradation",
+    );
+  });
+
+  it("rejects a lossless claim in the canonical known-loss section", () => {
+    const failures = validate({
+      graduationText: baseline.graduationText.replace(
+        "### Known loss, stated up front",
+        "### Known loss, stated up front\n\nThe standards exports are fully lossless.",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS-GRADUATION.md: Known loss section must not claim lossless standards export",
+    );
+  });
+
+  it("requires actionable provenance maintenance references", () => {
+    const failures = validate({
+      standardsText: baseline.standardsText.replace(
+        "`pnpm public-truth:check`",
+        "the repository validator",
+      ),
+    });
+
+    expect(failures).toContain(
+      "docs/STANDARDS.md: Maintaining tested provenance must reference pnpm public-truth:check",
+    );
+  });
+});

--- a/scripts/lib/standards-provenance-rule.mjs
+++ b/scripts/lib/standards-provenance-rule.mjs
@@ -1,0 +1,251 @@
+function markdownSection(markdown, headingPrefix, level) {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const heading = "#".repeat(level) + " ";
+  const start = lines.findIndex(
+    (line) =>
+      line.startsWith(heading) &&
+      line.slice(heading.length).trim().toLowerCase().startsWith(headingPrefix.toLowerCase()),
+  );
+  if (start < 0) return null;
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const match = /^(#{1,6})\s+/.exec(lines[index]);
+    if (match && match[1].length <= level) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+function semconvPinVersion(source) {
+  const block =
+    /\b(?:export\s+)?const\s+OTEL_GEN_AI_SEMCONV_PIN\s*=\s*\{([\s\S]*?)\n\}/.exec(source)?.[1];
+  return block ? /\bversion\s*:\s*["']([^"']+)["']/.exec(block)?.[1] ?? null : null;
+}
+
+function explicitOtlpVersions(section) {
+  const versions = [];
+  const pattern =
+    /\b(?:tested(?:\s+(?:OTLP|semantic-convention|semconv|mapping))?|semantic-convention(?:\s+(?:pin|version|mapping))?|semconv(?:\s+(?:pin|version))?|mapping(?:\s+version)?|pin(?:ned)?(?:\s+version)?)\b[^\n]{0,100}?\bv?(\d+\.\d+\.\d+)\b/gi;
+  for (const match of section.matchAll(pattern)) versions.push(match[1]);
+  return versions;
+}
+
+function otlpFixtureRevisions(fixture) {
+  if (!fixture || typeof fixture !== "object" || !Array.isArray(fixture.resourceSpans)) {
+    return [];
+  }
+
+  const revisions = [];
+  for (const resourceSpan of fixture.resourceSpans) {
+    if (
+      !resourceSpan ||
+      typeof resourceSpan !== "object" ||
+      !Array.isArray(resourceSpan.scopeSpans)
+    ) {
+      continue;
+    }
+    for (const scopeSpan of resourceSpan.scopeSpans) {
+      if (!scopeSpan || typeof scopeSpan !== "object") continue;
+      const scope = scopeSpan.scope;
+      if (!scope || typeof scope !== "object") continue;
+      if (typeof scope.version === "string" && scope.version) {
+        revisions.push(scope.version);
+      }
+    }
+  }
+  return [...new Set(revisions)];
+}
+
+/**
+ * Validate standards documentation against repository-owned tested provenance.
+ * The returned diagnostics are deterministic and safe to print from repository gates.
+ */
+export function validateStandardsProvenance({
+  standardsText,
+  graduationText,
+  openInferenceFixture,
+  otlpFixture,
+  semconvSource,
+}) {
+  const failures = [];
+  const pinVersion = semconvPinVersion(semconvSource);
+  const fixtureRevision =
+    openInferenceFixture &&
+    typeof openInferenceFixture === "object" &&
+    typeof openInferenceFixture.version === "string"
+      ? openInferenceFixture.version
+      : null;
+  const otlpRevisions = otlpFixtureRevisions(otlpFixture);
+
+  if (!pinVersion) {
+    failures.push(
+      "packages/core/src/exporters/semconv.ts: OTEL_GEN_AI_SEMCONV_PIN must declare a string version",
+    );
+  }
+  if (!fixtureRevision) {
+    failures.push(
+      "fixtures/standards/openinference-basic.json: top-level version must declare the AgentInspect reference fixture revision",
+    );
+  }
+  if (otlpRevisions.length === 0) {
+    failures.push(
+      "fixtures/standards/otlp-basic.json: scopeSpans[].scope.version must declare an AgentInspect test-scope fixture revision",
+    );
+  }
+
+  const openInference = markdownSection(standardsText, "OpenInference", 2);
+  if (!openInference) {
+    failures.push("docs/STANDARDS.md: OpenInference section is required");
+  } else {
+    if (!openInference.includes("fixtures/standards/openinference-basic.json")) {
+      failures.push(
+        "docs/STANDARDS.md: OpenInference tested provenance must reference fixtures/standards/openinference-basic.json",
+      );
+    }
+    if (!/AgentInspect reference fixture revision/i.test(openInference)) {
+      failures.push(
+        "docs/STANDARDS.md: label the OpenInference fixture version as an AgentInspect reference fixture revision",
+      );
+    }
+    if (!/not an upstream OpenInference version/i.test(openInference)) {
+      failures.push(
+        "docs/STANDARDS.md: clarify that the fixture revision is not an upstream OpenInference version",
+      );
+    }
+    if (/\bOpenInference\s+(?:upstream\s+|spec(?:ification)?\s+|library\s+)?version\s+v?\d/i.test(openInference)) {
+      failures.push(
+        "docs/STANDARDS.md: OpenInference tested provenance is fixture-backed; do not claim an upstream OpenInference version",
+      );
+    }
+    if (fixtureRevision) {
+      for (const revision of openInference.match(/\b\d+\.\d+(?:\.\d+)?-fixture\b/g) ?? []) {
+        if (revision !== fixtureRevision) {
+          failures.push(
+            `docs/STANDARDS.md: OpenInference fixture revision ${revision} must match fixtures/standards/openinference-basic.json ${fixtureRevision}`,
+          );
+        }
+      }
+    }
+  }
+
+  const otlp = markdownSection(standardsText, "OTLP JSON", 2);
+  if (!otlp) {
+    failures.push("docs/STANDARDS.md: OTLP JSON section is required");
+  } else {
+    if (!/GenAI attribute mapping follows\s+`OTEL_GEN_AI_SEMCONV_PIN`/i.test(otlp)) {
+      failures.push(
+        "docs/STANDARDS.md: OTLP tested provenance must reference OTEL_GEN_AI_SEMCONV_PIN from packages/core/src/exporters/semconv.ts",
+      );
+    }
+    if (!otlp.includes("fixtures/standards/otlp-basic.json")) {
+      failures.push(
+        "docs/STANDARDS.md: OTLP tested provenance must reference fixtures/standards/otlp-basic.json",
+      );
+    }
+    if (!/AgentInspect test-scope fixture revision/i.test(otlp)) {
+      failures.push(
+        "docs/STANDARDS.md: label OTLP scope.version as an AgentInspect test-scope fixture revision",
+      );
+    }
+    if (!/not the [`]*OTEL_GEN_AI_SEMCONV_PIN[`]*/i.test(otlp)) {
+      failures.push(
+        "docs/STANDARDS.md: distinguish the OTLP fixture scope.version from OTEL_GEN_AI_SEMCONV_PIN",
+      );
+    }
+    if (!/not an upstream OpenTelemetry version/i.test(otlp)) {
+      failures.push(
+        "docs/STANDARDS.md: clarify that the OTLP fixture revision is not an upstream OpenTelemetry version",
+      );
+    }
+    if (pinVersion) {
+      for (const claimedVersion of explicitOtlpVersions(otlp)) {
+        if (claimedVersion !== pinVersion) {
+          failures.push(
+            `docs/STANDARDS.md: OTLP tested version ${claimedVersion} contradicts OTEL_GEN_AI_SEMCONV_PIN ${pinVersion} in packages/core/src/exporters/semconv.ts`,
+          );
+        }
+      }
+    }
+    for (const revision of otlp.match(/\b\d+\.\d+(?:\.\d+)?-fixture\b/g) ?? []) {
+      if (!otlpRevisions.includes(revision)) {
+        failures.push(
+          `docs/STANDARDS.md: OTLP fixture revision ${revision} must match a scope.version in fixtures/standards/otlp-basic.json (${otlpRevisions.join(", ") || "missing"})`,
+        );
+      }
+    }
+  }
+
+  const maintenance = markdownSection(standardsText, "Maintaining tested provenance", 2);
+  if (!maintenance) {
+    failures.push("docs/STANDARDS.md: Maintaining tested provenance section is required");
+  } else {
+    for (const requiredReference of [
+      "packages/core/src/exporters/semconv.ts",
+      "fixtures/standards/openinference-basic.json",
+      "fixtures/standards/otlp-basic.json",
+      "STANDARDS-GRADUATION.md",
+      "pnpm public-truth:check",
+    ]) {
+      if (!maintenance.includes(requiredReference)) {
+        failures.push(
+          `docs/STANDARDS.md: Maintaining tested provenance must reference ${requiredReference}`,
+        );
+      }
+    }
+  }
+
+  if (!standardsText.includes("STANDARDS-GRADUATION.md")) {
+    failures.push(
+      "docs/STANDARDS.md: standards claims must link to canonical known-loss boundaries in docs/STANDARDS-GRADUATION.md",
+    );
+  }
+
+  const knownLoss = markdownSection(graduationText, "Known loss", 3);
+  if (!knownLoss) {
+    failures.push("docs/STANDARDS-GRADUATION.md: Known loss section is required");
+  } else {
+    const requiredBoundaries = [
+      {
+        pattern: /\bRUN\b[\s\S]{0,100}\bLOGIC\b[\s\S]{0,100}\bERROR\b[\s\S]{0,100}\bCHAIN\b/,
+        description: "RUN / LOGIC / ERROR -> CHAIN degradation",
+      },
+      {
+        pattern: /\bRESULT\b[\s\S]{0,60}\bUNKNOWN\b/,
+        description: "RESULT -> UNKNOWN degradation",
+      },
+      {
+        pattern: /\bbounded\b[\s\S]{0,80}\bmetadata-only\b/i,
+        description: "bounded metadata-only attributes",
+      },
+      {
+        pattern: /\bChain-of-thought\b[\s\S]{0,80}\bnever captured\b/i,
+        description: "no chain-of-thought capture",
+      },
+      {
+        pattern: /\bsnapshot\b[\s\S]{0,80}\bnot a live pipeline\b/i,
+        description: "snapshot/export limitation",
+      },
+      {
+        pattern: /\bdegradation\b[\s\S]{0,100}\bwarnings\b/i,
+        description: "degradation warnings",
+      },
+    ];
+    for (const boundary of requiredBoundaries) {
+      if (!boundary.pattern.test(knownLoss)) {
+        failures.push(
+          `docs/STANDARDS-GRADUATION.md: Known loss must retain ${boundary.description}`,
+        );
+      }
+    }
+    if (/\b(?:is|are)\s+(?:fully\s+)?lossless\b|\bno known losses?\b|\bwithout (?:data )?loss\b/i.test(knownLoss)) {
+      failures.push(
+        "docs/STANDARDS-GRADUATION.md: Known loss section must not claim lossless standards export",
+      );
+    }
+  }
+
+  return failures;
+}

--- a/scripts/validate-public-truth.mjs
+++ b/scripts/validate-public-truth.mjs
@@ -5,6 +5,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { validateStandardsProvenance } from "./lib/standards-provenance-rule.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
@@ -12,6 +13,40 @@ const changeset = JSON.parse(readFileSync(path.join(root, ".changeset/config.jso
 const fixed = changeset.fixed?.[0] ?? [];
 const version = pkg.version;
 const failures = [];
+
+const standardsPath = path.join(root, "docs/STANDARDS.md");
+const graduationPath = path.join(root, "docs/STANDARDS-GRADUATION.md");
+const openInferenceFixturePath = path.join(root, "fixtures/standards/openinference-basic.json");
+const otlpFixturePath = path.join(root, "fixtures/standards/otlp-basic.json");
+const semconvPath = path.join(root, "packages/core/src/exporters/semconv.ts");
+
+let openInferenceFixture = null;
+try {
+  openInferenceFixture = JSON.parse(readFileSync(openInferenceFixturePath, "utf8"));
+} catch (error) {
+  failures.push(
+    `fixtures/standards/openinference-basic.json: must be readable JSON (${error instanceof Error ? error.message : String(error)})`,
+  );
+}
+
+let otlpFixture = null;
+try {
+  otlpFixture = JSON.parse(readFileSync(otlpFixturePath, "utf8"));
+} catch (error) {
+  failures.push(
+    `fixtures/standards/otlp-basic.json: must be readable JSON (${error instanceof Error ? error.message : String(error)})`,
+  );
+}
+
+failures.push(
+  ...validateStandardsProvenance({
+    standardsText: existsSync(standardsPath) ? readFileSync(standardsPath, "utf8") : "",
+    graduationText: existsSync(graduationPath) ? readFileSync(graduationPath, "utf8") : "",
+    openInferenceFixture,
+    otlpFixture,
+    semconvSource: existsSync(semconvPath) ? readFileSync(semconvPath, "utf8") : "",
+  }),
+);
 
 if (fixed.length !== 18) {
   failures.push(`expected 18 fixed packages, found ${fixed.length}`);


### PR DESCRIPTION
## Summary

Extend the existing public-truth validation to catch missing or contradictory standards tested-provenance and known-loss claims.

The check validates the existing OTLP semantic-convention pin, OTLP fixture revision, and committed OpenInference fixture revision as distinct provenance sources. It does not introduce new upstream version claims, require OTLP and OpenInference fixture revisions to match, or change canonical standards policy.

The standards documentation now makes the distinction between fixture revision, `OTEL_GEN_AI_SEMCONV_PIN`, and upstream OpenTelemetry version explicit.

**Linked issue (required):** #163
Closes #163

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan — maintainer approval required)

## Reproduction / evidence

Before this change, `scripts/validate-public-truth.mjs` did not enforce consistency between the standards documentation, committed fixture provenance, and documented known-loss boundaries.

This change extends the existing public-truth validation to detect:

- Missing OpenInference fixture references or revisions
- Missing OTLP fixture references or revisions
- Explicit fixture revisions that contradict the committed fixtures
- Missing or contradictory tested-provenance claims
- Missing or contradictory known-loss claims

OTLP fixture provenance is validated independently from the OpenInference fixture revision. Although both fixtures currently use `1.6-fixture`, the validator does not require those revisions to match because the repository does not define them as a shared canonical revision.

### Focused regression coverage

12 focused provenance and known-loss regression tests pass.

<!-- Paste focused 12/12 test screenshot below -->

<img width="946" height="470" alt="2026-08-26 132308" src="https://github.com/user-attachments/assets/abf50c54-44f7-4634-aced-cb671ac0a9b9" />

### Validation

- Focused regression tests: **12/12 passed**
- TypeScript typecheck: **passed**
- Full Vitest suite: **262 files, 1,880 tests passed**
- Docs commands / links: **passed**
- `public-truth:check`: **passed**
- AI assets validation: **passed**
- `repo:health`: **passed**
- `git diff --check`: **passed**

`pnpm docs:check` is currently blocked by the existing demo verification failures below:

<img width="721" height="235" alt="image" src="https://github.com/user-attachments/assets/2115b2c1-0699-48f6-8b50-d54cc8a0a3fa" />

These failures are unrelated to the four files changed by this PR. The corresponding demo verification fix is tracked in PR #263 and has not landed on the current base branch yet, so the same baseline failures are still expected here.

Commands used:

```bash
pnpm typecheck
pnpm test
pnpm public-truth:check
pnpm docs:check
git diff --check
```

## Product boundaries (check all that apply)

- [x] Local-first only — no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli` — ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

## Data safety

- [x] Synthetic data only — no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and no Changesets — maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] Tests added or updated for behavior changes
- [x] Docs updated where the standards provenance contract is clarified
- [x] `git diff --check` clean