### PR TITLE
test(adapters): add no-key packed consumer golden path

### DIFF
--- a/docs/OPENAI-AGENTS-LOCAL.md
+++ b/docs/OPENAI-AGENTS-LOCAL.md
@@ -41,6 +41,20 @@ setTraceProcessors([
 
 - [openai-agents-local-processor](../../examples/recipes/openai-agents-local-processor/)
 
+## No-key packed consumer check
+
+The repository includes a packed-consumer check that installs the root and
+OpenAI Agents adapter tarballs into a temporary project. It drives deterministic
+tracing fixtures without `OPENAI_API_KEY` or a live provider call, writes a local
+trace, and inspects it through the packed AgentInspect CLI.
+
+```bash
+pnpm build
+node scripts/packed-openai-agents-e2e.mjs
+```
+
+The check is also included in `pnpm pack:smoke`.
+
 ## Troubleshooting
 
 | Symptom | Check |

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "prepublishOnly": "AGENT_INSPECT_REPO_HEALTH_SKIP_VERSION=1 pnpm run prepublish:checks",
     "prepack": "pnpm run clean && pnpm run build",
     "pack:dry-run": "pnpm run build && npm pack --dry-run",
-    "pack:smoke": "pnpm run build && node scripts/package-smoke.mjs && node scripts/packed-quickstart-e2e.mjs && node scripts/packed-semantic-loop-e2e.mjs && node scripts/packed-swarm-loop-e2e.mjs && node scripts/evidence-ci-golden-paths.mjs",
+    "pack:smoke": "pnpm run build && node scripts/package-smoke.mjs && node scripts/packed-openai-agents-e2e.mjs && node scripts/packed-quickstart-e2e.mjs && node scripts/packed-semantic-loop-e2e.mjs && node scripts/packed-swarm-loop-e2e.mjs && node scripts/evidence-ci-golden-paths.mjs",
     "linked-versions:check": "node scripts/check-linked-versions.mjs",
     "docs:commands": "node scripts/validate-doc-commands.mjs",
     "docs:links": "node scripts/validate-doc-links.mjs",

--- a/scripts/packed-openai-agents-e2e.mjs
+++ b/scripts/packed-openai-agents-e2e.mjs
@@ -1,0 +1,261 @@
+/**
+ * Packed OpenAI Agents no-key consumer E2E.
+ * Run from repo root after build: node scripts/packed-openai-agents-e2e.mjs
+ */
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const adapterDir = path.join(root, "packages", "openai-agents");
+const adapterManifest = JSON.parse(
+  readFileSync(path.join(adapterDir, "package.json"), "utf8"),
+);
+const peerRange = adapterManifest.peerDependencies?.["@openai/agents"];
+const runId = "trace_openai_agents_packed";
+const traceDirName = ".agent-inspect-runs";
+
+function fail(message, detail = "") {
+  throw new Error(
+    `[packed-openai-agents-e2e] ${message}${detail ? `\n${detail}` : ""}`,
+  );
+}
+
+// npm/pnpm and .bin entries are cmd shims on Windows.
+function spawnCli(command, args, options = {}) {
+  const useShell =
+    process.platform === "win32" && !command.toLowerCase().endsWith(".exe");
+  const safeArgs = useShell
+    ? args.map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
+    : args;
+  return spawnSync(command, safeArgs, {
+    encoding: "utf8",
+    shell: useShell,
+    ...options,
+  });
+}
+
+function run(label, command, args, options = {}) {
+  const result = spawnCli(command, args, options);
+  if (result.status !== 0) {
+    fail(
+      `${label} failed`,
+      `${result.error?.message ?? ""}\n${result.stdout || ""}\n${result.stderr || ""}`.trim(),
+    );
+  }
+  return result;
+}
+
+function packPackage(label, packageDir, tarballDir) {
+  const before = new Set(readdirSync(tarballDir));
+  run(label, "pnpm", [
+    "--dir",
+    packageDir,
+    "pack",
+    "--pack-destination",
+    tarballDir,
+  ], {
+    env: {
+      ...process.env,
+      npm_config_json: "false",
+      NPM_CONFIG_JSON: "false",
+    },
+  });
+  const created = readdirSync(tarballDir).filter(
+    (file) => file.endsWith(".tgz") && !before.has(file),
+  );
+  if (created.length !== 1) {
+    fail(`${label} did not produce exactly one new tarball`, created.join(", "));
+  }
+  return path.join(tarballDir, created[0]);
+}
+
+function parseJson(label, output) {
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    fail(`${label} did not emit valid JSON`, `${error}\n${output}`);
+  }
+}
+
+function withoutOpenAiCredentials() {
+  const env = { ...process.env, AGENT_INSPECT_SILENT: "true" };
+  for (const name of [
+    "OPENAI_API_KEY",
+    "OPENAI_ORG_ID",
+    "OPENAI_ORGANIZATION",
+    "OPENAI_PROJECT",
+    "OPENAI_PROJECT_ID",
+  ]) {
+    delete env[name];
+  }
+  return env;
+}
+
+if (typeof peerRange !== "string" || peerRange.trim() === "") {
+  fail("@agent-inspect/openai-agents has no supported @openai/agents peer range");
+}
+
+const tarballDir = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-openai-pack-"));
+const consumerDir = mkdtempSync(
+  path.join(os.tmpdir(), "agent-inspect-openai-consumer-"),
+);
+
+try {
+  const rootTarball = packPackage("root package pack", root, tarballDir);
+  const adapterTarball = packPackage("OpenAI Agents adapter pack", adapterDir, tarballDir);
+
+  writeFileSync(
+    path.join(consumerDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "agent-inspect-openai-agents-packed-smoke",
+        private: true,
+        type: "module",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  run(
+    "packed consumer install",
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      rootTarball,
+      adapterTarball,
+      `@openai/agents@${peerRange}`,
+    ],
+    { cwd: consumerDir },
+  );
+
+  const consumerScript = path.join(consumerDir, "capture.mjs");
+  writeFileSync(
+    consumerScript,
+    `import { setTraceProcessors } from "@openai/agents";
+import { agentInspectProcessor } from "@agent-inspect/openai-agents";
+
+const processor = agentInspectProcessor({
+  traceDir: ${JSON.stringify(traceDirName)},
+  workflowName: "openai-agents-packed-fixture",
+  capture: "metadata-only",
+});
+setTraceProcessors([processor]);
+
+const trace = {
+  type: "trace",
+  traceId: ${JSON.stringify(runId)},
+  name: "ignored-by-workflow-option",
+  groupId: "packed-fixture-group",
+  metadata: { fixture: true },
+};
+
+function span(spanId, spanData, parentId = null) {
+  return {
+    type: "trace.span",
+    traceId: trace.traceId,
+    spanId,
+    parentId,
+    spanData,
+    traceMetadata: { fixture: true },
+    startedAt: "2026-08-26T00:00:00.000Z",
+    endedAt: "2026-08-26T00:00:00.010Z",
+    error: null,
+  };
+}
+
+const agentSpan = span("span_agent", {
+  type: "agent",
+  name: "PackedFixtureAgent",
+  tools: ["lookupFixture"],
+  handoffs: [],
+  output_type: "text",
+});
+const functionSpan = span(
+  "span_function",
+  {
+    type: "function",
+    name: "lookupFixture",
+    input: { fixture: "input" },
+    output: { fixture: "output" },
+  },
+  "span_agent",
+);
+
+await processor.onTraceStart(trace);
+await processor.onSpanStart(agentSpan);
+await processor.onSpanStart(functionSpan);
+await processor.onSpanEnd(functionSpan);
+await processor.onSpanEnd(agentSpan);
+await processor.onTraceEnd(trace);
+await processor.forceFlush();
+await processor.shutdown();
+
+const diagnostics = processor.getDiagnostics();
+if (diagnostics.writeFailures || diagnostics.flushFailures || diagnostics.shutdownFailures) {
+  throw new Error(\`unexpected processor diagnostics: \${JSON.stringify(diagnostics)}\`);
+}
+`,
+  );
+
+  const runtimeEnv = withoutOpenAiCredentials();
+  run("synthetic adapter capture", process.execPath, [consumerScript], {
+    cwd: consumerDir,
+    env: runtimeEnv,
+  });
+
+  const bin = path.join(consumerDir, "node_modules", ".bin", "agent-inspect");
+  if (!existsSync(bin)) fail("packed CLI binary missing after install");
+
+  const list = run(
+    "packed CLI list --json",
+    bin,
+    ["list", "--dir", traceDirName, "--json"],
+    { cwd: consumerDir, env: runtimeEnv },
+  );
+  const listJson = parseJson("packed CLI list --json", list.stdout);
+  const runs = Array.isArray(listJson) ? listJson : listJson.runs;
+  if (!Array.isArray(runs) || !runs.some((run) => run?.runId === runId)) {
+    fail("packed CLI list --json did not find the fixture run", list.stdout);
+  }
+
+  const view = run(
+    "packed CLI view --json",
+    bin,
+    ["view", runId, "--dir", traceDirName, "--json"],
+    { cwd: consumerDir, env: runtimeEnv },
+  );
+  const viewJson = parseJson("packed CLI view --json", view.stdout);
+  const inspected = JSON.stringify(viewJson);
+  for (const expected of [
+    runId,
+    "openai-agents-packed-fixture",
+    "PackedFixtureAgent",
+    "lookupFixture",
+  ]) {
+    if (!inspected.includes(expected)) {
+      fail(`packed CLI view --json is missing ${expected}`, view.stdout);
+    }
+  }
+
+  console.log(
+    "[packed-openai-agents-e2e] OK: pack -> install -> fixture capture -> list -> view",
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  rmSync(tarballDir, { recursive: true, force: true });
+  rmSync(consumerDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Adds the `@agent-inspect/openai-agents` packed consumer slice of #213.

The new golden path packs the root package and OpenAI Agents adapter, installs both tarballs into a clean temporary consumer, drives deterministic synthetic agent and tool tracing without provider credentials, persists the run locally, and verifies it through the packed CLI using `list --json` and `view --json`.

The consumer derives the supported `@openai/agents` peer range from the adapter package at runtime. The check is included in `pack:smoke`, and `OPENAI-AGENTS-LOCAL.md` documents how to run the no-key verification locally.

No adapter runtime behavior, public API, schema, dependencies, versions, Changesets, or workflows are changed.

**Linked issue (required):** #213

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

This locks in the `@agent-inspect/openai-agents` packed consumer contract from #213.

The path covers:

```text
pack
→ clean consumer install
→ synthetic capture
→ local persistence
→ list --json
→ view --json
```

It runs without `OPENAI_API_KEY` and does not make provider calls.

### Focused packed consumer E2E

<img width="940" height="144" alt="2026-08-26-175750" src="https://github.com/user-attachments/assets/54259974-1853-48a6-bd28-c5a8ffdcc4f7" />

```bash
node scripts/packed-openai-agents-e2e.mjs
```

PASS

This directly verifies the new packed consumer path from tarball installation through synthetic capture and packed CLI inspection.

### Packed smoke
<img width="853" height="141" alt="2026-08-26-182309" src="https://github.com/user-attachments/assets/63d88d53-d11a-496f-b51e-f326fa8f7ac9" />

```bash
pnpm pack:smoke
```

PASS

The new OpenAI Agents path runs as part of the existing packed validation chain, with all existing packed paths still passing.

`pnpm docs:check` passes its first five stages, then hits the same three existing demo:verify failures seen on clean 91f7d83. The fix is in #263, which has not merged yet.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

## Validation

```text
pnpm build
PASS

node scripts/packed-openai-agents-e2e.mjs
PASS

pnpm pack:smoke
PASS, including all existing packed paths

pnpm test:all
PASS, 261 files / 1,868 tests

Size
PASS, 12.02 kB / 120 kB

node --check scripts/packed-openai-agents-e2e.mjs
PASS

git diff --check
PASS

pnpm docs:check
First five stages PASS
Existing demo:verify bundle failures remain

Clean 91f7d83 baseline
Same three demo:verify bundle failures reproduced
```

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [ ] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean