### PR TITLE
feat(core): add retained fail-to-pass CI gate flow

### DIFF
--- a/docs/CI-ARTIFACTS.md
+++ b/docs/CI-ARTIFACTS.md
@@ -86,8 +86,9 @@ Recipes:
 
 - [examples/recipes/deterministic-ci-checks](../examples/recipes/deterministic-ci-checks/README.md) for v1.8 `check`, baseline, safe artifact, and step-summary workflows.
 - [examples/recipes/github-actions-artifact](../examples/recipes/github-actions-artifact/README.md) for share-safe trace exports and reporter manifest summaries.
+- [examples/recipes/github-actions-gate](../examples/recipes/github-actions-gate/README.md) for a retained broken-to-fixed suite/gate pilot with separate Evidence v2 artifacts.
 
-Sample workflows: [deterministic checks workflow](../examples/recipes/deterministic-ci-checks/workflow-example.yml), [share-safe export workflow](../examples/recipes/github-actions-artifact/workflow-example.yml)
+Sample workflows: [deterministic checks workflow](../examples/recipes/deterministic-ci-checks/workflow-example.yml), [share-safe export workflow](../examples/recipes/github-actions-artifact/workflow-example.yml), [retained gate workflow](../examples/recipes/github-actions-gate/workflow-example.yml)
 
 ```yaml
 - uses: actions/upload-artifact@v4

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -60,6 +60,7 @@ Use `AGENT_INSPECT_SILENT=true` to suppress live terminal tree output during scr
 | [nestjs-langgraph-local](nestjs-langgraph-local) | Env-gated NestJS-style LangGraph callback wiring | lazy `@agent-inspect/langchain`, metadata-only, relative `traceDir`, `close`/`getDiagnostics` | yes | no |
 | [langgraph-swarm-local](langgraph-swarm-local) | Multi-agent handoff via callback metadata | handoffFrom correlation, tool identity, persist-by-intent | yes | no |
 | [langgraph-gate-evidence](langgraph-gate-evidence) | No-key check→gate→Evidence on bridged LangGraph fixture | TraceFacts `semantics` on evidence.json | yes | no |
+| [github-actions-gate](github-actions-gate) | Retained broken → fixed CI gate pilot | `suite`, `gate`, TraceContract, Evidence v2 | yes | no |
 | [harness-basic](harness-basic) | v1.9 fixture harness basics | `@agent-inspect/harness`, fixture JSON, expected output | yes | no |
 | [harness-adapter-local](harness-adapter-local) | Adapter-shaped local harness target | `@agent-inspect/harness`, bootstrap/resolve/invoke, expected output | yes | no |
 | [mcp-client-tracing](mcp-client-tracing) | v2.4 MCP client wrap with mock client | `@agent-inspect/mcp`, `inspectRun`, `sessions` / `session` CLI | yes | no |

--- a/examples/recipes/github-actions-gate/README.md
+++ b/examples/recipes/github-actions-gate/README.md
@@ -2,7 +2,13 @@
 
 ## What this demonstrates
 
-Run `agent-inspect gate` against a local suite config and write CI-friendly artifacts (`gate-results.json`, `junit.xml`, `github-step-summary.md`, etc.) for GitHub Actions or other CI systems.
+A retained `broken -> fixed` CI pilot over synthetic traces:
+
+1. `agent-inspect gate` runs a local suite against a broken refund-agent trace and exits 1.
+2. The same gate runs against the fixed trace and exits 0.
+3. Both runs write CI reports and local Evidence v2 directories that a user-owned GitHub Actions workflow retains separately.
+
+The CLI `suite`/`gate` path is the copy-paste CI workflow. The optional programmatic path uses the existing experimental `TraceContract` API without changing its public surface.
 
 ## How to run
 
@@ -10,16 +16,73 @@ From the repository root:
 
 ```bash
 pnpm build
-cd examples/recipes/github-actions-gate
-pnpm install
-pnpm start
+pnpm --filter agent-inspect-recipe-github-actions-gate start
+pnpm --filter agent-inspect-recipe-github-actions-gate check:contract
 ```
 
-## Expected output
+`start` treats exit 1 from the broken suite as expected, requires exit 0 from the fixed suite, and checks that both retained output trees contain gate reports and Evidence v2 files. See `expected-output.txt`.
 
-See `expected-output.txt`. Exit code **0** when the gate passes.
+The two suite configs use only published CLI fields and the script imports only the public `agent-inspect/checks` and `agent-inspect/readers` subpaths. In this monorepo the dependency resolves through the workspace package; `pnpm pack:smoke` separately verifies the packed public package path used by external consumers on AgentInspect 6.17.1 and later.
+
+## Copy-paste gate commands
+
+Run these from this recipe directory after `pnpm build` at the repository root. The first command is intentionally non-zero:
+
+```bash
+npx agent-inspect gate \
+  --suite agent-inspect.broken.suite.json \
+  --dir ../../../fixtures/traces \
+  --output .agent-inspect/broken/gate-artifacts \
+  --format github \
+  --evidence-on fail \
+  --evidence-dir .agent-inspect/broken/evidence \
+  --evidence-profile share
+```
+
+After the trajectory is fixed, rerun the same policy against the fixed fixture:
+
+```bash
+npx agent-inspect gate \
+  --suite agent-inspect.fixed.suite.json \
+  --dir ../../../fixtures/traces \
+  --output .agent-inspect/fixed/gate-artifacts \
+  --format github \
+  --evidence-on always \
+  --evidence-dir .agent-inspect/fixed/evidence \
+  --evidence-profile share
+```
+
+## What retained means
+
+Keep these for a bounded CI retention window:
+
+- `gate-artifacts/`: deterministic JSON, Markdown, HTML, JUnit, and GitHub step-summary reports.
+- `evidence/`: the Evidence v2 manifest, check results, report, and share-redacted trace copy.
+- Separate broken and fixed artifacts so reviewers can compare the failure with the repaired trajectory.
+
+Do not commit generated `.agent-inspect/` output. Do not upload raw production traces, credentials, provider payloads, or unreviewed artifacts. This recipe uses repository-owned synthetic fixtures with no secrets or production data. For real traces, review the exact redacted output before upload; use `share` for controlled PR or issue attachments and `strict` for wider sharing. Redaction is a key-based safeguard, not compliance-grade DLP.
+
+See [Evidence retention](../../../docs/EVIDENCE-RETENTION.md) and [Safe trace sharing](../../../docs/SAFE-TRACE-SHARING.md).
+
+## GitHub Actions
+
+`workflow-example.yml` is deliberately scoped to `workflow_dispatch`. Its broken job asserts that the gate really failed before uploading `agent-inspect-gate-broken`; the fixed job must pass before uploading `agent-inspect-gate-fixed`. Each artifact has an explicit 14-day retention window. AgentInspect writes local files only; `actions/upload-artifact` is the user-owned network step.
+
+After downloading an Evidence v2 directory, verify it locally:
+
+```bash
+npx agent-inspect bundle verify ./path/to/evidence
+```
 
 ## Boundaries
 
-- Reads existing traces only; no network, no provider SDK, no replay.
-- Artifact upload to GitHub is user-owned CI YAML; AgentInspect does not call GitHub APIs.
+- Reads existing synthetic traces only; no agent replay, provider SDK, hosted runner, telemetry, or AgentInspect network I/O.
+- Does not add CLI behavior or broaden the experimental TraceContract public API.
+- Artifact upload and retention remain owned by the CI configuration.
+
+## See also
+
+- [CI artifacts](../../../docs/CI-ARTIFACTS.md)
+- [Evidence format](../../../docs/EVIDENCE-FORMAT.md)
+- [Evidence bundles](../../../docs/BUNDLES.md)
+- [Safety policy](../../../docs/SAFETY-POLICY.md)

--- a/examples/recipes/github-actions-gate/agent-inspect.broken.suite.json
+++ b/examples/recipes/github-actions-gate/agent-inspect.broken.suite.json
@@ -1,0 +1,15 @@
+{
+  "name": "retained-ci-gate-broken",
+  "traces": "../../../fixtures/traces",
+  "cases": [
+    {
+      "id": "refund-agent-must-call-refund-order",
+      "runId": "contract-broken",
+      "requireTools": ["refund_order"]
+    }
+  ],
+  "checks": {
+    "select": ["run.status"]
+  },
+  "redactionProfile": "share"
+}

--- a/examples/recipes/github-actions-gate/agent-inspect.fixed.suite.json
+++ b/examples/recipes/github-actions-gate/agent-inspect.fixed.suite.json
@@ -1,0 +1,15 @@
+{
+  "name": "retained-ci-gate-fixed",
+  "traces": "../../../fixtures/traces",
+  "cases": [
+    {
+      "id": "refund-agent-must-call-refund-order",
+      "runId": "contract-fixed",
+      "requireTools": ["refund_order"]
+    }
+  ],
+  "checks": {
+    "select": ["run.status"]
+  },
+  "redactionProfile": "share"
+}

--- a/examples/recipes/github-actions-gate/expected-output.txt
+++ b/examples/recipes/github-actions-gate/expected-output.txt
@@ -1,8 +1,1 @@
-# AgentInspect gate
-
-Status: **PASS** (exit 0)
-Suite config: `fixtures/configs/outcome-suite.suite.json`
-Runs evaluated: 0
-
-## Checks
-- [PASS] Suite: outcome-suite: Suite passed (1 cases)
+OK: broken gate exited 1, fixed gate exited 0, and both retained Evidence v2 artifacts.

--- a/examples/recipes/github-actions-gate/package.json
+++ b/examples/recipes/github-actions-gate/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node --import tsx src/index.ts"
+    "start": "node --import tsx src/index.ts",
+    "check:contract": "node --import tsx src/trace-contract-check.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/recipes/github-actions-gate/src/index.ts
+++ b/examples/recipes/github-actions-gate/src/index.ts
@@ -1,32 +1,90 @@
+import { existsSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const recipeDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(recipeDir, "../../..");
-const suitePath = path.join(repoRoot, "fixtures/configs/outcome-suite.suite.json");
-const outputDir = path.join(recipeDir, ".agent-inspect/gate-artifacts");
+const packageDir = path.resolve(recipeDir, "..");
+const repoRoot = path.resolve(recipeDir, "../../../..");
+const cli = path.join(repoRoot, "packages/cli/dist/index.cjs");
+const tracesDir = path.join(repoRoot, "fixtures/traces");
+const workDir = path.join(packageDir, ".agent-inspect");
 
-const result = spawnSync(
-  "node",
-  [
-    path.join(repoRoot, "packages/cli/dist/index.cjs"),
-    "gate",
-    "--suite",
-    suitePath,
-    "--output",
-    outputDir,
-  ],
-  {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    stdio: ["ignore", "pipe", "pipe"],
-  },
-);
-
-if (result.status !== 0) {
-  console.error(result.stderr || result.stdout);
-  process.exit(result.status ?? 1);
+interface GatePilotCase {
+  label: "broken" | "fixed";
+  suite: string;
+  evidenceOn: "fail" | "always";
+  expectedExitCode: 0 | 1;
 }
 
-process.stdout.write(result.stdout);
+const cases: GatePilotCase[] = [
+  {
+    label: "broken",
+    suite: "agent-inspect.broken.suite.json",
+    evidenceOn: "fail",
+    expectedExitCode: 1,
+  },
+  {
+    label: "fixed",
+    suite: "agent-inspect.fixed.suite.json",
+    evidenceOn: "always",
+    expectedExitCode: 0,
+  },
+];
+
+const retainedFiles = [
+  "gate-artifacts/gate-results.json",
+  "gate-artifacts/github-step-summary.md",
+  "evidence/evidence.html",
+  "evidence/evidence.json",
+  "evidence/check-results.json",
+  "evidence/trace.jsonl",
+] as const;
+
+rmSync(workDir, { recursive: true, force: true });
+
+for (const pilotCase of cases) {
+  const caseDir = path.join(workDir, pilotCase.label);
+  const result = spawnSync("node", [
+    cli,
+    "gate",
+    "--suite",
+    path.join(packageDir, pilotCase.suite),
+    "--dir",
+    tracesDir,
+    "--output",
+    path.join(caseDir, "gate-artifacts"),
+    "--format",
+    "github",
+    "--evidence-on",
+    pilotCase.evidenceOn,
+    "--evidence-dir",
+    path.join(caseDir, "evidence"),
+    "--evidence-profile",
+    "share",
+  ], {
+    cwd: packageDir,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== pilotCase.expectedExitCode) {
+    console.error(result.stderr || result.stdout);
+    console.error(
+      `Expected ${pilotCase.label} gate exit ${pilotCase.expectedExitCode}, received ${result.status ?? "none"}.`,
+    );
+    process.exit(1);
+  }
+
+  for (const relativePath of retainedFiles) {
+    const artifactPath = path.join(caseDir, relativePath);
+    if (!existsSync(artifactPath)) {
+      console.error(`Missing retained ${pilotCase.label} artifact: ${artifactPath}`);
+      process.exit(1);
+    }
+  }
+}
+
+process.stdout.write(
+  "OK: broken gate exited 1, fixed gate exited 0, and both retained Evidence v2 artifacts.\n",
+);

--- a/examples/recipes/github-actions-gate/src/trace-contract-check.ts
+++ b/examples/recipes/github-actions-gate/src/trace-contract-check.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  defineTraceContract,
+  evaluateTraceContractRead,
+} from "agent-inspect/checks";
+import { openTraceFile } from "agent-inspect/readers";
+
+const recipeDir = path.dirname(fileURLToPath(import.meta.url));
+const tracesDir = path.resolve(recipeDir, "../../../../fixtures/traces");
+
+const contract = defineTraceContract({
+  run: { requireCompleted: true, allowedStatuses: ["ok"] },
+  tools: { required: ["refund_order"] },
+});
+
+const cases = [
+  { file: "contract-broken.jsonl", expected: "fail" },
+  { file: "contract-fixed.jsonl", expected: "pass" },
+] as const;
+
+const statuses: string[] = [];
+for (const contractCase of cases) {
+  const read = await openTraceFile(path.join(tracesDir, contractCase.file));
+  const result = evaluateTraceContractRead(read, contract);
+  statuses.push(`${contractCase.file}=${result.status}`);
+  if (result.status !== contractCase.expected) {
+    console.error(
+      `Expected ${contractCase.file} to ${contractCase.expected}, received ${result.status}.`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+console.log(`TraceContract: ${statuses.join(", ")}`);

--- a/examples/recipes/github-actions-gate/workflow-example.yml
+++ b/examples/recipes/github-actions-gate/workflow-example.yml
@@ -1,10 +1,10 @@
-name: AgentInspect gate (example)
+name: AgentInspect retained gate (example)
 
 on:
   workflow_dispatch:
 
 jobs:
-  gate:
+  gate-broken:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,22 +15,63 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - name: Run AgentInspect gate
+      - name: Gate broken trace (expected failure)
+        id: broken_gate
+        continue-on-error: true
+        working-directory: examples/recipes/github-actions-gate
         run: |
+          set +e
           npx agent-inspect gate \
-            --suite fixtures/configs/outcome-suite.suite.json \
-            --output ./gate-artifacts \
+            --suite agent-inspect.broken.suite.json \
+            --dir ../../../fixtures/traces \
+            --output .agent-inspect/broken/gate-artifacts \
+            --format github \
             --evidence-on fail \
+            --evidence-dir .agent-inspect/broken/evidence \
             --evidence-profile share
-      - name: Trajectory preset check
-        run: |
-          npx agent-inspect check --dir .agent-inspect --preset trajectory \
-            --evidence-on fail --evidence-dir ./gate-artifacts/evidence
-      - name: Publish gate summary
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+      - name: Assert that the broken gate failed
         if: always()
-        run: cat ./gate-artifacts/github-step-summary.md >> "$GITHUB_STEP_SUMMARY"
+        run: test "${{ steps.broken_gate.outputs.exit_code }}" = "1"
+      - name: Publish broken gate summary
+        if: always()
+        run: cat examples/recipes/github-actions-gate/.agent-inspect/broken/gate-artifacts/github-step-summary.md >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: agent-inspect-gate
-          path: gate-artifacts/
+          name: agent-inspect-gate-broken
+          path: examples/recipes/github-actions-gate/.agent-inspect/broken/
+          retention-days: 14
+
+  gate-fixed:
+    needs: gate-broken
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Gate fixed trace
+        working-directory: examples/recipes/github-actions-gate
+        run: |
+          npx agent-inspect gate \
+            --suite agent-inspect.fixed.suite.json \
+            --dir ../../../fixtures/traces \
+            --output .agent-inspect/fixed/gate-artifacts \
+            --format github \
+            --evidence-on always \
+            --evidence-dir .agent-inspect/fixed/evidence \
+            --evidence-profile share
+      - name: Publish fixed gate summary
+        run: cat examples/recipes/github-actions-gate/.agent-inspect/fixed/gate-artifacts/github-step-summary.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-inspect-gate-fixed
+          path: examples/recipes/github-actions-gate/.agent-inspect/fixed/
+          retention-days: 14

--- a/examples/recipes/github-actions-gate/workflow-example.yml
+++ b/examples/recipes/github-actions-gate/workflow-example.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: examples/recipes/github-actions-gate
         run: |
           set +e
-          npx agent-inspect gate \
+          node ../../../packages/cli/dist/index.cjs gate \
             --suite agent-inspect.broken.suite.json \
             --dir ../../../fixtures/traces \
             --output .agent-inspect/broken/gate-artifacts \
@@ -44,6 +44,8 @@ jobs:
           name: agent-inspect-gate-broken
           path: examples/recipes/github-actions-gate/.agent-inspect/broken/
           retention-days: 14
+          include-hidden-files: true
+          if-no-files-found: error
 
   gate-fixed:
     needs: gate-broken
@@ -60,7 +62,7 @@ jobs:
       - name: Gate fixed trace
         working-directory: examples/recipes/github-actions-gate
         run: |
-          npx agent-inspect gate \
+          node ../../../packages/cli/dist/index.cjs gate \
             --suite agent-inspect.fixed.suite.json \
             --dir ../../../fixtures/traces \
             --output .agent-inspect/fixed/gate-artifacts \
@@ -75,3 +77,5 @@ jobs:
           name: agent-inspect-gate-fixed
           path: examples/recipes/github-actions-gate/.agent-inspect/fixed/
           retention-days: 14
+          include-hidden-files: true
+          if-no-files-found: error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,10 @@ importers:
         version: 4.21.0
 
   examples/recipes/github-actions-gate:
+    dependencies:
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
     devDependencies:
       tsx:
         specifier: ^4.19.2


### PR DESCRIPTION
## Summary

* Extend the existing GitHub Actions gate recipe with a retained CI flow that demonstrates a deterministic broken to fixed transition using the existing suite, gate, TraceContract, and Evidence surfaces.

* The broken case fails the gate and TraceContract checks as expected. The fixed case passes the same checks. Evidence from both outcomes is retained so the example shows how CI artifacts remain useful after the original failure is corrected.

* The recipe also documents what should be retained, what should not be uploaded, and how to keep the workflow synthetic and safe to share.

* No runtime behavior, public API, Evidence schema, or TraceContract semantics are changed.

**Linked issue (required):** #153

Closes #153

## Type of change

* [ ] Bug fix (non breaking)
* [ ] Documentation only
* [x] Example / recipe / fixture
* [x] Test / regression coverage
* [ ] Feature or enhancement (scoped)
* [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

* The retained recipe exercises both sides of the CI gate using the existing public surfaces.

* The broken case produces the expected gate exit code `1` and fails the TraceContract check.

* The fixed case produces gate exit code `0` and passes the same TraceContract check.

* Evidence integrity verification succeeds for both generated outputs. The broken case is intentionally classified as `UNSAFE`, while the fixed case is classified as `SAFE`.

### Live GitHub Actions verification

I also exercised the retained flow on a GitHub Actions runner in my fork using a demo scoped `workflow_dispatch` workflow.

**Live run:** [GitHub Actions run #3](https://github.com/HsienW/agent-inspect/actions/runs/32957611259#artifacts)

The overall GitHub Actions run is `Success`. The `AgentInspect gate: FAIL` result shown for the broken case is intentional. That result is the retained evidence that the CI gate correctly rejected the broken trace.

The workflow allows that gate step to return its expected failure, captures the exit code, and then explicitly asserts that the exit code is `1`. The fixed case is evaluated separately and must pass normally.

**Fork verification workflow:** [Expected broken gate and exit code assertion](https://github.com/HsienW/agent-inspect/blob/refs/heads/verify/retained-ci-gate-actions/.github/workflows/retained-ci-gate-demo.yml#L615-L657)

The live run confirmed:

* `gate-broken` completed successfully after validating the expected gate failure
* `gate-fixed` completed successfully with a passing gate
* the broken summary reports `AgentInspect gate: FAIL`
* the fixed summary reports `AgentInspect gate: PASS`
* both artifact sets were retained

**Screenshot 1: Live fail to pass GitHub Actions verification**

<img width="1257" height="891" alt="Live retained CI gate verification" src="https://github.com/user-attachments/assets/52b136b1-2df1-4941-b917-66b6c800604d" />

The broken result above is expected evidence, not a workflow failure. The workflow run remains successful because the broken gate exit code is explicitly captured and verified before the fixed case runs.

**Screenshot 2: Retained artifacts from both outcomes**

<img width="1353" height="313" alt="Retained artifacts from broken and fixed outcomes" src="https://github.com/user-attachments/assets/b0ba088d-da60-4973-a660-1eacf96047fd" />

The live runner retained both outputs:

* `agent-inspect-gate-broken`
* `agent-inspect-gate-fixed`

Each artifact is independently retained with its own GitHub generated SHA256 digest.

## Product boundaries

* [x] Local first only, no network upload added
* [x] No new vendor sinks
* [x] No SaaS / dashboard scope added
* [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
* [x] No `step_failed` event introduced
* [x] `inspectRun` default tracing behavior unchanged
* [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

* [ ] `agent-inspect` (root: core + CLI, published)
* [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
* [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
* [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
* [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
* [x] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm build
# passed

# retained recipe
# broken exit 1
# fixed exit 0

# TraceContract
# broken = fail
# fixed = pass

# Evidence verification
# broken = UNSAFE, integrity verified
# fixed = SAFE, integrity verified

# live GitHub Actions
# gate-broken = success with expected gate exit 1
# gate-fixed = success
# retained artifacts = 2

# workflow YAML parse
# passed

# focused golden coverage
# 2/2 passed

pnpm recipes:check
# 40 recipes passed

pnpm typecheck
# passed

pnpm docs:check
# passed

pnpm pack:smoke
# passed

pnpm test
# 261 test files
# 1868 tests passed

git diff --check
# passed
```

## Data safety

* [x] Synthetic data only, no real prompts, logs, tokens, or PII
* [x] Trace and log samples in the PR were generated from synthetic fixtures

## Release hygiene

* [x] No version bumps and no Changesets. Maintainers own Changesets and releases
* [x] No new runtime dependencies without prior maintainer approval
* [ ] No publish, tag, or workflow changes

The PR does not change any repository CI workflow under `.github/workflows`. It only updates the demo scoped workflow example that belongs to this recipe.

## Checklist

* [x] Linked issue explains the why and was commented on before the PR
* [x] Focused regression coverage was added for the retained broken to fixed flow
* [x] Docs were updated for the recipe and retained Evidence guidance
* [x] `git diff --check` clean