### PR TITLE
test(pack): complete Windows Node 24 packed consumer coverage

### DIFF
--- a/docs/COMPATIBILITY-PACKED-MATRIX.md
+++ b/docs/COMPATIBILITY-PACKED-MATRIX.md
@@ -1,16 +1,16 @@
-# Cross-platform packed consumer matrix (v6.12)
+# Cross-platform packed consumer matrix (target: v6.18)
 
 **Status:** PARTIAL — evidence from maintainer CI + local smoke scripts; not a full OS×Node grid.  
 **Authority:** [implementation/ROADMAP.md](./implementation/ROADMAP.md) · [history/RELEASE-HISTORY.md](./history/RELEASE-HISTORY.md)
-**Date:** 2026-08-02 · baseline `agent-inspect@6.12.0`
+**Date:** 2026-08-26 · tested baseline `agent-inspect@6.17.3`
 
 ## Method
 
 | Source | What it proves |
 |--------|----------------|
 | GitHub Actions `CI` / `Publish` on `ubuntu-latest` + Node **22** | typecheck, unit, size, release-train gates |
-| `pnpm pack:smoke` (`scripts/package-smoke.mjs` + `packed-quickstart-e2e.mjs`) | packed tarball install, ESM/CJS/TS for core + optional packages, quickstart CLI path |
-| `pnpm compat:smoke` (`scripts/compat-smoke.mjs`) | ESM/CJS consumer fixtures, Jest-style CJS, `ts-jest` **Node16**, CLI bin help |
+| `pnpm pack:smoke` (`scripts/package-smoke.mjs` + packed E2E scripts) | packed tarball install; root ESM/CJS; manifest-driven JS/type target presence and ESM/CJS loading for every concrete public root subpath; optional-package and packed E2E paths |
+| `pnpm compat:smoke` (`scripts/compat-smoke.mjs`) | ESM/CJS consumer fixtures, semantic public-subpath imports, Jest-style CJS, `ts-jest` **Node16**, CLI bin help |
 
 Do **not** infer untested cells as supported.
 
@@ -20,7 +20,8 @@ Do **not** infer untested cells as supported.
 |-----------|----------------|----------|--------|
 | Node 20 | engines `>=20` | engines field; not separately matrixed in CI | **DECLARED** / CI not multi-version |
 | Node 22 | CI primary | GHA typecheck/unit/publish | **PASS** |
-| Node 24 / 26 | Desired | Not in GHA matrix | **UNTESTED** |
+| Node 24 | Desired | 2026-08-26 native Windows packed-consumer run below; not in GHA matrix | **PASS** for the executed root/subpath slice |
+| Node 26 | Desired | Not in GHA matrix and not covered by the dated run below | **UNTESTED** |
 | ESM | Supported | pack + compat smoke | **PASS** (CI Linux) |
 | CJS | Supported | pack + compat smoke | **PASS** (CI Linux) |
 | TypeScript Node16 / NodeNext | Supported | compat `ts-jest-node16`; docs recommend NodeNext/Node16 | **PASS** (fixture) |
@@ -28,9 +29,22 @@ Do **not** infer untested cells as supported.
 | pnpm consumer | Supported | monorepo + docs guide; CI uses pnpm | **PASS** (repo) / clean consumer **DOCUMENTED** |
 | Linux | Supported | GHA ubuntu | **PASS** |
 | macOS | Supported intent | Maintainer local Darwin; not GHA matrix | **PARTIAL** |
-| Windows | Supported intent | quickstart script has `win32` shell handling; not GHA matrix | **UNTESTED** in CI |
+| Windows | Supported intent | 2026-08-26 manual native Windows + Node 24 evidence below; not in GHA matrix | **PASS** for the #209 root/subpath slice; broader matrix **PARTIAL** |
 | Jest 29 / 30 | Reporters packed | pack smoke Jest reporter import | **PARTIAL** (import smoke, not full Jest version matrix) |
 | Vitest | Reporters packed | pack smoke Vitest reporter import | **PARTIAL** |
+
+## Dated evidence
+
+| Date | OS | Node | Package managers | Package | Root ESM | Root CJS | Public subpaths ESM | Public subpaths CJS | Result |
+|------|----|------|------------------|---------|----------|----------|---------------------|---------------------|--------|
+| 2026-08-26 | Native Windows; registry product `Windows 10 Home`, display `25H2`, build `26200.9168` | `v24.13.0` | `pnpm 9.15.0`; `npm 11.17.0` | `agent-inspect@6.17.3` | **PASS** | **PASS** | **PASS** (10/10) | **PASS** (10/10) | `pack:smoke` + `compat:smoke` **PASS** |
+
+This Windows + Node 24 row specifically closes the root packed-consumer and
+public-root-subpath slice for issue #209. The same `pack:smoke` run exercised
+all 17 configured optional/public package smoke checks, including the native
+`better-sqlite3` rebuild, but this is not a claim of a complete Windows support
+matrix across the full package family. Node 26 remains untested, and the macOS
+status is unchanged.
 
 ## Retention
 

--- a/scripts/compat-smoke.mjs
+++ b/scripts/compat-smoke.mjs
@@ -30,6 +30,15 @@ function run(label, cmd, args, opts = {}) {
   return result;
 }
 
+function spawnCli(cmd, args, opts = {}) {
+  const useShell =
+    process.platform === "win32" && !cmd.toLowerCase().endsWith(".exe");
+  const safeArgs = useShell
+    ? args.map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
+    : args;
+  return spawnSync(cmd, safeArgs, { encoding: "utf8", shell: useShell, ...opts });
+}
+
 function parsePackedFilename(output) {
   const trimmed = output.trim();
   if (!trimmed) return undefined;
@@ -114,7 +123,7 @@ for (const [args, needles] of cliChecks) {
   );
 }
 
-const packProc = spawnSync("npm", ["pack", "--silent", "--ignore-scripts"], {
+const packProc = spawnCli("npm", ["pack", "--silent", "--ignore-scripts"], {
   cwd: root,
   encoding: "utf8",
   env: {
@@ -178,7 +187,7 @@ try {
   if (!existsSync(binPath)) {
     fail("missing node_modules/.bin/agent-inspect after install");
   }
-  const binHelp = spawnSync(binPath, ["--help"], { cwd: binDir, encoding: "utf8" });
+  const binHelp = spawnCli(binPath, ["--help"], { cwd: binDir });
   assertCliHelp("agent-inspect --help", binHelp.stdout, binHelp.stderr, binHelp.status, [
     "agent-inspect",
     "list",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -708,6 +708,150 @@ function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"));
 }
 
+function getConcreteRootExports(manifest) {
+  if (
+    !manifest.exports ||
+    typeof manifest.exports !== "object" ||
+    Array.isArray(manifest.exports)
+  ) {
+    fail("packed root manifest has no exports object");
+  }
+
+  const concrete = [];
+  const patterns = [];
+  for (const [exportKey, conditions] of Object.entries(manifest.exports)) {
+    if (exportKey !== "." && !exportKey.startsWith("./")) continue;
+    if (exportKey.includes("*")) {
+      patterns.push(exportKey);
+      continue;
+    }
+    concrete.push({ exportKey, conditions });
+  }
+
+  if (!concrete.some(({ exportKey }) => exportKey === ".")) {
+    fail("packed root manifest is missing the root export");
+  }
+  if (patterns.length > 0) {
+    console.log(
+      `[pack:smoke] excluding pattern exports from concrete root-subpath smoke: ${patterns.join(", ")}`,
+    );
+  }
+
+  return concrete;
+}
+
+function rootExportSpecifier(exportKey) {
+  return exportKey === "."
+    ? "agent-inspect"
+    : `agent-inspect/${exportKey.slice(2)}`;
+}
+
+function assertPackedRootExportTargets(packageDir, concreteExports) {
+  for (const { exportKey, conditions } of concreteExports) {
+    if (
+      !conditions ||
+      typeof conditions !== "object" ||
+      Array.isArray(conditions)
+    ) {
+      fail(`packed root export ${exportKey} has invalid conditions`);
+    }
+
+    for (const moduleFormat of ["import", "require"]) {
+      const targets = conditions[moduleFormat];
+      if (!targets || typeof targets !== "object" || Array.isArray(targets)) {
+        fail(`packed root export ${exportKey} is missing ${moduleFormat} conditions`);
+      }
+
+      for (const targetKind of ["default", "types"]) {
+        const declaredTarget = targets[targetKind];
+        if (
+          typeof declaredTarget !== "string" ||
+          !declaredTarget.startsWith("./")
+        ) {
+          fail(
+            `packed root export ${exportKey} has invalid ${moduleFormat}.${targetKind} target`,
+            String(declaredTarget),
+          );
+        }
+
+        const targetPath = path.resolve(packageDir, declaredTarget);
+        const relativeTarget = path.relative(packageDir, targetPath);
+        if (
+          relativeTarget.startsWith("..") ||
+          path.isAbsolute(relativeTarget) ||
+          !existsSync(targetPath)
+        ) {
+          fail(
+            `packed root export ${exportKey} has missing ${moduleFormat}.${targetKind} target`,
+            declaredTarget,
+          );
+        }
+      }
+    }
+  }
+}
+
+function createRootSubpathSmokeSource(moduleFormat, specifiers) {
+  const formatLabel = moduleFormat === "esm" ? "ESM" : "CJS";
+  const loadExpression =
+    moduleFormat === "esm" ? "await import(specifier)" : "require(specifier)";
+
+  return `
+const specifiers = ${JSON.stringify(specifiers)};
+const failures = [];
+let passed = 0;
+
+for (const specifier of specifiers) {
+  try {
+    const loaded = ${loadExpression};
+    if (!loaded || (typeof loaded !== "object" && typeof loaded !== "function")) {
+      throw new Error("unexpected module value");
+    }
+    passed += 1;
+  } catch (error) {
+    failures.push({
+      specifier,
+      reason: String(error?.stack ?? error),
+    });
+  }
+}
+
+if (failures.length > 0) {
+  console.error("[pack:smoke] root public subpaths ${formatLabel} FAILED (" + passed + "/" + specifiers.length + ")");
+  for (const failure of failures) {
+    console.error("\\n- " + failure.specifier + "\\n  " + failure.reason);
+  }
+  process.exit(1);
+}
+`;
+}
+
+function smokeRootSubpaths(moduleFormat, consumerDir, specifiers) {
+  const formatLabel = moduleFormat === "esm" ? "ESM" : "CJS";
+  const args =
+    moduleFormat === "esm"
+      ? [
+          "--input-type=module",
+          "-e",
+          createRootSubpathSmokeSource(moduleFormat, specifiers),
+        ]
+      : ["-e", createRootSubpathSmokeSource(moduleFormat, specifiers)];
+  const result = spawnSync(process.execPath, args, {
+    cwd: consumerDir,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    console.error(result.stdout || "");
+    console.error(result.stderr || result.error || "");
+    process.exit(1);
+  }
+
+  console.log(
+    `[pack:smoke] root public subpaths ${formatLabel} OK (${specifiers.length}/${specifiers.length}): ${specifiers.map((specifier) => specifier.slice("agent-inspect/".length)).join(", ")}`,
+  );
+}
+
 function readPackedPackageJson(tgzPath) {
   const result = run("read packed package.json", "tar", [
     "-xOf",
@@ -954,6 +1098,24 @@ try {
     encoding: "utf8",
   });
 
+  const installedPackageDir = path.join(
+    tmpRoot,
+    "node_modules",
+    "agent-inspect",
+  );
+  const installedManifest = readJson(
+    path.join(installedPackageDir, "package.json"),
+  );
+  const concreteRootExports = getConcreteRootExports(installedManifest);
+  assertPackedRootExportTargets(installedPackageDir, concreteRootExports);
+  const rootSubpathSpecifiers = concreteRootExports
+    .filter(({ exportKey }) => exportKey !== ".")
+    .map(({ exportKey }) => rootExportSpecifier(exportKey));
+
+  if (rootSubpathSpecifiers.length === 0) {
+    fail("packed root manifest has no concrete public subpaths");
+  }
+
   const esm = spawnSync(
     process.execPath,
     [
@@ -966,6 +1128,7 @@ try {
     console.error("[pack:smoke] ESM import check failed:\n", esm.stderr || esm.stdout);
     process.exit(1);
   }
+  smokeRootSubpaths("esm", tmpRoot, rootSubpathSpecifiers);
 
   const cjsDir = path.join(tmpRoot, "cjs-check");
   mkdirSync(cjsDir, { recursive: true });
@@ -985,6 +1148,7 @@ try {
     console.error("[pack:smoke] CJS require check failed:\n", cjs.stderr || cjs.stdout);
     process.exit(1);
   }
+  smokeRootSubpaths("cjs", cjsDir, rootSubpathSpecifiers);
 
   const binPath = path.join(tmpRoot, "node_modules", ".bin", "agent-inspect");
   if (!existsSync(binPath)) {
@@ -1027,7 +1191,7 @@ try {
   smokeOptionalPackages(tgzPath, tmpRoot);
 
   console.log(
-    `[pack:smoke] OK: tarball install, ESM import, CJS require, CLI ${expectedVersion}, optional package installs, and local bin / npm exec / npx --no-install --help`,
+    `[pack:smoke] OK: tarball install, root ESM import, root CJS require, ${rootSubpathSpecifiers.length} public root subpaths in ESM/CJS, CLI ${expectedVersion}, optional package installs, and local bin / npm exec / npx --no-install --help`,
   );
 } finally {
   if (!keep) {

--- a/test/consumer-fixtures/subpath-cjs/smoke.cjs
+++ b/test/consumer-fixtures/subpath-cjs/smoke.cjs
@@ -28,6 +28,9 @@ const {
   createReporterArtifactPath,
   createTraceArtifactManifest,
 } = require("agent-inspect/reporters");
+const {
+  createDefaultWorkspaceManifest,
+} = require("agent-inspect/workspace");
 
 const functionChecks = [
   parseLogsToTrees,
@@ -49,6 +52,7 @@ const functionChecks = [
   runTraceChecks,
   createReporterArtifactPath,
   createTraceArtifactManifest,
+  createDefaultWorkspaceManifest,
 ];
 
 const objectChecks = [agentInspectJsonlReader];

--- a/test/consumer-fixtures/subpath-esm/smoke.mjs
+++ b/test/consumer-fixtures/subpath-esm/smoke.mjs
@@ -28,6 +28,7 @@ import {
   createReporterArtifactPath,
   createTraceArtifactManifest,
 } from "agent-inspect/reporters";
+import { createDefaultWorkspaceManifest } from "agent-inspect/workspace";
 
 const functionChecks = [
   parseLogsToTrees,
@@ -49,6 +50,7 @@ const functionChecks = [
   runTraceChecks,
   createReporterArtifactPath,
   createTraceArtifactManifest,
+  createDefaultWorkspaceManifest,
 ];
 
 const objectChecks = [agentInspectJsonlReader];


### PR DESCRIPTION
## Summary

Complete the Windows + Node 24 slice of #209 using the real packed `agent-inspect` consumer path.

This change:

* Extends `package-smoke.mjs` to discover concrete public exports from the installed package manifest
* Verifies packed ESM and CJS runtime targets plus declared type targets for every current public root subpath
* Reports all subpath failures in one run instead of stopping at the first failure
* Fixes Windows `.cmd` and `.bin` spawning in the compatibility smoke harness
* Adds `workspace` coverage to the existing ESM and CJS subpath fixtures using `createDefaultWorkspaceManifest`
* Records native Windows + Node 24 evidence in the existing packed compatibility matrix

The verified root package surface is now `10/10` for both ESM and CJS public subpaths.

**Linked issue (required):** #209

## Type of change

- [ ] Bug fix (non breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan and maintainer approval)

## Reproduction / evidence

Validated on native Windows 25H2, build `26200.9168`, with Node `v24.19.0` against `agent-inspect@6.17.3`.

### Packed consumer verification

`pnpm pack:smoke` passes with:

* Root ESM consumer PASS
* Root CJS consumer PASS
* Public root subpaths ESM `10/10`
* Public root subpaths CJS `10/10`
* 17 configured optional package packed smoke checks PASS
* Packed E2E coverage PASS

**Screenshot 1: Windows Node 24 packed consumer verification**

<img width="877" height="217" alt="image" src="https://github.com/user-attachments/assets/e4a86d12-8f31-44ca-a405-a9e375597a12" />

### Compatibility and regression coverage

`pnpm compat:smoke` passes, including the Windows spawn path and the updated ESM/CJS `workspace` fixture coverage.

The full test suite also passes:

```text
Test Files  261 passed
Tests       1868 passed
```

**Screenshot 2: Compatibility smoke and full test suite**

<img width="1256" height="191" alt="2026-08-26-215344" src="https://github.com/user-attachments/assets/4b029a6f-ba6b-4d5f-91c6-c4465f3f3505" />

## Validation

```text
pnpm pack:smoke           PASS
pnpm compat:smoke         PASS
pnpm typecheck            PASS
pnpm test                 PASS, 261 files / 1868 tests
pnpm public-truth:check   PASS
git diff --check          PASS
```

`pnpm docs:check` passes its first five validation stages and reaches the existing three `demo:verify` bundle failures. The same failures reproduce on the clean baseline and are unrelated to this change. The corresponding fixture normalization fix is tracked in #263 and has not merged into the current base branch yet.

## Product boundaries

- [x] Local first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS or dashboard scope added
- [x] Persisted schema compatibility preserved
- [x] No public API behavior changed

## Packages touched

Root `agent-inspect` packed consumer and compatibility test infrastructure only.

No package exports, runtime APIs, dependencies, or package versions are changed.

## Data safety

No new data collection, persistence, upload, telemetry, or network behavior is introduced.

This change only exercises existing packed artifacts in temporary local consumers.

## Compatibility scope

This PR records evidence specifically for:

```text
Windows
Node 24
packed consumer
ESM and CJS
root package
current public root subpaths
```

Node 26 remains `UNTESTED`.

macOS remains unchanged.

The same `pack:smoke` run also exercises its configured optional package smoke checks, but this PR does not claim a complete Windows compatibility matrix for the full package family.

## Release hygiene

- [x] No version bump
- [x] No Changeset
- [x] No publish or tag changes
- [x] No workflow changes
- [x] No new dependencies
- [x] No export map changes
- [x] No runtime API changes

## Checklist

- [x] Scope is limited to the Windows + Node 24 slice claimed in #209
- [x] Packed verification uses the real generated tarball from a clean consumer
- [x] Root ESM and CJS checks remain covered
- [x] All current concrete public root subpaths are covered
- [x] ESM and CJS failures are aggregated before failing
- [x] Existing semantic subpath checks are preserved
- [x] Windows compatibility evidence is recorded in the existing matrix
- [x] Node 26 and macOS status are not inferred from this result
- [x] Required validation completed with baseline only `docs:check` failures documented