### PR TITLE
fix(redact): redact camelCase compound credential keys

### DIFF
--- a/.changeset/fix-sensitive-key-camelcase-239.md
+++ b/.changeset/fix-sensitive-key-camelcase-239.md
@@ -1,0 +1,6 @@
+---
+"agent-inspect": patch
+"@agent-inspect/redact": patch
+---
+
+Fix camelCase / kebab / dot compound credential key redaction (`userPassword`, `clientSecret`) while keeping token-config keys and camelCase topic fields (`emailNote`) un-key-redacted.

--- a/packages/core/src/safety/sensitive-key.ts
+++ b/packages/core/src/safety/sensitive-key.ts
@@ -9,8 +9,22 @@
  * surfaces lands in the same patch train.
  */
 
+/** True when the original key already uses an explicit separator. */
+function keyHasExplicitSeparator(value: string): boolean {
+  return /[_\-.]/.test(value);
+}
+
+/**
+ * Canonicalize field names so camelCase / kebab / dot / snake forms share a
+ * snake_case shape the compound matcher can recognize (`userPassword` →
+ * `user_password`).
+ */
 export function normalizeSensitiveKey(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9_]/g, "");
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
 }
 
 /** Model / usage configuration keys that are not credentials by key alone. */
@@ -58,13 +72,18 @@ export const DEFAULT_CREDENTIAL_SENSITIVE_KEYS = [
 function isTokenCredentialKey(normalized: string): boolean {
   if (NON_CREDENTIAL_TOKEN_CONFIG_KEYS.has(normalized)) return false;
   if (normalized === "token") return true;
-  // access_token / refreshToken → *token, but not *tokens (max_tokens → maxtokens)
+  // access_token / refreshToken → *token, but not *tokens (max_tokens → max_tokens)
   if (normalized.endsWith("tokens")) return false;
   return normalized.endsWith("token");
 }
 
 /**
  * True when the field name looks credential-sensitive under the shared policy.
+ *
+ * Suffix compounds (`user_password`, `userPassword`) always match. Prefix
+ * compounds (`email_note`) match only when the original key already contained
+ * an explicit separator, so camelCase topic fields like `emailNote` stay for
+ * value detectors instead of key redaction.
  */
 export function isCredentialSensitiveKey(
   key: string | undefined,
@@ -75,6 +94,8 @@ export function isCredentialSensitiveKey(
   if (!normalized) return false;
   if (NON_CREDENTIAL_TOKEN_CONFIG_KEYS.has(normalized)) return false;
 
+  const allowPrefixCompound = keyHasExplicitSeparator(key);
+
   for (const sensitive of sensitiveKeys) {
     const s = normalizeSensitiveKey(sensitive);
     if (!s) continue;
@@ -83,8 +104,9 @@ export function isCredentialSensitiveKey(
       continue;
     }
     if (normalized === s) return true;
-    // Compound keys only with explicit separators (user_password, api-key → api_key).
-    if (normalized.endsWith(`_${s}`) || normalized.startsWith(`${s}_`)) return true;
+    // Compound keys with explicit separators, plus camelCase owner+secret suffixes.
+    if (normalized.endsWith(`_${s}`)) return true;
+    if (allowPrefixCompound && normalized.startsWith(`${s}_`)) return true;
   }
   return false;
 }

--- a/packages/core/test/safety-surface-parity.test.ts
+++ b/packages/core/test/safety-surface-parity.test.ts
@@ -111,4 +111,37 @@ describe("safety surface parity (6.14.2-6)", () => {
     );
     expect(unsafe.findings.some((f) => f.ruleId === "safety.redaction")).toBe(true);
   });
+
+  it("flags camelCase compound credentials without flagging maxTokens (#239)", () => {
+    expect(isCredentialSensitiveKey("userPassword")).toBe(true);
+    expect(isCredentialSensitiveKey("clientSecret")).toBe(true);
+    expect(isCredentialSensitiveKey("maxTokens")).toBe(false);
+    expect(isCredentialSensitiveKey("emailNote")).toBe(false);
+
+    const findings = runTraceChecks(
+      {
+        read: readResult([
+          persisted("camel", {
+            attributes: {
+              userPassword: "hunter2",
+              clientSecret: "sk-abc",
+              maxTokens: 2048,
+            },
+          }),
+        ]),
+      },
+      { rules: [createSafetyRedactionRule()] },
+    ).findings.filter((f) => f.ruleId === "safety.redaction");
+
+    const paths = findings.flatMap((f) => [
+      f.message,
+      ...f.evidence.map((e) => e.path ?? ""),
+      typeof f.actual === "object" && f.actual && "path" in f.actual
+        ? String((f.actual as { path?: string }).path ?? "")
+        : "",
+    ]);
+    expect(paths.some((p) => p.includes("userPassword"))).toBe(true);
+    expect(paths.some((p) => p.includes("clientSecret"))).toBe(true);
+    expect(paths.some((p) => p.includes("maxTokens"))).toBe(false);
+  });
 });

--- a/packages/core/test/sensitive-key.test.ts
+++ b/packages/core/test/sensitive-key.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { isCredentialSensitiveKey } from "../src/safety/sensitive-key.js";
+import {
+  isCredentialSensitiveKey,
+  normalizeSensitiveKey,
+} from "../src/safety/sensitive-key.js";
 
-describe("isCredentialSensitiveKey (6.14.2-5)", () => {
+describe("normalizeSensitiveKey (compound forms)", () => {
+  it("maps camelCase / kebab / dot / snake / SCREAMING to the same snake form", () => {
+    expect(normalizeSensitiveKey("userPassword")).toBe("user_password");
+    expect(normalizeSensitiveKey("user_password")).toBe("user_password");
+    expect(normalizeSensitiveKey("user-password")).toBe("user_password");
+    expect(normalizeSensitiveKey("user.password")).toBe("user_password");
+    expect(normalizeSensitiveKey("USER_PASSWORD")).toBe("user_password");
+    expect(normalizeSensitiveKey("clientSecret")).toBe("client_secret");
+    expect(normalizeSensitiveKey("maxTokens")).toBe("max_tokens");
+    expect(normalizeSensitiveKey("tokenLimit")).toBe("token_limit");
+  });
+});
+
+describe("isCredentialSensitiveKey (6.14.2-5 / #239)", () => {
   it("does not flag token configuration fields", () => {
     for (const key of [
       "ls_max_tokens",
@@ -13,6 +29,9 @@ describe("isCredentialSensitiveKey (6.14.2-5)", () => {
       "input_tokens",
       "output_tokens",
       "tokens",
+      "maxTokens",
+      "tokenLimit",
+      "maxOutputTokens",
     ]) {
       expect(isCredentialSensitiveKey(key), key).toBe(false);
     }
@@ -24,11 +43,43 @@ describe("isCredentialSensitiveKey (6.14.2-5)", () => {
       "access_token",
       "refresh_token",
       "idToken",
+      "accessToken",
       "authorization",
       "api_key",
       "password",
     ]) {
       expect(isCredentialSensitiveKey(key), key).toBe(true);
     }
+  });
+
+  it("flags compound credential / PII keys across separator styles", () => {
+    for (const key of [
+      "password",
+      "userPassword",
+      "user_password",
+      "user-password",
+      "user.password",
+      "USER_PASSWORD",
+      "clientSecret",
+      "client_secret",
+      "client-secret",
+      "userEmail",
+      "user_email",
+      "sessionCookie",
+      "session_cookie",
+    ]) {
+      expect(isCredentialSensitiveKey(key), key).toBe(true);
+    }
+  });
+
+  it("does not key-match camelCase topic fields that should use value detectors", () => {
+    for (const key of ["emailNote", "passwordPolicy"]) {
+      expect(isCredentialSensitiveKey(key), key).toBe(false);
+    }
+  });
+
+  it("still key-matches explicit-separator prefix compounds", () => {
+    expect(isCredentialSensitiveKey("email_note")).toBe(true);
+    expect(isCredentialSensitiveKey("password_policy")).toBe(true);
   });
 });

--- a/packages/redact/src/sensitive-key.ts
+++ b/packages/redact/src/sensitive-key.ts
@@ -3,8 +3,22 @@
  * @agent-inspect/redact consumers. Keep both copies in sync (6.14.2 parity).
  */
 
+/** True when the original key already uses an explicit separator. */
+function keyHasExplicitSeparator(value: string): boolean {
+  return /[_\-.]/.test(value);
+}
+
+/**
+ * Canonicalize field names so camelCase / kebab / dot / snake forms share a
+ * snake_case shape the compound matcher can recognize (`userPassword` →
+ * `user_password`).
+ */
 export function normalizeSensitiveKey(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9_]/g, "");
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
 }
 
 export const NON_CREDENTIAL_TOKEN_CONFIG_KEYS: ReadonlySet<string> = new Set(
@@ -32,6 +46,14 @@ function isTokenCredentialKey(normalized: string): boolean {
   return normalized.endsWith("token");
 }
 
+/**
+ * True when the field name looks credential-sensitive under the shared policy.
+ *
+ * Suffix compounds (`user_password`, `userPassword`) always match. Prefix
+ * compounds (`email_note`) match only when the original key already contained
+ * an explicit separator, so camelCase topic fields like `emailNote` stay for
+ * value detectors instead of key redaction.
+ */
 export function isCredentialSensitiveKey(
   key: string | undefined,
   sensitiveKeys: readonly string[],
@@ -41,6 +63,8 @@ export function isCredentialSensitiveKey(
   if (!normalized) return false;
   if (NON_CREDENTIAL_TOKEN_CONFIG_KEYS.has(normalized)) return false;
 
+  const allowPrefixCompound = keyHasExplicitSeparator(key);
+
   for (const sensitive of sensitiveKeys) {
     const s = normalizeSensitiveKey(sensitive);
     if (!s) continue;
@@ -49,7 +73,8 @@ export function isCredentialSensitiveKey(
       continue;
     }
     if (normalized === s) return true;
-    if (normalized.endsWith(`_${s}`) || normalized.startsWith(`${s}_`)) return true;
+    if (normalized.endsWith(`_${s}`)) return true;
+    if (allowPrefixCompound && normalized.startsWith(`${s}_`)) return true;
   }
   return false;
 }

--- a/packages/redact/test/index.test.ts
+++ b/packages/redact/test/index.test.ts
@@ -41,6 +41,31 @@ describe("@agent-inspect/redact", () => {
     });
   });
 
+  it("redacts camelCase compound credentials without key-redacting maxTokens (#239)", () => {
+    const result = redact({
+      userPassword: "hunter2",
+      user_password: "hunter2",
+      clientSecret: "sk-abc",
+      maxTokens: 2048,
+      tokenLimit: 100,
+      emailNote: "owner@example.test",
+    });
+    expect(result.value).toEqual({
+      userPassword: "[REDACTED]",
+      user_password: "[REDACTED]",
+      clientSecret: "[REDACTED]",
+      maxTokens: 2048,
+      tokenLimit: 100,
+      emailNote: "owner@example.test",
+    });
+    expect(result.findings.map((f) => f.detector)).toEqual(
+      expect.arrayContaining(["key.password", "key.secret"]),
+    );
+    expect(result.findings.some((f) => f.path === "emailNote" && f.matchKind === "key")).toBe(
+      false,
+    );
+  });
+
   it("does not mutate nested objects or arrays", () => {
     const input = { nested: { password: "p" }, arr: [{ email: "a@example.com" }] };
     const result = redact(input);


### PR DESCRIPTION
## Summary
- Fix `normalizeSensitiveKey` so camelCase / kebab / dot compound keys map to snake_case (`userPassword` → `user_password`)
- Keep prefix compound matching only when the original key already has `_` / `-` / `.`, preserving `emailNote` → value.email behavior
- Mirror the change in core and `@agent-inspect/redact`; add focused + parity regressions
- Patch changeset for the fixed package group

Closes #239

## Test plan
- [x] `pnpm exec vitest run packages/core/test/sensitive-key.test.ts packages/core/test/safety-surface-parity.test.ts packages/redact/test/index.test.ts packages/cli/test/redact.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/core/test packages/redact/test packages/cli/test/redact.test.ts`
- [x] `git diff --check`