### PR TITLE
docs: add deferred and external issue drafts from feedback backlog

### DIFF
--- a/.github/ISSUE_DRAFTS/deferred/mneme-interoperability-contract.md
+++ b/.github/ISSUE_DRAFTS/deferred/mneme-interoperability-contract.md
@@ -1,0 +1,65 @@
+# Correct Mneme architectural-intent interoperability contract before recipe
+
+**Status:** DRAFT — partner-gated; do not implement a recipe until Theo confirms  
+**Related:** closed proposal [#112](https://github.com/rajudandigam/agent-inspect/issues/112)  
+**Contribution lane:** documentation / proposal / integration  
+**Difficulty:** advanced  
+**Ownership:** maintainer + partner  
+**Priority:** p2  
+**Suggested labels:** `documentation`, `proposal`, `integration`, `metadata`, `status:blocked`, `difficulty:advanced`, `priority:p2`  
+**Baseline:** agent-inspect@6.17.3 → 6.18.x
+
+## Problem
+
+#112 proposed Mneme architectural-intent metadata for AgentInspect traces. Partner validation showed that some originally proposed fields **cannot be emitted honestly**.
+
+This follow-up must **correct the contract** before any recipe is written. Do **not** simply repeat #112.
+
+## Corrected contract requirements
+
+Capture these corrections explicitly:
+
+- `severity` should **not** be assumed from Mneme
+- stable per-rule `ruleId` is **not** currently available
+- stable **decision IDs** are available and are the honest reference
+- `PASS` means “no violation detected among evaluated/retrieved decisions”, **not** positive proof that every possible rule passed
+- `WARN` represents a detected violation and must **not** be converted into severity
+- `action` should be assigned by the **adapter/integration boundary** because different callers can warn/block differently
+- do **not** fabricate per-rule PASS evaluations
+
+## Why it matters
+
+An incorrect recipe would teach partners to overclaim Mneme semantics inside AgentInspect traces.
+
+## Proposed scope
+
+- Document the corrected interoperability contract (proposal / ADR-style note)
+- Wait for Theo / Mneme partner confirmation before promoting to a recipe
+- Keep metadata bounded, redaction-safe, and local-first
+
+## Out of scope
+
+- Implementing a Mneme recipe before confirmation
+- Core schema expansion solely for Mneme
+- Claiming AgentInspect verifies Mneme decisions
+- Network defaults or hosted integration
+
+## Suggested files
+
+- `docs/proposals/` or `docs/community/` contract note
+- Later (after approval): recipe under `examples/recipes/` — separate issue
+
+## Acceptance criteria
+
+- [ ] Corrected field semantics are written down
+- [ ] Partner confirmation recorded (comment or linked ack)
+- [ ] Explicitly blocked from recipe work until confirmed
+- [ ] No product code until the contract is approved
+
+## Privacy / network
+
+Opaque decision IDs only. No copying of Mneme payloads, secrets, or customer content.
+
+## Maintainer-review boundary
+
+Proposal/docs only until partner gate clears. Reject recipe PRs that invent severity/ruleId/PASS-all-rules semantics.

--- a/.github/ISSUE_DRAFTS/deferred/npm-clean-room-verification.md
+++ b/.github/ISSUE_DRAFTS/deferred/npm-clean-room-verification.md
@@ -1,0 +1,72 @@
+# Add clean-room verification of the published npm package
+
+**Status:** DRAFT — optional; coordinate with open packed-consumer work  
+**Related open issues:** [#209](https://github.com/rajudandigam/agent-inspect/issues/209), [#213](https://github.com/rajudandigam/agent-inspect/issues/213)  
+**Contribution lane:** testing / release  
+**Difficulty:** advanced  
+**Ownership:** maintainer-owned or community-owned with maintainer review  
+**Priority:** p2  
+**Suggested labels:** `testing`, `area:release`, `status:ready`, `difficulty:advanced`, `priority:p2`, `support:stable`  
+**Baseline:** agent-inspect@latest on npm
+
+## Problem
+
+Local `pnpm pack` / `pack:smoke` verify the tarball built in-repo. They do **not** prove what a real user gets from the **published npm registry**.
+
+## Why it matters
+
+Registry packaging, `files` allow-lists, and Trusted Publishing can diverge from a local pack. Niche-launch partners need periodic clean-room confidence.
+
+## Proposed scope
+
+Periodically verify a clean temporary consumer:
+
+```bash
+mkdir temp-project && cd temp-project
+pnpm init
+pnpm add agent-inspect@latest
+
+npx agent-inspect init --yes
+# create synthetic / no-key run
+npx agent-inspect list
+npx agent-inspect view ...
+npx agent-inspect check ...
+npx agent-inspect verify-safe ...
+npx agent-inspect bundle ...
+npx agent-inspect bundle verify ...
+```
+
+Prefer:
+
+- `workflow_dispatch` and/or scheduled workflow
+- release verification after publish
+
+**Not** a mandatory every-PR network gate.
+
+## Out of scope
+
+- npm publishing from this issue
+- Provider/API keys or live LLM calls
+- Default telemetry
+- Customer traces
+- Duplicating all of #209/#213 if those already cover the claimed matrix cells
+
+## Suggested files
+
+- `.github/workflows/npm-clean-room.yml` (dispatch/schedule)
+- Short docs note under release / compatibility docs
+
+## Acceptance criteria
+
+- [ ] Clean-room path documented
+- [ ] Runs without provider keys
+- [ ] Does not block ordinary PRs by default
+- [ ] Coordinates with #209 / #213 (references remaining gaps)
+
+## Privacy / network
+
+Network only to the npm registry (and GitHub Actions). Synthetic local traces only. No upload of evidence.
+
+## Maintainer-review boundary
+
+Release/CI hygiene. Reject every-PR mandatory registry installs unless maintainers explicitly approve.

--- a/.github/ISSUE_DRAFTS/deferred/sensitive-key-normalization-corpus.md
+++ b/.github/ISSUE_DRAFTS/deferred/sensitive-key-normalization-corpus.md
@@ -1,0 +1,60 @@
+# Add sensitive-key normalization parity and regression corpus
+
+**Status:** DRAFT — do not open until [#239](https://github.com/rajudandigam/agent-inspect/issues/239) / fix PR is merged  
+**Blocked by:** #239  
+**Contribution lane:** testing / security  
+**Difficulty:** intermediate  
+**Ownership:** community-owned  
+**Priority:** p2  
+**Suggested labels:** `testing`, `security`, `redaction`, `area:core`, `community-owned`, `status:blocked`, `difficulty:intermediate`, `priority:p2`  
+**Baseline:** agent-inspect@6.17.3 → 6.18.x (after #239 patch)
+
+## Problem
+
+#239 is the urgent focused fix for camelCase/kebab/dot compound credential keys. After it lands, the repository still needs a **broader permanent regression corpus** so normalization stays consistent across core and `@agent-inspect/redact` without relying on ad-hoc tests alone.
+
+## Why it matters
+
+Duplicate `sensitive-key.ts` copies can drift. A table-driven corpus catches separator-style regressions and false positives (especially token-config keys) before release.
+
+## Proposed scope
+
+- Table-driven tests covering at least:
+
+| Must redact | Must not key-redact |
+|-------------|---------------------|
+| password, userPassword, user_password, user-password, user.password, USER_PASSWORD | maxTokens |
+| clientSecret, client_secret, client-secret | tokenLimit |
+| userEmail, sessionCookie | maxOutputTokens |
+| accessToken, idToken | emailNote / passwordPolicy (camelCase topic fields) |
+
+- Parity assertions across core and `@agent-inspect/redact` (no new public API)
+- Synthetic values only
+
+## Out of scope
+
+- Competing with the #239 PR while it is open
+- Public API expansion
+- Weaker redaction
+- Overly broad substring matching (`*token*` without the existing non-credential allowlist)
+
+## Suggested files
+
+- `packages/core/test/sensitive-key-corpus.test.ts` (or extend existing)
+- `packages/redact/test/` parity table
+- Keep implementations private and mirrored
+
+## Acceptance criteria
+
+- [ ] Corpus runs in CI
+- [ ] Core and redact agree on every row
+- [ ] False-positive rows remain false
+- [ ] No package boundary / dependency changes
+
+## Privacy / network
+
+Synthetic only. No real secrets. No network.
+
+## Maintainer-review boundary
+
+Tests only after #239 merges. Reject scope that rewrites redaction policy without docs.

--- a/.github/ISSUE_DRAFTS/external/redstamp-agentinspect-recipe-issue.md
+++ b/.github/ISSUE_DRAFTS/external/redstamp-agentinspect-recipe-issue.md
@@ -1,0 +1,99 @@
+# External issue draft — askalf/redstamp (NOT an AgentInspect issue)
+
+**Target repository:** [askalf/redstamp](https://github.com/askalf/redstamp)  
+**Status:** Ready-to-post draft for partner confirmation  
+**AgentInspect action:** Do **not** file this against `rajudandigam/agent-inspect`.
+
+---
+
+## Proposed title
+
+Recipe: Surface redstamp block/escalation verdicts in AgentInspect trace reports
+
+## Context
+
+The redstamp maintainer (Thomas) has indicated that a small recipe/fixture is a reasonable first interoperability experiment between redstamp and AgentInspect.
+
+**Ownership boundary**
+
+| System | Owns |
+|--------|------|
+| **redstamp** | Security decision; allow / approve / block (and related) semantics; risk classification; tamper-evident hash-chained audit |
+| **AgentInspect** | Local execution context; trace presentation; share-safe / redacted debugging artifacts |
+
+AgentInspect must **not** claim to be a security engine, duplicate the audit log, or depend on redstamp at core.
+
+## Verified public concepts (from redstamp docs / README)
+
+Use these as the basis; prefer linking to current redstamp docs over inventing fields:
+
+- Deterministic firewall for agent tool calls (offline-capable; same input → same verdict)
+- Verdict-style outcomes in the allow / approve / block family (exact enum names need maintainer confirmation)
+- Risk classification described publicly as green / yellow / red / black style tiers (exact field names need confirmation)
+- Tamper-evident, hash-chained audit (`verifyAuditFile` / related APIs — confirm current export names before coding examples)
+
+## Suggested flow (illustrative)
+
+```text
+agent run
+├─ llm:plan-action
+├─ tool:shell/curl
+│  ├─ redstamp verdict: block          # placeholder — confirm enum
+│  ├─ risk tier: <real redstamp value> # placeholder — confirm field
+│  ├─ reason: <bounded/redacted>
+│  └─ audit reference: <safe opaque ref / hash only>
+└─ result: side effect prevented
+```
+
+## Safe metadata to show in AgentInspect
+
+**Safe**
+
+- Opaque audit / decision reference (hash or ID only)
+- Bounded verdict label after redstamp confirmation
+- Bounded risk tier label after redstamp confirmation
+- Short redacted reason string (no secrets, no full policy dump)
+
+**Unsafe**
+
+- Auth tokens
+- Full audit log copy
+- Customer payloads / prompts
+- Secret-bearing URLs
+- Claiming AgentInspect independently verified the audit chain
+
+## Proposed recipe shape (redstamp repo or joint example)
+
+- Synthetic tool call that redstamp would block/escalate
+- Record only safe references into a local AgentInspect trace (manual attributes or existing adapter hooks)
+- Show AgentInspect `view` / `report` / Evidence with redacted fields
+- No AgentInspect core dependency on `@askalf/redstamp`
+- Optional peer dependency only inside the example package
+
+## Out of scope
+
+- AgentInspect core dependency on redstamp
+- Duplicating redstamp’s audit log into Evidence by default
+- AgentInspect “security certification” claims
+- Write-back from AgentInspect into redstamp
+- Hosted upload / telemetry
+
+## Partner confirmation checklist (Thomas / redstamp)
+
+Before posting or implementing, confirm:
+
+- [ ] Exact verdict enum / string values for the recipe
+- [ ] Exact risk-tier field names and allowed values
+- [ ] Preferred safe audit reference field (hash vs entry id vs checkpoint)
+- [ ] Whether `approve` / escalate is the right “held for human” label in current API
+- [ ] Preferred example location (`askalf/redstamp/examples/...` vs AgentInspect recipes vs both)
+
+## Privacy / network
+
+Synthetic fixtures only. Redstamp remains offline-capable by default. AgentInspect remains local-first with no default upload.
+
+## Suggested AgentInspect cross-links (after recipe exists)
+
+- `docs/SAFE-TRACE-SHARING.md`
+- Evidence retention / bundle verify
+- (Future) external-reference metadata convention issue if opened in AgentInspect


### PR DESCRIPTION
## Summary
- Add deferred issue drafts (sensitive-key corpus after #239, npm clean-room, Mneme contract)
- Add external redstamp recipe draft under `.github/ISSUE_DRAFTS/external/` (not an AgentInspect issue)

Live issues already created separately: #278–#281. Fix PR for #239: #277.

## Test plan
- [x] Docs/drafts only; not packed into npm `files`