### PR TITLE
docs(mcp): separate the three MCP roles AgentInspect takes part in

### DIFF
--- a/docs/MCP-ROLES.md
+++ b/docs/MCP-ROLES.md
@@ -1,0 +1,115 @@
+# MCP roles
+
+AgentInspect appears in three different MCP workflows. They are frequently
+treated as one product surface, which mis-routes recipes, issues and
+expectations — so this page states which is which, and what each can and cannot
+observe.
+
+Every claim here is sourced from the package READMEs, the recipes, and
+[NETWORK-BEHAVIOR.md](./NETWORK-BEHAVIOR.md); nothing on this page is asserted
+independently of those.
+
+## The three roles at a glance
+
+| | 1. MCP **client** tracing | 2. MCP **server-side** instrumentation | 3. AgentInspect **read-only** MCP |
+| --- | --- | --- | --- |
+| Package | [`@agent-inspect/mcp`](../packages/mcp) | none — you instrument the server like any app | [`@agent-inspect/mcp-server`](../packages/mcp-server) |
+| Where instrumentation runs | in the agent / MCP client process | inside the MCP server process | alongside your local evidence, read by a coding agent |
+| What it observes | the agent trajectory and the client-side `tools/list` / `tools/call` lifecycle | the server's own internals for one tool call | `.agent-inspect/` traces that already exist |
+| What it cannot infer | what the server did internally to answer | the calling agent's trajectory or its other steps | anything not already captured in a trace |
+| Who owns agent-loop tracing | **this role** | nobody — a server sees one call, not a loop | nobody — nothing is being traced |
+| Support level | Supported | n/a (ordinary tracing) | Preview |
+| Network | to **your** MCP servers | none added by AgentInspect | exposes local evidence to the connected client |
+| Recipe | [mcp-client-tracing](../examples/recipes/mcp-client-tracing) | — | [read-only-mcp-server](../examples/recipes/read-only-mcp-server) |
+
+```text
+role 1: client-side tracing            role 2: server-side instrumentation
+   Agent / MCP client                     Agent / MCP client
+   [AgentInspect] ......                          |
+          |            :                          | MCP call
+          | MCP call   : trajectory +             v
+          v            : client-side call    MCP server
+     MCP server        :                     [AgentInspect] ... server internals
+
+
+role 3: reading existing evidence
+
+   Coding assistant (Cursor, Claude Code, Codex, ...)
+          |
+          | MCP call: list runs, summarize failures, get_trace_facts
+          v
+   @agent-inspect/mcp-server  --->  .agent-inspect/ (local, read-only)
+```
+
+## 1. MCP client tracing — `@agent-inspect/mcp`
+
+Wrap an MCP client so its `tools/list` and `tools/call` calls emit AgentInspect
+tool steps carrying `source.type: mcp-client` metadata.
+
+This is the only role that traces an **agent loop**. The MCP calls appear as
+steps inside the surrounding trajectory, next to the LLM and tool steps around
+them, which is what makes "the agent called the wrong tool" answerable.
+
+- **Observes:** the agent trajectory; the client side of each MCP call; bounded
+  argument summaries.
+- **Cannot infer:** what happened *inside* the server. A slow or wrong result
+  is visible as a slow or wrong result, not as a cause.
+- **Not a gateway or proxy.** The client's own connection to your MCP servers
+  is the only network involved; AgentInspect adds none.
+  ([NETWORK-BEHAVIOR.md](./NETWORK-BEHAVIOR.md): *"To your MCP servers —
+  tracing only; not a gateway"*.)
+
+## 2. MCP server-side instrumentation — no AgentInspect MCP package
+
+If you need to see inside the server, instrument the server's own code with
+ordinary AgentInspect tracing (`inspectRun`, `step`, `step.tool`). There is no
+special package for this: from AgentInspect's point of view an MCP server is an
+application like any other.
+
+- **Observes:** the server's internals for the call it is handling.
+- **Cannot infer:** the calling agent's trajectory. A server is handed one
+  call; it never sees the loop that produced it, or the steps either side.
+- **Needed when:** the question is *why did the tool return this*, rather than
+  *why did the agent call this tool*.
+
+Role 1 and role 2 are complementary, not alternatives — they observe the two
+halves of the same call from opposite sides, and neither can be reconstructed
+from the other.
+
+## 3. AgentInspect read-only MCP — `@agent-inspect/mcp-server`
+
+A read-only MCP server that lets a coding assistant read evidence you already
+have: list runs, summarize failures, inspect trees, evaluate contracts, fetch
+TraceFacts.
+
+**This is not tracing.** Connecting it does not capture the assistant's own
+run, and it does not instrument anything. It is a reader pointed at
+`.agent-inspect/`, and if no trace was captured there is nothing for it to
+answer with.
+
+- **Observes:** traces that already exist locally.
+- **Cannot infer:** anything that was not captured. It does not invoke your
+  application's tools and does not mutate traces.
+- **Network and privacy:** it exposes local evidence to the connected client,
+  under the share-profile boundary
+  ([NETWORK-BEHAVIOR.md](./NETWORK-BEHAVIOR.md)). Nothing is uploaded to a
+  remote host or collector.
+- **Preview** — see [SUPPORT-LEVELS.md](./SUPPORT-LEVELS.md) for what that
+  promises.
+
+## Which one do I want?
+
+| If you are asking… | Role |
+| --- | --- |
+| Why did my agent choose that tool? | 1 — client tracing |
+| Why was that MCP call slow, or wrong? | 1 tells you *that* it was; 2 tells you *why* |
+| What did the server do internally? | 2 — instrument the server |
+| Can my coding assistant read yesterday's failed run? | 3 — read-only MCP |
+| Can I trace my coding assistant's whole session by connecting role 3? | No. Role 3 reads evidence; it does not create it. |
+
+## See also
+
+- [MCP.md](./MCP.md) — read-only MCP server tools and safety defaults
+- [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) — the local coding-agent loop
+- [COMPATIBILITY-MCP-CLIENT-MATRIX.md](./COMPATIBILITY-MCP-CLIENT-MATRIX.md) — client conformance evidence
+- [NETWORK-BEHAVIOR.md](./NETWORK-BEHAVIOR.md) · [SUPPORT-LEVELS.md](./SUPPORT-LEVELS.md)

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,6 +4,11 @@
 
 For the **6.11+ coding-agent debug loop** (flagship tools, causal failure, configure CLI, Evidence v2), see [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) and [coding-agent-instructions/](./coding-agent-instructions/).
 
+> This is **role 3** of three MCP workflows — reading evidence you already have.
+> It does not trace the connecting assistant. See
+> [MCP-ROLES.md](./MCP-ROLES.md) for how it differs from MCP client tracing
+> (`@agent-inspect/mcp`) and from instrumenting an MCP server.
+
 ## Quick start
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ Optional Preview: [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) · [MCP.md](./M
 | [EVIDENCE-FORMAT.md](./EVIDENCE-FORMAT.md) · [BUNDLES.md](./BUNDLES.md) | Evidence v2 |
 | [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md) | Redaction and share checks |
 | [SUPPORT-REPRODUCTION.md](./SUPPORT-REPRODUCTION.md) | Safe, minimized support reproduction workflow |
+| [MCP-ROLES.md](./MCP-ROLES.md) | Which MCP role you are in: client tracing, server instrumentation, or read-only MCP |
 | [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) | Local MCP coding-agent loop |
 | [SELF-HOSTING.md](./SELF-HOSTING.md) | Customer-owned Studio |
 

--- a/examples/recipes/mcp-client-tracing/README.md
+++ b/examples/recipes/mcp-client-tracing/README.md
@@ -38,3 +38,7 @@ npx agent-inspect session sess-123 --timeline
 - MCP server implementation
 - Hosted gateway or broker
 - Automatic tool invocation on behalf of the user
+
+## Which MCP role is this?
+
+This recipe is role 1 (MCP client tracing). See [MCP-ROLES.md](../../../docs/MCP-ROLES.md) for the three roles and what each can observe.

--- a/examples/recipes/read-only-mcp-server/README.md
+++ b/examples/recipes/read-only-mcp-server/README.md
@@ -8,3 +8,7 @@ pnpm start
 ```
 
 Tools are advisory and use the `share` redaction profile by default.
+
+## Which MCP role is this?
+
+This recipe is role 3 (AgentInspect read-only MCP). See [MCP-ROLES.md](../../../docs/MCP-ROLES.md) for the three roles and what each can observe.


### PR DESCRIPTION
Closes #279

Adds `docs/MCP-ROLES.md` — one page separating the three architectural positions "MCP" names in this project, with the comparison table, the ASCII sketch, and the observability boundaries the issue asks for.

## The distinction the page exists for

The issue lists the three roles; the thing that makes them hard to keep apart is **what each one cannot infer**, so that is a first-class row in the table:

| | client tracing | server instrumentation | read-only MCP |
| --- | --- | --- | --- |
| **Observes** | agent trajectory + client side of the call | the server's internals for one call | traces that already exist |
| **Cannot infer** | what the server did to answer | the calling agent's trajectory | anything not already captured |
| **Owns agent-loop tracing** | **this role** | nobody — a server sees one call, not a loop | nobody — nothing is being traced |

Two points the page makes explicitly, because they are where the confusion actually lands:

- **Roles 1 and 2 are complementary, not alternatives.** They watch opposite sides of the same call, and neither is reconstructible from the other. Role 1 tells you *that* a call was slow or wrong; role 2 tells you *why*.
- **Role 3 is not tracing.** Connecting `@agent-inspect/mcp-server` does not capture the connecting assistant's run — it reads `.agent-inspect/`, and if nothing was captured there is nothing to answer with. That is the last row of the "which one do I want?" table, phrased as the question people actually ask.

Role 2 gets a section saying plainly that **there is no AgentInspect MCP package for it** — you instrument the server with ordinary `inspectRun` / `step` tracing, because from AgentInspect's side an MCP server is an application like any other. That absence is itself a thing worth documenting.

## Sourced, not restated

Network and privacy come from `NETWORK-BEHAVIOR.md` rather than being paraphrased:

> `MCP client (@agent-inspect/mcp)` — **To your MCP servers** — Tracing only; not a gateway
> `MCP server` — **Exposes local evidence to connected client** — Preview; share-profile boundary

Support levels (Supported / Preview) come from the package READMEs. Capabilities and non-capabilities come from each package's own **When to use** / **When not to use** sections — e.g. "does not invoke target-app tools" and "does not mutate traces" are `@agent-inspect/mcp-server`'s own words, not my characterisation.

## Linked from where people land

- `docs/README.md` index, next to `CODING-AGENT-LOOP.md`
- **`docs/MCP.md`** — a callout at the top. This is the one that matters: `MCP.md` is the read-only-server page, so it is exactly where someone who actually wants role 1 ends up.
- both MCP recipes (`mcp-client-tracing`, `read-only-mcp-server`), each naming which role it is

## Verification

```
[docs:links]         OK (8 docs + README packed-files check + archived-link rule over 149 active docs)
[recipes:check]      OK — 40 recipes validated.
[docs:commands]      OK (223 files scanned)
[public-truth:check] OK (version 6.17.3, 18 fixed packages)
[ai-assets:check]    OK (version 6.17.3)
[repo:health]        OK (version 6.17.3)
```

Docs only; no runtime or packaging changes.
