### PR TITLE
docs: add CODEOWNERS and an area ownership policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,96 @@
+# CODEOWNERS — review routing for AgentInspect.
+#
+# WHAT THIS IS. GitHub requests a review from the owner of every path a pull
+# request touches. It is routing, not permission: it does not grant or restrict
+# access, and it does not gate merges unless branch protection is separately
+# configured to require owner review. This file deliberately does not do that
+# (#100) — changing branch protection or the collaborator list is out of scope.
+#
+# WHO. @rajudandigam is the only publicly identified maintainer, so every area
+# routes there today. That is a statement of fact about the project, not a
+# ceiling: when an area gains a second maintainer or a team, replace the handle
+# on that line and nothing else has to move. The area layout below exists so
+# that substitution is a one-line change per area rather than a re-derivation.
+#
+# HOW IT LINES UP WITH THE LABELS. The sections mirror the `area:` labels used
+# on issues, so a path, its label, and its owner are the same fact told three
+# ways. Adding an area means a label, a section here, and a row in
+# docs/community/OWNERSHIP.md.
+#
+# ORDER MATTERS. The LAST matching pattern wins, so the catch-all is first and
+# each area narrows it.
+
+# Catch-all. Anything not claimed by a section below.
+*                                   @rajudandigam
+
+# --- area:core ---------------------------------------------------------------
+/packages/core/                     @rajudandigam
+
+# --- area:cli ----------------------------------------------------------------
+/packages/cli/                      @rajudandigam
+/packages/tui/                      @rajudandigam
+
+# --- area:diff / area:logs (both live inside core) ---------------------------
+/packages/core/src/diff/            @rajudandigam
+/packages/core/src/logs/            @rajudandigam
+
+# --- area:index --------------------------------------------------------------
+/packages/index-sqlite/             @rajudandigam
+
+# --- area:workspace (bundles, evidence, gates — inside core) -----------------
+/packages/core/src/bundle/          @rajudandigam
+/packages/core/src/evidence/        @rajudandigam
+/packages/core/src/gate/            @rajudandigam
+
+# --- area:studio -------------------------------------------------------------
+/packages/studio/                   @rajudandigam
+
+# --- area:viewer -------------------------------------------------------------
+/packages/viewer/                   @rajudandigam
+
+# --- area:vscode -------------------------------------------------------------
+/packages/vscode/                   @rajudandigam
+
+# --- area:adapters -----------------------------------------------------------
+/packages/adapter-sdk/              @rajudandigam
+/packages/ai-sdk/                   @rajudandigam
+/packages/openai-agents/            @rajudandigam
+/packages/langchain/                @rajudandigam
+/packages/vitest/                   @rajudandigam
+/packages/jest/                     @rajudandigam
+/packages/harness/                  @rajudandigam
+/packages/eval/                     @rajudandigam
+/packages/guardrails/               @rajudandigam
+/packages/circuit/                  @rajudandigam
+/packages/redact/                   @rajudandigam
+
+# --- area:mcp ----------------------------------------------------------------
+/packages/mcp/                      @rajudandigam
+/packages/mcp-server/               @rajudandigam
+
+# --- area:standards ----------------------------------------------------------
+/packages/core/src/exporters/       @rajudandigam
+/fixtures/standards/                @rajudandigam
+
+# --- area:website ------------------------------------------------------------
+/apps/website/                      @rajudandigam
+
+# --- area:community ----------------------------------------------------------
+/CONTRIBUTING.md                    @rajudandigam
+/CODE_OF_CONDUCT.md                 @rajudandigam
+/GOOD-FIRST-ISSUES.md               @rajudandigam
+/docs/community/                    @rajudandigam
+/.github/ISSUE_TEMPLATE/            @rajudandigam
+/.github/PULL_REQUEST_TEMPLATE.md   @rajudandigam
+
+# --- area:release ------------------------------------------------------------
+# The highest-blast-radius paths: what ships, what CI enforces, and the files
+# whose claims the public-truth validators check.
+/.github/workflows/                 @rajudandigam
+/.github/CODEOWNERS                 @rajudandigam
+/scripts/                           @rajudandigam
+/package.json                       @rajudandigam
+/pnpm-workspace.yaml                @rajudandigam
+/docs/SUPPORT-LEVELS.md             @rajudandigam
+/docs/NETWORK-BEHAVIOR.md           @rajudandigam
+/docs/product/                      @rajudandigam

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for helping improve **AgentInspect** — a local-first execution-tree 
 
 **Website:** [https://agentinspect.vercel.app/](https://agentinspect.vercel.app/) · **Docs:** [https://agentinspect.vercel.app/docs/](https://agentinspect.vercel.app/docs/) · **Contributing (web):** [https://agentinspect.vercel.app/docs/contributing/](https://agentinspect.vercel.app/docs/contributing/)
 
-This guide covers setup, boundaries, validation, and what we expect in pull requests. For a first contributor PR flow, see [docs/community/FIRST-PR-WALKTHROUGH.md](docs/community/FIRST-PR-WALKTHROUGH.md). For deeper maintainer notes, see [docs/community/CONTRIBUTING.md](docs/community/CONTRIBUTING.md).
+This guide covers setup, boundaries, validation, and what we expect in pull requests. For a first contributor PR flow, see [docs/community/FIRST-PR-WALKTHROUGH.md](docs/community/FIRST-PR-WALKTHROUGH.md). For deeper maintainer notes, see [docs/community/CONTRIBUTING.md](docs/community/CONTRIBUTING.md). For who reviews a change and why, see [docs/community/OWNERSHIP.md](docs/community/OWNERSHIP.md).
 
 ## What AgentInspect is (and is not)
 

--- a/docs/community/CONTRIBUTOR-ROLES.md
+++ b/docs/community/CONTRIBUTOR-ROLES.md
@@ -14,6 +14,9 @@ How participation works in AgentInspect after the 1.1.0 open-source activation. 
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) and [MAINTAINER-GUIDE.md](./MAINTAINER-GUIDE.md).
 
+For which *area* of the tree a change routes to for review, see
+[OWNERSHIP.md](./OWNERSHIP.md) and `.github/CODEOWNERS`.
+
 ---
 
 ## External contributor

--- a/docs/community/OWNERSHIP.md
+++ b/docs/community/OWNERSHIP.md
@@ -1,0 +1,107 @@
+# Area ownership
+
+How a change is routed for review, and what that does and does not mean.
+
+This is about **which part of the tree**. For **what a person may do** — external
+contributor, issue owner, triage, write, maintainer — see
+[CONTRIBUTOR-ROLES.md](./CONTRIBUTOR-ROLES.md). The two are different axes: roles
+say what you are allowed to own, this says who reviews it once you have.
+
+## The three names for one fact
+
+Every part of AgentInspect has an **area**. The area appears in three places,
+and they are kept in step deliberately:
+
+| where | form | used for |
+| --- | --- | --- |
+| issues | an `area:` label | finding work, and the collision rule below |
+| `.github/CODEOWNERS` | a path pattern | GitHub requesting a review |
+| this page | a row in the table | saying who that is, in prose |
+
+Adding an area means adding all three. If they disagree, `CODEOWNERS` is what
+GitHub acts on, and the disagreement is a bug in the other two.
+
+## Areas
+
+| `area:` label | paths | owner |
+| --- | --- | --- |
+| `area:core` | `packages/core/` | @rajudandigam |
+| `area:cli` | `packages/cli/`, `packages/tui/` | @rajudandigam |
+| `area:diff` | `packages/core/src/diff/` | @rajudandigam |
+| `area:logs` | `packages/core/src/logs/` | @rajudandigam |
+| `area:index` | `packages/index-sqlite/` | @rajudandigam |
+| `area:workspace` | `packages/core/src/{bundle,evidence,gate}/` | @rajudandigam |
+| `area:studio` | `packages/studio/` | @rajudandigam |
+| `area:viewer` | `packages/viewer/` | @rajudandigam |
+| `area:vscode` | `packages/vscode/` | @rajudandigam |
+| `area:adapters` | `packages/{adapter-sdk,ai-sdk,openai-agents,langchain,vitest,jest,harness,eval,guardrails,circuit,redact}/` | @rajudandigam |
+| `area:mcp` | `packages/mcp/`, `packages/mcp-server/` | @rajudandigam |
+| `area:standards` | `packages/core/src/exporters/`, `fixtures/standards/` | @rajudandigam |
+| `area:website` | `apps/website/` | @rajudandigam |
+| `area:community` | `CONTRIBUTING.md`, `docs/community/`, the issue and PR templates | @rajudandigam |
+| `area:release` | `.github/workflows/`, `scripts/`, `package.json`, the public-truth docs | @rajudandigam |
+
+Three areas — `diff`, `logs` and `workspace` — live *inside* `packages/core/`
+rather than in packages of their own. `CODEOWNERS` lists them after the
+`area:core` line so the narrower pattern wins; today both resolve to the same
+owner, so the ordering matters only for the day they do not.
+
+## Every area routes to one person today
+
+@rajudandigam is the only publicly identified maintainer, so that is the honest
+mapping. It is recorded per area rather than as a single catch-all so that
+adding a second owner is a one-line edit on that area's line, not a
+re-derivation of which paths belong to what.
+
+Nothing here is a claim that one person reviews everything forever. It is a
+claim about who to ask **today**, which is the question a contributor waiting on
+a review actually has.
+
+## What CODEOWNERS does not do
+
+- **It does not grant or restrict access.** Ownership is routing; permissions
+  are the collaborator list, which this does not touch.
+- **It does not block merges.** Requiring owner approval is a branch-protection
+  setting, and it is deliberately not enabled — see below.
+- **It does not mean nobody else may review.** Anyone may review anything; the
+  owner is who GitHub asks, not who is allowed.
+
+## Why review is not required for merge
+
+Making owner review *required* on a project with one maintainer converts every
+pull request into a wait on one person, including their own. The routing is
+useful now; the gate would only be useful once an area has more than one owner.
+That change belongs with the second owner, not before.
+
+## `maintainer-owned` and `community-owned`
+
+The two labels answer a different question from this page — not *who reviews it*
+but *who is expected to do it*:
+
+- **`community-owned`** — an outside contributor can take this end to end. Most
+  issues are.
+- **`maintainer-owned`** — needs maintainer coordination: a release, a support
+  level, a public claim, or something touching credentials or infrastructure.
+
+An issue is `maintainer-owned` because of what the work requires, not because of
+which files it touches. Both kinds route to the same owner for review.
+
+## Two agents, one area
+
+Issues carrying the same `area:` label should not be held at the same time by
+two people working in parallel. The area labels map to directories, and that is
+what makes them usable as collision boundaries. An issue that genuinely needs
+two areas is usually two issues.
+
+## Adding an owner
+
+1. Add the handle to that area's line in `.github/CODEOWNERS`.
+2. Update the row in the table above.
+3. Leave branch protection alone unless the intent is specifically to start
+   requiring review — that is a separate decision with its own tradeoff.
+
+## Adding an area
+
+1. Create the `area:` label.
+2. Add a section to `.github/CODEOWNERS`, after any broader pattern it narrows.
+3. Add a row above.


### PR DESCRIPTION
Closes #100

`.github/CODEOWNERS` plus `docs/community/OWNERSHIP.md`. Branch protection and the collaborator list are untouched, per the issue's out-of-scope list.

## The mapping mirrors the `area:` labels

Sections in `CODEOWNERS` are named for the `area:` labels already in use, so a path, its label, and its owner are the same fact told three ways — and adding an area is a mechanical three-step (label, section, table row) rather than a judgement call.

**Every path in the file was checked to exist**, so this is not a mapping to aspirational directories.

One thing worth flagging because it is easy to get wrong: `area:diff`, `area:logs` and `area:workspace` have no packages of their own — they live *inside* `packages/core/`. Their patterns therefore come **after** the `area:core` line, since CODEOWNERS resolves last-match-wins. Both resolve to the same owner today, so the ordering only matters on the day they do not — which is exactly when nobody will be re-reading this file.

## Everything routes to @rajudandigam, and that is the honest answer

You are the only publicly identified maintainer, and the issue says to map areas to *maintainers/teams already public*. So one handle, everywhere.

It is written out **per area** rather than as a single `* @rajudandigam` line on purpose: adding a second owner then becomes a one-line edit on that area's line, instead of first re-deriving which paths belong to which area. The structure is the part that has value now; the handle is the part that will change.

## What the policy doc spends its length on

Mostly on what CODEOWNERS **does not** do, since that is where the misreadings are:

- it is **routing, not permission** — ownership does not grant or restrict access
- it **does not block merges** — that is a branch-protection setting, deliberately left off
- it **does not mean nobody else may review** — the owner is who GitHub asks, not who is allowed

And the reasoning for leaving the gate off, stated rather than left implicit: requiring owner approval on a project with one maintainer converts every pull request into a wait on one person, **including their own**. The routing is useful now; the gate becomes useful with the second owner. That is a decision that should travel with the second owner rather than be inherited silently.

It also separates two labels that look like ownership but answer a different question — `community-owned` / `maintainer-owned` describe *who is expected to do the work*, not who reviews it, and an issue is maintainer-owned because of **what the work requires** (a release, a support level, a public claim, credentials) rather than which files it touches.

## Cross-linked with `CONTRIBUTOR-ROLES.md`

That doc already existed and covers a **different axis** — what a person may do (external contributor → issue owner → triage → write → maintainer). This one covers which part of the tree. Neither is the whole story, and the failure mode is a reader finding one and assuming it is, so they now link both ways:

> roles say what you are allowed to own, this says who reviews it once you have.

`CONTRIBUTING.md` gains a one-line pointer too.

## Verification

```
[docs:links]         OK (8 docs + README packed-files check + archived-link rule over 149 active docs)
[docs:commands]      OK (223 files scanned)
[public-truth:check] OK (version 6.17.3, 18 fixed packages)
[ai-assets:check]    OK (version 6.17.3)
[repo:health]        OK (version 6.17.3)
[recipes:check]      OK — 40 recipes validated.
```

Plus a script over the file asserting every non-comment path pattern resolves to something that exists — no output, i.e. all of them do.

Docs and one config file; no runtime changes.
