### PR TITLE
test(mcp): pin first causal failure parity across surfaces

### DIFF
--- a/fixtures/traces/README.md
+++ b/fixtures/traces/README.md
@@ -15,6 +15,8 @@ Small **manual trace** files consumed by list/view/export/diff and compatibility
 |------|---------|
 | `minimal-success.jsonl` | Shortest successful run |
 | `minimal-error.jsonl` | Failed step + failed run |
+| `causal-linked-errors.jsonl` | Upstream error + explicitly linked downstream symptom |
+| `causal-unlinked-errors.jsonl` | Two chronological errors with no fabricated parent relationship |
 | `nested-3-levels.jsonl` | Three nested steps via explicit `parentId` |
 | `parallel-siblings.jsonl` | Multiple root-level steps (ordering) |
 | `llm-with-tokens.jsonl` | LLM step with input/output/total/cached token metadata |

--- a/fixtures/traces/causal-linked-errors.jsonl
+++ b/fixtures/traces/causal-linked-errors.jsonl
@@ -1,0 +1,6 @@
+{"schemaVersion":"0.1","event":"run_started","timestamp":1700000010000,"runId":"causal-linked-errors","name":"causal-linked-errors","startTime":1700000010000}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000010010,"runId":"causal-linked-errors","stepId":"root_fetch","name":"fetch-policy","type":"tool","startTime":1700000010010}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000010040,"runId":"causal-linked-errors","stepId":"root_fetch","status":"error","endTime":1700000010040,"durationMs":30,"error":{"message":"upstream policy service unavailable"}}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000010050,"runId":"causal-linked-errors","stepId":"symptom_render","parentId":"root_fetch","name":"render-decision","type":"logic","startTime":1700000010050}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000010070,"runId":"causal-linked-errors","stepId":"symptom_render","status":"error","endTime":1700000010070,"durationMs":20,"error":{"message":"decision could not be rendered"}}
+{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000010080,"runId":"causal-linked-errors","status":"error","endTime":1700000010080,"durationMs":80,"error":{"message":"run ended with linked failures"}}

--- a/fixtures/traces/causal-unlinked-errors.jsonl
+++ b/fixtures/traces/causal-unlinked-errors.jsonl
@@ -1,0 +1,6 @@
+{"schemaVersion":"0.1","event":"run_started","timestamp":1700000020000,"runId":"causal-unlinked-errors","name":"causal-unlinked-errors","startTime":1700000020000}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000020010,"runId":"causal-unlinked-errors","stepId":"error_a","name":"validate-input","type":"logic","startTime":1700000020010}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000020030,"runId":"causal-unlinked-errors","stepId":"error_a","status":"error","endTime":1700000020030,"durationMs":20,"error":{"message":"synthetic validation failure"}}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1700000020040,"runId":"causal-unlinked-errors","stepId":"error_b","name":"persist-result","type":"tool","startTime":1700000020040}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1700000020060,"runId":"causal-unlinked-errors","stepId":"error_b","status":"error","endTime":1700000020060,"durationMs":20,"error":{"message":"synthetic persistence failure"}}
+{"schemaVersion":"0.1","event":"run_completed","timestamp":1700000020070,"runId":"causal-unlinked-errors","status":"error","endTime":1700000020070,"durationMs":70,"error":{"message":"run ended with unlinked failures"}}

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -42,6 +42,12 @@ npx @agent-inspect/mcp-server --dir .agent-inspect
 | `compare_runs` | Structural diff |
 | `create_share_checked_evidence` | Share-gated Evidence package |
 
+### First causal failure ambiguity
+
+Unlinked failures remain unrelated. `get_first_causal_failure` does not infer
+causal parents from event adjacency or timing alone, so ambiguous relationships
+remain explicit rather than being fabricated.
+
 Results are redacted (share profile by default), bounded, and deterministic for the same inputs.
 
 ## Privacy

--- a/packages/mcp-server/test/first-causal-failure-surface-parity.test.ts
+++ b/packages/mcp-server/test/first-causal-failure-surface-parity.test.ts
@@ -1,0 +1,258 @@
+import { copyFile, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { findFirstCausalFailure } from "agent-inspect/advanced";
+import type { TraceCheckResult } from "agent-inspect/checks";
+import { persistedInspectEventsToTraceEvents } from "agent-inspect/persisted";
+import { openTraceFile } from "agent-inspect/readers";
+
+import { checkCommand } from "../../cli/src/check.js";
+import { reportCommand } from "../../cli/src/report.js";
+import { callReadOnlyTool, createMcpServerContext } from "../src/tools.js";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.resolve(testDir, "../../../fixtures/traces");
+
+type CausalProjection = {
+  kind: string;
+  evidenceIds: string[];
+  primaryName?: string;
+  primaryStepId?: string;
+  relationshipRole?: string;
+  relatedIds: string[];
+};
+
+type ReportPayload = {
+  content: string;
+};
+
+function projectCausal(value: {
+  kind: string;
+  evidenceIds: string[];
+  primary?: { name?: string; stepId?: string };
+  relationship?: { role: string; relatedIds: string[] };
+}): CausalProjection {
+  return {
+    kind: value.kind,
+    evidenceIds: [...value.evidenceIds],
+    ...(value.primary?.name ? { primaryName: value.primary.name } : {}),
+    ...(value.primary?.stepId ? { primaryStepId: value.primary.stepId } : {}),
+    ...(value.relationship?.role ? { relationshipRole: value.relationship.role } : {}),
+    relatedIds: [...(value.relationship?.relatedIds ?? [])],
+  };
+}
+
+function contractFindingsFromCheck(check: TraceCheckResult) {
+  return check.findings
+    .filter((finding) => finding.status === "fail")
+    .map((finding) => ({
+      ruleId: finding.ruleId,
+      status: finding.status,
+      evidenceIds: finding.evidence
+        .map((item) => item.eventId ?? item.parentId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+      message: finding.message,
+    }));
+}
+
+function firstTimelineErrorName(content: string): string | undefined {
+  const timeline = content.split("## Timeline")[1]?.split("## Observed outcomes")[0];
+  const firstError = timeline
+    ?.split("\n")
+    .map((line) => line.trim())
+    .find((line) => /^\+\S+\s+.+\s+\([^)]*\)\s+error$/.test(line));
+  const label = firstError?.match(/^\+\S+\s+(.+?)\s+\([^)]*\)\s+error$/)?.[1];
+  if (!label) return undefined;
+  const separator = label.indexOf(":");
+  return separator >= 0 ? label.slice(separator + 1) : label;
+}
+
+describe("first causal failure surface parity", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it.each([
+    {
+      file: "minimal-error.jsonl",
+      runId: "minimal-error",
+      expectedName: "failing-step",
+      expectedStepId: "step_fail",
+      ambiguity: false,
+    },
+    {
+      file: "causal-linked-errors.jsonl",
+      runId: "causal-linked-errors",
+      expectedName: "fetch-policy",
+      expectedStepId: "root_fetch",
+      ambiguity: false,
+    },
+    {
+      file: "causal-unlinked-errors.jsonl",
+      runId: "causal-unlinked-errors",
+      expectedName: "validate-input",
+      expectedStepId: "error_a",
+      ambiguity: true,
+    },
+  ])(
+    "keeps report, check evidence, and read-only MCP aligned for $runId",
+    async ({ file, runId, expectedName, expectedStepId, ambiguity }) => {
+      const fixture = path.join(fixturesDir, file);
+      const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), "agent-inspect-causal-parity-"),
+      );
+      tempDirs.push(tempRoot);
+      const tracePath = path.join(tempRoot, file);
+      await copyFile(fixture, tracePath);
+
+      const read = await openTraceFile(tracePath);
+      const legacyEvents = persistedInspectEventsToTraceEvents(read.events);
+      const canonical = findFirstCausalFailure(legacyEvents);
+      expect(projectCausal(canonical)).toMatchObject({
+        kind: "explicit_error_event",
+        evidenceIds: [expectedStepId],
+        primaryName: expectedName,
+        primaryStepId: expectedStepId,
+      });
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await reportCommand(runId, { dir: tempRoot, json: true });
+      expect(process.exitCode ?? 0).toBe(0);
+      const report = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as ReportPayload;
+      expect(firstTimelineErrorName(report.content)).toBe(expectedName);
+
+      logSpy.mockClear();
+      process.exitCode = 0;
+      await checkCommand(runId, {
+        dir: tempRoot,
+        json: true,
+        rule: ["run.status"],
+      });
+      expect(process.exitCode).toBe(1);
+      const check = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as TraceCheckResult;
+      expect(check.status).toBe("fail");
+      const contractFindings = contractFindingsFromCheck(check);
+      expect(contractFindings).toEqual([
+        expect.objectContaining({ ruleId: "run.status", evidenceIds: [] }),
+      ]);
+      expect(
+        projectCausal(findFirstCausalFailure(legacyEvents, { contractFindings })),
+      ).toEqual(projectCausal(canonical));
+
+      const beforeMcpRead = await readdir(tempRoot);
+      const beforeMcpBytes = await readFile(tracePath);
+      const mcpResult = await callReadOnlyTool(
+        createMcpServerContext({ traceDir: tempRoot }),
+        "get_first_causal_failure",
+        { runId },
+      );
+      expect(mcpResult.isError).toBe(false);
+      const mcp = JSON.parse(mcpResult.content[0]!.text as string) as Parameters<
+        typeof projectCausal
+      >[0];
+      expect(projectCausal(mcp)).toEqual(projectCausal(canonical));
+      expect(await readdir(tempRoot)).toEqual(beforeMcpRead);
+      expect(await readFile(tracePath)).toEqual(beforeMcpBytes);
+
+      if (ambiguity) {
+        expect(mcp.relationship).toEqual({ role: "self", relatedIds: [] });
+        expect(mcp.evidenceIds).not.toContain("error_b");
+      }
+    },
+  );
+
+  it("keeps linked check evidence aligned with the first causal failure", async () => {
+    const file = "causal-linked-errors.jsonl";
+    const runId = "causal-linked-errors";
+
+    const fixture = path.join(fixturesDir, file);
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "agent-inspect-causal-parity-"),
+    );
+    tempDirs.push(tempRoot);
+
+    const tracePath = path.join(tempRoot, file);
+    await copyFile(fixture, tracePath);
+
+    const read = await openTraceFile(tracePath);
+    const legacyEvents = persistedInspectEventsToTraceEvents(read.events);
+    const canonical = findFirstCausalFailure(legacyEvents);
+
+    expect(projectCausal(canonical)).toMatchObject({
+      kind: "explicit_error_event",
+      evidenceIds: ["root_fetch"],
+      primaryName: "fetch-policy",
+      primaryStepId: "root_fetch",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await checkCommand(runId, {
+      dir: tempRoot,
+      json: true,
+      rule: ["tool.usage"],
+      forbiddenTool: ["fetch-policy"],
+    });
+
+    expect(process.exitCode).toBe(1);
+
+    const check = JSON.parse(
+      String(logSpy.mock.calls.at(-1)?.[0]),
+    ) as TraceCheckResult;
+
+    expect(check.status).toBe("fail");
+
+    const failedFinding = check.findings.find(
+      (finding) =>
+        finding.ruleId === "tool.usage" && finding.status === "fail",
+    );
+
+    expect(failedFinding).toBeDefined();
+    expect(failedFinding?.evidence).toEqual([
+      expect.objectContaining({
+        runId,
+        kind: "TOOL",
+        name: "fetch-policy",
+        status: "error",
+      }),
+    ]);
+
+    expect(failedFinding?.evidence[0]?.eventId).toBeTruthy();
+
+    const contractFindings = contractFindingsFromCheck(check);
+
+    expect(contractFindings).toHaveLength(1);
+    expect(contractFindings[0]).toEqual(
+      expect.objectContaining({
+        ruleId: "tool.usage",
+        status: "fail",
+      }),
+    );
+
+    expect(contractFindings[0]?.evidenceIds).toEqual([
+      failedFinding?.evidence[0]?.eventId,
+    ]);
+
+    expect(contractFindings[0]?.evidenceIds[0]).toBeTruthy();
+
+    const withCheckEvidence = findFirstCausalFailure(legacyEvents, {
+      contractFindings,
+    });
+
+    expect(projectCausal(withCheckEvidence)).toEqual(
+      projectCausal(canonical),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared synthetic fixtures that pin first causal failure parity across report, check evidence, and read only MCP.
- The coverage includes explicit, linked, and ambiguous failures. It also exercises a built in `tool.usage` check with non empty linked event evidence and verifies that forwarding the finding into causal selection preserves the same canonical result.
- Unlinked failures remain unrelated, with no causal parent inferred from adjacency or timing alone.
- No runtime behavior, public API, or causal policy is changed.

**Linked issue (required):** #223

Closes #223

## Type of change

- [ ] Bug fix (non breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan and maintainer approval)

## Reproduction / evidence

Shared fixtures cover:

- `minimal-error` for a single explicit failure
- `causal-linked-errors` for an upstream failure with an explicitly linked downstream symptom
- `causal-unlinked-errors` for chronological failures with no supported causal relationship
- A focused `tool.usage` case with non empty linked check evidence

The parity coverage drives the same fixture through the existing report, check, and read only MCP paths. The linked check case verifies that the check evidence ID is preserved when converted to contract findings and that causal selection remains aligned with the canonical `root_fetch` failure.

The ambiguous case verifies that no unsupported parent relationship is introduced.

**Screenshot 1: focused first causal failure parity, 4/4 passing**

<img width="1260" height="319" alt="2026-08-27-044042" src="https://github.com/user-attachments/assets/5b6e472b-25b4-47da-b12c-a580430ea275" />

**Screenshot 2: built in tool.usage check with linked event evidence**

<img width="1746" height="698" alt="2026-08-27-044108" src="https://github.com/user-attachments/assets/cf8b4f63-c9c1-4a7b-b832-6dd5b3094908" />

## Product boundaries (check all that apply)

- [x] Local first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [x] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

## Validation

```bash
pnpm exec vitest run packages/mcp-server/test/first-causal-failure-surface-parity.test.ts
# 4/4 passed

pnpm fixtures:check
# passed

pnpm repo:health
# passed

pnpm typecheck
# passed

pnpm test
# 264 files, 1889 tests passed

git diff --check
git diff --cached --check
# passed
```

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were generated from fixtures

## Release hygiene

- [x] No version bumps and no Changesets
- [x] No new runtime dependencies
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why and was commented on before the PR
- [x] Tests added or updated for behavior coverage
- [x] Docs updated for the ambiguity behavior covered by this PR
- [x] `git diff --check` clean