### PR TITLE
docs: document safe external-reference metadata

### DIFF
--- a/docs/EVIDENCE-FORMAT.md
+++ b/docs/EVIDENCE-FORMAT.md
@@ -151,6 +151,8 @@ Emitters write **both** during the transition. As of 6.10-1, `agent-inspect bund
 - No default upload; no hosted CDN; no collector
 - Safe artifact directory names; original run ids only inside the manifest
 
+When cross-system correlation is needed, retain only bounded, disclosure-approved identifiers and follow [External reference metadata](./EXTERNAL-REFERENCES.md). Evidence integrity verification does not resolve or validate the referenced external system or record.
+
 ## Review workflow
 
 ```text
@@ -162,4 +164,5 @@ capture → check → redact → verify-safe → bundle → bundle verify → at
 - Bundles today: [BUNDLES.md](./BUNDLES.md)
 - Safety: [SAFETY-POLICY.md](./SAFETY-POLICY.md)
 - Safe sharing: [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md)
+- External reference metadata: [EXTERNAL-REFERENCES.md](./EXTERNAL-REFERENCES.md)
 - Example fixture: [`fixtures/evidence/evidence.v1.example.json`](../fixtures/evidence/evidence.v1.example.json)

--- a/docs/EXTERNAL-REFERENCES.md
+++ b/docs/EXTERNAL-REFERENCES.md
@@ -1,0 +1,84 @@
+# External reference metadata
+
+Use external reference metadata when an AgentInspect run needs a bounded pointer to a record owned by another system. Retain the pointer, not the owned record.
+
+For example, a run may retain an external policy decision ID so a reviewer can correlate the run with the policy system. The policy system still owns the decision record and its interpretation.
+
+## Existing attachment points
+
+Use an existing field only when its meaning fits the reference:
+
+| Supported surface | Use when |
+| ----------------- | -------- |
+| `run_started.metadata.correlationId` | The value is a cross-system correlation handle |
+| `run_started.metadata.requestId` | The value identifies the request associated with the run |
+| `run_started.metadata.decisionId` | The value identifies a decision associated with the run |
+| `run_started.metadata.groupId` | The value intentionally groups related runs; do not use it as a catch-all reference |
+| `run_started.metadata` | A compact custom value is needed and none of the named correlation fields fit |
+| `InspectEvent.attributes` | A supported writer or adapter emits source-agnostic persisted events with compact event metadata |
+
+The manual trace helpers accept the named correlation fields directly and persist them under `run_started.metadata`:
+
+```ts
+await inspectRun(
+  "policy-gated-agent",
+  async () => runAgent(),
+  {
+    decisionId: "decision_123",
+  },
+);
+```
+
+The external policy system owns `decision_123`; AgentInspect retains only the identifier. Use generic `metadata` or `attributes` only for compact, synthetic, non-sensitive values. Name custom keys in the producing integration's own contract rather than implying that AgentInspect defines a new canonical field.
+
+AgentInspect does not define an `externalReferences` schema field or public API. Do not add that shape to persisted events unless a future published schema explicitly supports it.
+
+## Safe to retain
+
+Subject to your own data-handling policy, suitable pointer-style values include:
+
+- opaque IDs that do not embed secrets or personal data
+- bounded reference types, such as `decision` or `trace`
+- local artifact identifiers without sensitive paths
+- hashes used as identifiers when the hash itself is approved for disclosure
+- correlation, request, decision, or grouping IDs whose existing semantics match
+
+Prefer an opaque ID over a URL. If a URL is necessary, remove credentials, tokens, sensitive query parameters, internal host details, and copied payload data before it reaches a trace.
+
+## Do not copy
+
+Do not attach an external record merely because `metadata` or `attributes` can hold arbitrary values. In particular, do not copy:
+
+- authorization headers, API keys, cookies, JWTs, OAuth codes, or session secrets
+- raw audit logs, governance records, or observability payloads
+- customer payloads or production records
+- unredacted prompts, model outputs, retrieved documents, or tool inputs and outputs
+- secret-bearing URLs or sensitive internal paths
+- external records whose size, sensitivity, or disclosure policy is unknown
+
+## External references are not workflow causality
+
+Internal workflow-causality metadata explains relationships among AgentInspect runs or agent workflows. Fields such as `parentGroupId`, `retryOf`, `handoffFrom`, `handoffTo`, `sessionId`, and `conversationId` describe parentage, retries, handoffs, sessions, or conversations.
+
+External reference metadata instead points to a bounded identifier owned by another system, such as a policy decision, observability trace, architecture decision, governance ledger entry, or local artifact. Do not use workflow-causality fields as external reference slots, and do not infer retry or handoff relationships from an external ID.
+
+See the [schema metadata policy](./SCHEMA.md#metadata-policy) for the supported internal causality fields and placement.
+
+## Non-verification boundary
+
+Recording an external reference establishes only that the producing trace supplied that value. It does not establish the external record's:
+
+- semantics or correctness
+- authenticity or ownership
+- compliance status or business validity
+- integrity or tamper resistance
+
+`agent-inspect bundle verify` checks the Evidence artifact's local structure and file hashes. It does not resolve an external ID or verify the referenced system. An external reference is therefore a correlation pointer, not verified external evidence.
+
+## Redaction and sharing
+
+Correlation and reference IDs may themselves be sensitive. The `share` and `strict` redaction profiles redact the named `correlationId`, `requestId`, `decisionId`, and `groupId` keys. Custom keys may not match key-based safeguards, so inspect the exact derived artifact before sharing it.
+
+If a reviewer needs a reference in shared Evidence, use only a disclosure-approved or synthetic value and confirm that the final artifact contains no owned record, secret, personal data, or sensitive URL. A successful safety check or integrity verification is not a certification that every sensitive value was detected.
+
+Follow the [safe trace sharing checklist](./SAFE-TRACE-SHARING.md) before disclosure. See [Evidence format](./EVIDENCE-FORMAT.md) for the artifact integrity and policy boundary.

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -36,6 +36,7 @@ When a maintainer or support responder needs reproducible evidence, follow the [
 - Inspect manual metadata passed to `inspectRun()`, `step()`, `step.tool()`, `step.llm()`, or `observe()`.
 - Inspect log-derived fields from `logs` / `tail` ingest configs, including custom `run-id`, `event`, `parent`, timestamp, and attribute mappings.
 - Avoid posting raw prompts, completions, tool inputs, or tool outputs in public threads unless the content is approved for public disclosure.
+- For cross-system correlation, retain a bounded identifier instead of copying the external record or payload. Follow [External reference metadata](./EXTERNAL-REFERENCES.md), and expect `share` / `strict` profiles to redact the named correlation fields.
 - Prefer Markdown export for issue or PR sharing when a summarized tree is enough.
 
 ## Remove or replace sensitive values


### PR DESCRIPTION
## Summary

* Document how to retain bounded external reference metadata using existing AgentInspect metadata and attributes surfaces.
* Define safe and unsafe reference content, distinguish external references from workflow causality, and state the non verification boundary explicitly.
* Link the guidance from Evidence format and safe trace sharing docs.
* No API, schema, runtime, dependency, or version changes.

**Linked issue (required):** #280

Closes #280

## Type of change

* [ ] Bug fix (non breaking)
* [x] Documentation only
* [ ] Example / recipe / fixture
* [ ] Test / regression coverage
* [ ] Feature or enhancement (scoped)
* [ ] Breaking change (requires major version plan and maintainer approval)

## Reproduction / evidence

- The new guidance uses existing attachment points such as `correlationId`, `requestId`, `decisionId`, `groupId`, and event attributes where their documented semantics fit.
- It keeps external references as bounded correlation pointers rather than copied external records, and makes clear that retaining a reference does not mean AgentInspect verifies the external system.

<img width="949" height="130" alt="image" src="https://github.com/user-attachments/assets/fcdb580c-bec4-493f-a0b7-9f08854fb5ed" />

<img width="1135" height="738" alt="image" src="https://github.com/user-attachments/assets/da42a229-102d-4858-91cb-53c085369007" />

<img width="861" height="163" alt="image" src="https://github.com/user-attachments/assets/99c1d8de-fe18-41ef-b194-4f7d5681fd3b" />

## Product boundaries (check all that apply)

* [x] Local first only, no network upload added
* [x] No new vendor sinks
* [x] No SaaS / dashboard scope added
* [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
* [x] No `step_failed` event introduced
* [x] `inspectRun` default tracing behavior unchanged
* [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

* [ ] `agent-inspect` (root: core + CLI, published)
* [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
* [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
* [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
* [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
* [x] Docs / fixtures / recipes / community only

## Validation

```text
pnpm docs:links
# passed

pnpm typecheck
# passed

pnpm test
# 263 files, 1885 tests passed

pnpm demo:verify
# passed on a clean worktree

git diff --check
# passed
```

## Data safety

* [x] Synthetic data only, no real prompts, logs, tokens, or PII
* [ ] Trace/log samples in the PR were generated from fixtures

## Release hygiene

* [x] No version bumps and no Changesets
* [x] No new runtime dependencies
* [x] No publish, tag, or workflow changes

## Checklist

* [x] Linked issue explains the why and was commented on before the PR
* [ ] Tests added or updated for behavior coverage
* [x] Docs updated for the behavior covered by this PR
* [x] `git diff --check` clean