### PR TITLE
feat(recipes): add browser MCP observed outcome example

### DIFF
--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -64,6 +64,7 @@ Use `AGENT_INSPECT_SILENT=true` to suppress live terminal tree output during scr
 | [harness-basic](harness-basic) | v1.9 fixture harness basics | `@agent-inspect/harness`, fixture JSON, expected output | yes | no |
 | [harness-adapter-local](harness-adapter-local) | Adapter-shaped local harness target | `@agent-inspect/harness`, bootstrap/resolve/invoke, expected output | yes | no |
 | [mcp-client-tracing](mcp-client-tracing) | v2.4 MCP client wrap with mock client | `@agent-inspect/mcp`, `inspectRun`, `sessions` / `session` CLI | yes | no |
+| [browser-mcp-observed-outcomes](browser-mcp-observed-outcomes) | Successful Browser/MCP-style action with a failed independent state observation | `step.tool`, `observeOutcome`, observation CLI filters | yes | no |
 | [guardrails-basic](guardrails-basic) | v2.5 deterministic guardrail samples | `@agent-inspect/guardrails`, phrase/PII/injection rules | yes | no |
 | [circuit-breaker-basic](circuit-breaker-basic) | v2.5 circuit repetition analysis | `@agent-inspect/circuit`, tool/args repetition | yes | no |
 | [read-only-mcp-server](read-only-mcp-server) | v2.6 read-only MCP trace tools | `@agent-inspect/mcp-server`, list/search/check tools | yes | no |

--- a/examples/recipes/browser-mcp-observed-outcomes/README.md
+++ b/examples/recipes/browser-mcp-observed-outcomes/README.md
@@ -1,0 +1,36 @@
+# Recipe: browser-mcp-observed-outcomes
+
+## What this demonstrates
+
+A synthetic Browser/MCP-style action can complete successfully without producing its expected effect. This recipe records the difference between execution evidence and an independently observed outcome:
+
+1. Snapshot the page at `cart`.
+2. Run a tool action that returns `status: "success"` but does not mutate the page.
+3. Snapshot the page again independently.
+4. Compare the observed `cart` page with the expected `checkout` page.
+5. Record `checkoutTransition` as a failed observed outcome.
+
+The recipe uses only in-memory state. It requires no browser, MCP server, network access, secrets, or screenshots.
+
+## How to run
+
+From the repository root:
+
+```bash
+pnpm build
+pnpm --filter agent-inspect-recipe-browser-mcp-observed-outcomes start
+```
+
+Inspect the failed observed outcome:
+
+```bash
+npx agent-inspect report <run-id> --dir ./examples/recipes/browser-mcp-observed-outcomes/.agent-inspect --section observations
+npx agent-inspect check <run-id> --dir ./examples/recipes/browser-mcp-observed-outcomes/.agent-inspect --fail-on-observation failed
+npx agent-inspect search --dir ./examples/recipes/browser-mcp-observed-outcomes/.agent-inspect --observation failed
+```
+
+The `check` command exits nonzero because the failed observation is intentional.
+
+## Expected output
+
+The tool action passes and returns `success`, while the independently observed page remains `cart` and the observed outcome is `failed`. See `expected-output.txt`.

--- a/examples/recipes/browser-mcp-observed-outcomes/expected-output.txt
+++ b/examples/recipes/browser-mcp-observed-outcomes/expected-output.txt
@@ -1,0 +1,9 @@
+Browser/MCP observed outcome recipe complete
+Trace directory: ./.agent-inspect
+Tool action: passed
+Returned status: success
+Expected page: checkout
+Observed page: cart
+Observed outcome: failed
+Try:
+  npx agent-inspect search --dir ./.agent-inspect --observation failed

--- a/examples/recipes/browser-mcp-observed-outcomes/package.json
+++ b/examples/recipes/browser-mcp-observed-outcomes/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agent-inspect-recipe-browser-mcp-observed-outcomes",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/recipes/browser-mcp-observed-outcomes/src/index.ts
+++ b/examples/recipes/browser-mcp-observed-outcomes/src/index.ts
@@ -1,0 +1,69 @@
+import path from "node:path";
+
+import { inspectRun, observeOutcome, step } from "agent-inspect";
+
+type BrowserState = {
+  page: "cart" | "checkout";
+};
+
+const browserState: BrowserState = {
+  page: "cart",
+};
+
+const traceDir = path.join(process.cwd(), ".agent-inspect");
+
+function snapshotBrowserState(): BrowserState {
+  return { ...browserState };
+}
+
+async function clickCheckout() {
+  return { status: "success" as const };
+}
+
+const expectedPage: BrowserState["page"] = "checkout";
+let observedPage: BrowserState["page"] = browserState.page;
+let observedStatus: "passed" | "failed" = "failed";
+
+await inspectRun(
+  "browser-mcp-observed-outcome-demo",
+  async () => {
+    const before = snapshotBrowserState();
+    const actionResult = await step.tool(
+      "browser.clickCheckout",
+      clickCheckout
+    );
+    const after = snapshotBrowserState();
+
+    const transitioned = before.page === "cart" && after.page === expectedPage;
+
+    observedPage = after.page;
+    observedStatus = transitioned ? "passed" : "failed";
+
+    await observeOutcome("checkoutTransition", {
+      expectation: "Page transitioned from cart to checkout",
+      status: observedStatus,
+      method: "snapshot",
+      actual: {
+        beforePage: before.page,
+        afterPage: after.page,
+        expectedPage,
+      },
+      evidence: {
+        actionStatus: actionResult.status,
+      },
+    });
+  },
+  { silent: true, traceDir }
+);
+
+console.log("Browser/MCP observed outcome recipe complete");
+console.log(`Trace directory: ${traceDir}`);
+console.log("Tool action: passed");
+console.log("Returned status: success");
+console.log(`Expected page: ${expectedPage}`);
+console.log(`Observed page: ${observedPage}`);
+console.log(`Observed outcome: ${observedStatus}`);
+console.log("Try:");
+console.log(
+  "  npx agent-inspect search --dir ./.agent-inspect --observation failed"
+);

--- a/examples/recipes/observed-outcome-basic/README.md
+++ b/examples/recipes/observed-outcome-basic/README.md
@@ -24,3 +24,5 @@ npx agent-inspect search --dir ./.agent-inspect --observation failed
 ## Expected output
 
 See `expected-output.txt`.
+
+For a Browser/MCP-shaped example where a successful action does not produce its expected effect, see [browser-mcp-observed-outcomes](../browser-mcp-observed-outcomes/).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,15 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/recipes/browser-mcp-observed-outcomes:
+    dependencies:
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/recipes/circuit-breaker-basic:
     dependencies:
       '@agent-inspect/circuit':

--- a/scripts/validate-recipes.mjs
+++ b/scripts/validate-recipes.mjs
@@ -46,6 +46,7 @@ const RECIPES = [
   "phoenix-openinference-import",
   "langfuse-local-import",
   "observed-outcome-basic",
+  "browser-mcp-observed-outcomes",
   "trace-suite-basic",
   "cohort-baseline-candidate",
   "github-actions-gate",


### PR DESCRIPTION
## Summary

- Add a deterministic Browser/MCP observed outcome recipe that shows a successful tool action does not guarantee the expected state transition occurred.
- The recipe starts on `cart`, runs a synthetic checkout action that returns success, then independently snapshots the state. Because the page remains on `cart` instead of transitioning to `checkout`, the recipe records `checkoutTransition` as a failed observed outcome using the existing `observeOutcome()` API.
- The new recipe is registered in the recipe index and validator, with a cross link from the canonical observed outcome example.
- No core API, export, schema, or runtime behavior is changed.

**Linked issue (required):** #278

Closes #278

## Type of change

- [ ] Bug fix (non breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Focused recipe execution:

```text
pnpm --filter agent-inspect-recipe-browser-mcp-observed-outcomes start

Browser/MCP observed outcome recipe complete
Tool action: passed
Returned status: success
Expected page: checkout
Observed page: cart
Observed outcome: failed
```

**Focused recipe execution**

<img width="1522" height="342" alt="2026-08-27-210621" src="https://github.com/user-attachments/assets/1fbb443c-505e-4026-9ad3-30839c782259" />

The persisted evidence keeps the successful action and failed observed effect separate:

```text
actionStatus: success
beforePage: cart
afterPage: cart
expectedPage: checkout
checkoutTransition: failed
```

The generated trace was also verified through the supported `search` and `report` inspection surfaces, both of which surface `checkoutTransition` as a failed observation.

Evidence run used for verification:

```text
run_axJzUFID_P
```

## Product boundaries (check all that apply)

- [x] Local first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

## Validation

```text
pnpm build
PASS, 20 tsup configs

pnpm typecheck
PASS

pnpm test
PASS, 263 files and 1,885 tests

pnpm recipes:check
PASS, 41 recipes

pnpm --filter agent-inspect-recipe-browser-mcp-observed-outcomes start
PASS

pnpm docs:check
PASS, all six stages

git diff --check
PASS
```

No new dependencies or bundle size impact.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace and log samples in this PR were generated from synthetic recipe state

## Release hygiene

- [x] No version bumps and no Changesets, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [ ] Tests added or updated for behavior changes
- [x] Docs updated where relevant
- [x] `git diff --check` clean