### PR TITLE
feat(vscode): add Open Sample Trace command

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -74,6 +74,11 @@
       {
         "command": "agentInspect.openTraceFromEditor",
         "title": "AgentInspect: Open Trace From Editor"
+      },
+      {
+        "command": "agentInspect.openSampleTrace",
+        "title": "AgentInspect: Open Sample Trace",
+        "icon": "$(beaker)"
       }
     ],
     "menus": {
@@ -90,6 +95,11 @@
         },
         {
           "command": "agentInspect.runDoctor",
+          "when": "view == agentInspect.traces",
+          "group": "navigation"
+        },
+        {
+          "command": "agentInspect.openSampleTrace",
           "when": "view == agentInspect.traces",
           "group": "navigation"
         }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,7 +1,16 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import * as vscode from "vscode";
 
 import type { CliRunner } from "./cli.js";
 import { createCliRunner } from "./cli.js";
+import {
+  SAMPLE_TRACE_FILENAME,
+  SAMPLE_TRACE_RUN_ID,
+  buildSampleTrace,
+} from "./sampleTrace.js";
 import { findTraceHints, pickPrimaryTraceDir, discoverTraceDirs } from "./traceDirs.js";
 import {
   TraceTreeProvider,
@@ -130,6 +139,21 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       await showCliOutput("Verify safe", runner, ["verify-safe", "--dir", dir], root);
+    }),
+    vscode.commands.registerCommand("agentInspect.openSampleTrace", async () => {
+      // Onboarding: write a synthetic sample trace to a temp dir, open it in an
+      // editor so the user sees the JSONL format, and render its tree via the CLI.
+      const dir = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-sample-"));
+      const file = path.join(dir, SAMPLE_TRACE_FILENAME);
+      await writeFile(file, buildSampleTrace(), "utf-8");
+      const document = await vscode.workspace.openTextDocument(vscode.Uri.file(file));
+      await vscode.window.showTextDocument(document, { preview: false });
+      await showCliOutput(
+        "View sample tree",
+        runner,
+        ["view", SAMPLE_TRACE_RUN_ID, "--dir", dir],
+        dir,
+      );
     }),
     vscode.commands.registerCommand("agentInspect.openTraceFromEditor", async () => {
       const editor = vscode.window.activeTextEditor;

--- a/packages/vscode/src/sampleTrace.ts
+++ b/packages/vscode/src/sampleTrace.ts
@@ -1,0 +1,76 @@
+/**
+ * A small synthetic AgentInspect trace used by the "Open Sample Trace" command
+ * so new users can explore the tree/timeline/report views without capturing a
+ * run first. Fully synthetic — no real prompts, tools, or data.
+ */
+
+export const SAMPLE_TRACE_RUN_ID = "agent-inspect-sample";
+export const SAMPLE_TRACE_FILENAME = "agent-inspect-sample.jsonl";
+
+const BASE = 1_700_000_000_000;
+
+/** Returns the sample trace as AgentInspect v0.1 JSONL (one event per line). */
+export function buildSampleTrace(): string {
+  const rows: Record<string, unknown>[] = [
+    {
+      schemaVersion: "0.1",
+      event: "run_started",
+      timestamp: BASE,
+      runId: SAMPLE_TRACE_RUN_ID,
+      name: "sample-support-agent",
+      startTime: BASE,
+    },
+    {
+      schemaVersion: "0.1",
+      event: "step_started",
+      timestamp: BASE + 10,
+      runId: SAMPLE_TRACE_RUN_ID,
+      stepId: "llm_001",
+      name: "llm:plan",
+      type: "llm",
+      startTime: BASE + 10,
+      metadata: { model: "sample-model" },
+    },
+    {
+      schemaVersion: "0.1",
+      event: "step_completed",
+      timestamp: BASE + 210,
+      runId: SAMPLE_TRACE_RUN_ID,
+      stepId: "llm_001",
+      status: "success",
+      endTime: BASE + 210,
+      durationMs: 200,
+    },
+    {
+      schemaVersion: "0.1",
+      event: "step_started",
+      timestamp: BASE + 220,
+      runId: SAMPLE_TRACE_RUN_ID,
+      stepId: "tool_001",
+      name: "tool:lookup-order",
+      type: "tool",
+      startTime: BASE + 220,
+      metadata: { toolName: "lookup_order", inputPreview: '{"orderId":"A-1"}' },
+    },
+    {
+      schemaVersion: "0.1",
+      event: "step_completed",
+      timestamp: BASE + 320,
+      runId: SAMPLE_TRACE_RUN_ID,
+      stepId: "tool_001",
+      status: "success",
+      endTime: BASE + 320,
+      durationMs: 100,
+    },
+    {
+      schemaVersion: "0.1",
+      event: "run_completed",
+      timestamp: BASE + 330,
+      runId: SAMPLE_TRACE_RUN_ID,
+      status: "success",
+      endTime: BASE + 330,
+      durationMs: 330,
+    },
+  ];
+  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+}

--- a/packages/vscode/test/sampleTrace.test.ts
+++ b/packages/vscode/test/sampleTrace.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SAMPLE_TRACE_FILENAME,
+  SAMPLE_TRACE_RUN_ID,
+  buildSampleTrace,
+} from "../src/sampleTrace.js";
+
+describe("vscode sample trace", () => {
+  it("emits valid AgentInspect v0.1 JSONL for the sample run", () => {
+    const lines = buildSampleTrace().trim().split("\n");
+    const events = lines.map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    // Every event is on the sample run and uses the v0.1 schema.
+    for (const event of events) {
+      expect(event.schemaVersion).toBe("0.1");
+      expect(event.runId).toBe(SAMPLE_TRACE_RUN_ID);
+    }
+
+    // A well-formed run: opens, has paired steps, and completes successfully.
+    expect(events[0]?.event).toBe("run_started");
+    expect(events.at(-1)).toMatchObject({ event: "run_completed", status: "success" });
+
+    const started = events.filter((e) => e.event === "step_started");
+    const completed = events.filter((e) => e.event === "step_completed");
+    expect(started.length).toBe(completed.length);
+    expect(started.length).toBeGreaterThan(0);
+
+    // Includes an llm and a tool step so the sample shows a real tree.
+    expect(started.some((e) => e.type === "llm")).toBe(true);
+    expect(started.some((e) => e.type === "tool")).toBe(true);
+  });
+
+  it("uses a stable, self-describing filename and run id", () => {
+    expect(SAMPLE_TRACE_FILENAME).toMatch(/\.jsonl$/);
+    expect(SAMPLE_TRACE_FILENAME).toContain(SAMPLE_TRACE_RUN_ID);
+  });
+});


### PR DESCRIPTION
## What

Adds an **AgentInspect: Open Sample Trace** command so a new user can explore the extension without capturing a run first.

## Behavior

The command writes a small synthetic sample trace to a temp directory, opens the JSONL in an editor (so the format is visible), and renders its execution tree through the existing CLI runner (`agent-inspect view`). It is registered in the command palette and the trace view title menu.

## Implementation

- New pure helper `packages/vscode/src/sampleTrace.ts` (`buildSampleTrace()`) returns valid v0.1 JSONL: a run with paired `llm` and `tool` steps that completes successfully. No new dependencies; fully synthetic data.
- A vitest test validates the sample is well-formed (schema, paired steps, llm + tool, completes ok, stable filename/run id).

Verified end to end that `agent-inspect view` renders the sample tree:

```
AgentInspect Run: sample-support-agent
✔ llm:plan (200ms)
✔ tool:lookup-order (100ms)
```

Closes #66