### PR TITLE
fix(validation): enforce fixed group README completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
   <a href="package.json"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="Node.js 20 or newer"></a>
 </p>
 
+**Support level:** Stable — see [SUPPORT-LEVELS.md](docs/SUPPORT-LEVELS.md). Network behavior: [NETWORK-BEHAVIOR.md](docs/NETWORK-BEHAVIOR.md).
+
 ```bash
 npm install agent-inspect
 ```

--- a/docs/SUPPORT-LEVELS.md
+++ b/docs/SUPPORT-LEVELS.md
@@ -49,7 +49,8 @@ shows). `pnpm package-readmes:check` enforces the agreement and runs as part of
 To promote or demote a surface:
 
 1. Edit the row in the matrix above.
-2. Edit the `**Support level:**` line in each affected `packages/*/README.md`.
+2. Edit the `**Support level:**` line in the affected public README: `README.md`
+   for the root `agent-inspect` package, or `packages/*/README.md` for scoped packages.
 3. Run `pnpm package-readmes:check`.
 
 The check also reports packages whose level is **unenforced** — those the matrix

--- a/packages/core/test/docs/package-readme-support-rule.test.ts
+++ b/packages/core/test/docs/package-readme-support-rule.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const rulePath = new URL(
+  "../../../../scripts/lib/package-readme-support-rule.mjs",
+  import.meta.url,
+).href;
+
+type GoverningSupportRow = { level: string; label: string };
+type SupportRuleModule = {
+  parseSupportRows(markdown: string): GoverningSupportRow[];
+  resolveSupportPackages(label: string): string[];
+  buildSupportMatrixLevels(markdown: string): Map<string, GoverningSupportRow>;
+  supportLevelDisagreement(
+    matrixLevels: Map<string, GoverningSupportRow>,
+    packageName: string,
+    declaredLevel: string,
+  ): GoverningSupportRow | null;
+};
+
+const {
+  parseSupportRows,
+  resolveSupportPackages,
+  buildSupportMatrixLevels,
+  supportLevelDisagreement,
+} = (await import(rulePath)) as SupportRuleModule;
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const supportLevels = readFileSync(path.join(repoRoot, "docs/SUPPORT-LEVELS.md"), "utf8");
+const matrixLevels = buildSupportMatrixLevels(supportLevels);
+
+const proseBoundPackages = [
+  "@agent-inspect/ai-sdk",
+  "@agent-inspect/openai-agents",
+  "@agent-inspect/langchain",
+  "@agent-inspect/vitest",
+  "@agent-inspect/jest",
+];
+
+describe("package README canonical support rules", () => {
+  it("parses canonical prose rows without requiring backticked package identifiers", () => {
+    expect(parseSupportRows(supportLevels)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: expect.stringMatching(/^Official adapters/),
+          level: "Supported",
+        }),
+        { label: "Vitest / Jest reporters", level: "Supported" },
+      ]),
+    );
+  });
+
+  it("preserves explicit backticked package bindings", () => {
+    expect(matrixLevels.get("@agent-inspect/harness")).toEqual({
+      label: "`@agent-inspect/harness`",
+      level: "Supported",
+    });
+  });
+
+  it.each(proseBoundPackages)("accepts %s when its README matches canonical support", (name) => {
+    expect(matrixLevels.get(name)?.level).toBe("Supported");
+    expect(supportLevelDisagreement(matrixLevels, name, "Supported")).toBeNull();
+  });
+
+  it.each(proseBoundPackages)("rejects %s when its README drifts from canonical support", (name) => {
+    expect(supportLevelDisagreement(matrixLevels, name, "Beta")).toEqual(
+      expect.objectContaining({ level: "Supported" }),
+    );
+  });
+
+  it("takes prose-bound maturity from the canonical row instead of the allowlist", () => {
+    const changedMatrix = buildSupportMatrixLevels(
+      "| Official adapters (ai-sdk, openai-agents, langchain / LangGraph fidelity classes) | Beta |",
+    );
+
+    expect(changedMatrix.get("@agent-inspect/ai-sdk")?.level).toBe("Beta");
+  });
+
+  it("does not infer package identities for unrelated canonical prose rows", () => {
+    expect(resolveSupportPackages("TraceContract API")).toEqual([]);
+    expect(resolveSupportPackages("Workspace / bundles / observed outcomes / Evidence v2")).toEqual(
+      [],
+    );
+  });
+
+  it.each([
+    "@agent-inspect/mcp",
+    "@agent-inspect/tui",
+    "@agent-inspect/eval",
+    "@agent-inspect/guardrails",
+    "@agent-inspect/circuit",
+  ])("keeps %s unresolved", (name) => {
+    expect(matrixLevels.has(name)).toBe(false);
+  });
+});

--- a/scripts/lib/package-readme-support-rule.mjs
+++ b/scripts/lib/package-readme-support-rule.mjs
@@ -1,0 +1,51 @@
+const SUPPORT_PROSE_SURFACE_PACKAGES = new Map([
+  [
+    "Official adapters (ai-sdk, openai-agents, langchain / LangGraph fidelity classes)",
+    [
+      "@agent-inspect/ai-sdk",
+      "@agent-inspect/openai-agents",
+      "@agent-inspect/langchain",
+    ],
+  ],
+  ["Vitest / Jest reporters", ["@agent-inspect/vitest", "@agent-inspect/jest"]],
+]);
+
+/** Parse structurally valid two-column support rows without inferring package identity. */
+export function parseSupportRows(markdown) {
+  return [
+    ...markdown.matchAll(
+      /^[ \t]*\|[ \t]*([^|\r\n]+?)[ \t]*\|[ \t]*(\w+)[ \t]*\|[ \t]*$/gm,
+    ),
+  ].map(([, label, level]) => ({ label: label.trim(), level }));
+}
+
+/** Resolve only explicit package identifiers and allowlisted canonical prose surfaces. */
+export function resolveSupportPackages(label) {
+  const packageNames = new Set();
+  for (const [, name] of label.matchAll(/`(@?[a-z0-9/@-]+)`/g)) {
+    packageNames.add(name);
+  }
+
+  const normalizedLabel = label.replace(/\*\*/g, "").trim();
+  for (const name of SUPPORT_PROSE_SURFACE_PACKAGES.get(normalizedLabel) ?? []) {
+    packageNames.add(name);
+  }
+  return [...packageNames];
+}
+
+/** Build package bindings while keeping every maturity value document-driven. */
+export function buildSupportMatrixLevels(markdown) {
+  const matrixLevels = new Map();
+  for (const { label, level } of parseSupportRows(markdown)) {
+    for (const name of resolveSupportPackages(label)) {
+      if (!matrixLevels.has(name)) matrixLevels.set(name, { level, label });
+    }
+  }
+  return matrixLevels;
+}
+
+/** Return the governing row only when a package README claim disagrees with it. */
+export function supportLevelDisagreement(matrixLevels, packageName, declaredLevel) {
+  const governing = matrixLevels.get(packageName);
+  return governing && governing.level !== declaredLevel ? governing : null;
+}

--- a/scripts/package-readme-coverage.mjs
+++ b/scripts/package-readme-coverage.mjs
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+function relativePath(repositoryRoot, filePath) {
+  return path.relative(repositoryRoot, filePath).replaceAll("\\", "/");
+}
+
+/** Build a package-name index from the root and packages/* manifests. */
+export function buildPackageManifestIndex(repositoryRoot) {
+  const manifestPaths = [path.join(repositoryRoot, "package.json")];
+  const packagesDir = path.join(repositoryRoot, "packages");
+
+  if (existsSync(packagesDir)) {
+    for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const manifestPath = path.join(packagesDir, entry.name, "package.json");
+      if (existsSync(manifestPath)) manifestPaths.push(manifestPath);
+    }
+  }
+
+  const manifestsByName = new Map();
+  for (const manifestPath of manifestPaths) {
+    if (!existsSync(manifestPath)) continue;
+    const name = JSON.parse(readFileSync(manifestPath, "utf8")).name;
+    if (typeof name !== "string" || name.length === 0) continue;
+
+    const manifests = manifestsByName.get(name) ?? [];
+    manifests.push({
+      manifestPath,
+      packageDir: path.dirname(manifestPath),
+    });
+    manifestsByName.set(name, manifests);
+  }
+
+  return manifestsByName;
+}
+
+/** Resolve every fixed member to exactly one manifest and adjacent README. */
+export function resolveFixedGroupReadmes({
+  repositoryRoot,
+  fixedGroup,
+  manifestIndex,
+}) {
+  const failures = [];
+  const readmes = [];
+
+  for (const name of fixedGroup) {
+    const manifests = manifestIndex.get(name) ?? [];
+    if (manifests.length === 0) {
+      failures.push(
+        `Fixed-group package resolution is incomplete: ${name}: no repository package.json declares this package name`,
+      );
+      continue;
+    }
+
+    if (manifests.length > 1) {
+      const paths = manifests
+        .map(({ manifestPath }) => relativePath(repositoryRoot, manifestPath))
+        .sort()
+        .join(", ");
+      failures.push(`Duplicate package identity: ${name}: ${paths}`);
+      continue;
+    }
+
+    const readmePath = path.join(manifests[0].packageDir, "README.md");
+    const rel = relativePath(repositoryRoot, readmePath);
+    if (!existsSync(readmePath)) {
+      failures.push(
+        `Fixed-group README coverage is incomplete: ${name}: ${rel} was not found`,
+      );
+      continue;
+    }
+
+    readmes.push({ name, rel, text: readFileSync(readmePath, "utf8") });
+  }
+
+  const resolvedNames = new Set(readmes.map(({ name }) => name));
+  const missing = [...fixedGroup]
+    .filter((name) => !resolvedNames.has(name))
+    .sort();
+  const unexpected = [...resolvedNames]
+    .filter((name) => !fixedGroup.has(name))
+    .sort();
+  if (missing.length > 0 || unexpected.length > 0) {
+    failures.push(
+      "Fixed-group README coverage mismatch:" +
+        (missing.length > 0 ? ` missing ${missing.join(", ")}` : "") +
+        (unexpected.length > 0 ? ` unexpected ${unexpected.join(", ")}` : ""),
+    );
+  }
+
+  return { failures, readmes };
+}
+
+/** Preserve visible skips for discovered, non-fixed packages with READMEs. */
+export function listVisibleNonFixedPackages({ fixedGroup, manifestIndex }) {
+  return [...manifestIndex]
+    .filter(([name, manifests]) => {
+      if (fixedGroup.has(name) || manifests.length !== 1) return false;
+      return existsSync(path.join(manifests[0].packageDir, "README.md"));
+    })
+    .map(([name]) => name)
+    .sort();
+}
+
+export function listUngovernedPackages({ readmes, matrixLevels }) {
+  return readmes
+    .filter(({ name }) => !matrixLevels.has(name))
+    .map(({ name }) => name)
+    .sort();
+}

--- a/scripts/package-readme-coverage.test.mjs
+++ b/scripts/package-readme-coverage.test.mjs
@@ -1,0 +1,158 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildPackageManifestIndex,
+  listUngovernedPackages,
+  listVisibleNonFixedPackages,
+  resolveFixedGroupReadmes,
+} from "./package-readme-coverage.mjs";
+
+const fixtures = [];
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0))
+    rmSync(fixture, { recursive: true, force: true });
+});
+
+function write(root, relativePath, contents) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+function createFixture({
+  includeRootReadme = true,
+  includeFooManifest = true,
+  includeFooReadme = true,
+  duplicateFoo = false,
+} = {}) {
+  const root = mkdtempSync(
+    path.join(tmpdir(), "agent-inspect-package-readmes-"),
+  );
+  fixtures.push(root);
+
+  write(root, "package.json", JSON.stringify({ name: "agent-inspect" }));
+  if (includeRootReadme) write(root, "README.md", "root\n");
+  if (includeFooManifest) {
+    write(
+      root,
+      "packages/foo/package.json",
+      JSON.stringify({ name: "@agent-inspect/foo" }),
+    );
+  }
+  if (includeFooReadme) write(root, "packages/foo/README.md", "foo\n");
+  if (duplicateFoo) {
+    write(
+      root,
+      "packages/foo-copy/package.json",
+      JSON.stringify({ name: "@agent-inspect/foo" }),
+    );
+    write(root, "packages/foo-copy/README.md", "foo copy\n");
+  }
+  write(
+    root,
+    "packages/vscode/package.json",
+    JSON.stringify({ name: "agent-inspect-vscode" }),
+  );
+  write(root, "packages/vscode/README.md", "vscode\n");
+
+  return root;
+}
+
+function resolve(root) {
+  const fixedGroup = new Set(["agent-inspect", "@agent-inspect/foo"]);
+  const manifestIndex = buildPackageManifestIndex(root);
+  return {
+    fixedGroup,
+    manifestIndex,
+    result: resolveFixedGroupReadmes({
+      repositoryRoot: root,
+      fixedGroup,
+      manifestIndex,
+    }),
+  };
+}
+
+describe("fixed-group package README coverage", () => {
+  it("resolves root and scoped members by package identity", () => {
+    const { fixedGroup, manifestIndex, result } = resolve(createFixture());
+
+    expect(result.failures).toEqual([]);
+    expect(result.readmes.map(({ name }) => name)).toEqual([
+      "agent-inspect",
+      "@agent-inspect/foo",
+    ]);
+    expect(listVisibleNonFixedPackages({ fixedGroup, manifestIndex })).toEqual([
+      "agent-inspect-vscode",
+    ]);
+  });
+
+  it("fails closed when the root README is missing", () => {
+    const { result } = resolve(createFixture({ includeRootReadme: false }));
+
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("agent-inspect: README.md was not found"),
+        expect.stringContaining("coverage mismatch: missing agent-inspect"),
+      ]),
+    );
+  });
+
+  it("fails closed when a scoped fixed-member README is missing", () => {
+    const { result } = resolve(createFixture({ includeFooReadme: false }));
+
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "@agent-inspect/foo: packages/foo/README.md was not found",
+        ),
+        expect.stringContaining(
+          "coverage mismatch: missing @agent-inspect/foo",
+        ),
+      ]),
+    );
+  });
+
+  it("names a fixed member whose manifest cannot be resolved", () => {
+    const { result } = resolve(
+      createFixture({ includeFooManifest: false, includeFooReadme: false }),
+    );
+
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "@agent-inspect/foo: no repository package.json declares",
+        ),
+        expect.stringContaining(
+          "coverage mismatch: missing @agent-inspect/foo",
+        ),
+      ]),
+    );
+  });
+
+  it("rejects duplicate fixed-member package identities", () => {
+    const { result } = resolve(createFixture({ duplicateFoo: true }));
+
+    expect(result.failures.join("\n")).toContain(
+      "Duplicate package identity: @agent-inspect/foo",
+    );
+    expect(result.failures.join("\n")).toContain("packages/foo/package.json");
+    expect(result.failures.join("\n")).toContain(
+      "packages/foo-copy/package.json",
+    );
+  });
+
+  it("keeps resolved but canonically ungoverned packages non-fatal", () => {
+    const { result } = resolve(createFixture());
+    const matrixLevels = new Map([["agent-inspect", { level: "Stable" }]]);
+
+    expect(result.failures).toEqual([]);
+    expect(
+      listUngovernedPackages({ readmes: result.readmes, matrixLevels }),
+    ).toEqual(["@agent-inspect/foo"]);
+  });
+});

--- a/scripts/validate-package-readmes.mjs
+++ b/scripts/validate-package-readmes.mjs
@@ -7,9 +7,16 @@
  * behavior changes. This check makes the canonical docs the source of truth and
  * fails when a README drifts from them.
  */
-import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import {
+  buildPackageManifestIndex,
+  listUngovernedPackages,
+  listVisibleNonFixedPackages,
+  resolveFixedGroupReadmes,
+} from "./package-readme-coverage.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const failures = [];
@@ -78,22 +85,15 @@ const fixedGroup = new Set(
 );
 if (fixedGroup.size === 0) failures.push(".changeset/config.json: no fixed package group found");
 
-const readmes = [];
-const skipped = [];
-for (const dir of readdirSync(path.join(root, "packages"))) {
-  const pkgPath = path.join(root, "packages", dir, "package.json");
-  const readmePath = path.join(root, "packages", dir, "README.md");
-  if (!existsSync(pkgPath) || !existsSync(readmePath)) continue;
-  const name = JSON.parse(readFileSync(pkgPath, "utf8")).name;
-  const entry = {
-    name,
-    rel: path.posix.join("packages", dir, "README.md"),
-    text: readFileSync(readmePath, "utf8"),
-  };
-  if (fixedGroup.has(name)) readmes.push(entry);
-  else skipped.push(name);
-}
-if (readmes.length === 0) failures.push("no fixed-group package READMEs found under packages/");
+const manifestIndex = buildPackageManifestIndex(root);
+const resolved = resolveFixedGroupReadmes({
+  repositoryRoot: root,
+  fixedGroup,
+  manifestIndex,
+});
+failures.push(...resolved.failures);
+const readmes = resolved.readmes;
+const skipped = listVisibleNonFixedPackages({ fixedGroup, manifestIndex });
 
 for (const { name, rel, text } of readmes) {
   const declared = text.match(/\*\*Support level:\*\*\s*(\w+)/);
@@ -160,10 +160,7 @@ if (failures.length > 0) {
  * path made visible rather than a blocked build. Add a row naming the package
  * and this check starts enforcing agreement for it.
  */
-const ungoverned = readmes
-  .filter(({ name }) => !matrixLevels.has(name))
-  .map(({ name }) => name)
-  .sort();
+const ungoverned = listUngovernedPackages({ readmes, matrixLevels });
 
 console.log(
   `[package-readmes:check] OK (${readmes.length} fixed-group package READMEs` +

--- a/scripts/validate-package-readmes.mjs
+++ b/scripts/validate-package-readmes.mjs
@@ -18,6 +18,11 @@ import {
   resolveFixedGroupReadmes,
 } from "./package-readme-coverage.mjs";
 
+import {
+  buildSupportMatrixLevels,
+  supportLevelDisagreement,
+} from "./lib/package-readme-support-rule.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const failures = [];
 
@@ -34,17 +39,7 @@ if (canonicalLevels.size === 0) {
   failures.push(`${supportLevelsRel}: could not parse the Definitions table`);
 }
 
-/**
- * Package-matrix rows, keyed by every package name the row mentions. A row may
- * name several ("Official adapters (ai-sdk, openai-agents, langchain ...)"), so
- * a package is governed by any row that names it.
- */
-const matrixLevels = new Map();
-for (const [, label, level] of supportLevels.matchAll(/^\|\s*([^|]*`[^|]*)\|\s*(\w+)\s*\|$/gm)) {
-  for (const [, name] of label.matchAll(/`(@?[a-z0-9/@-]+)`/g)) {
-    if (!matrixLevels.has(name)) matrixLevels.set(name, { level, label: label.trim() });
-  }
-}
+const matrixLevels = buildSupportMatrixLevels(supportLevels);
 
 /**
  * Surfaces NETWORK-BEHAVIOR.md records as making network calls.
@@ -113,11 +108,11 @@ for (const { name, rel, text } of readmes) {
       );
     }
 
-    const governing = matrixLevels.get(name);
-    if (governing && governing.level !== level) {
+    const disagreement = supportLevelDisagreement(matrixLevels, name, level);
+    if (disagreement) {
       failures.push(
-        `${rel}: declares "${level}" but ${supportLevelsRel} rates it "${governing.level}" ` +
-          `via the row "${governing.label}". Change the README, or promote the package in ` +
+        `${rel}: declares "${level}" but ${supportLevelsRel} rates it "${disagreement.level}" ` +
+          `via the row "${disagreement.label}". Change the README, or promote the package in ` +
           `${supportLevelsRel} — they must not disagree.`,
       );
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -201,7 +201,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["packages/**/*.test.ts"],
+    include: ["packages/**/*.test.ts", "scripts/**/*.test.mjs"],
     exclude: ["**/dist/**", "**/node_modules/**", "docs/**", "examples/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Package README validator added in #284 targets the fixed release group, but its discovery started from `packages/*`. That left the root `agent-inspect` package outside the validation universe even though it is part of the 18 member fixed release group.
- This PR resolves fixed group members by package identity through repository manifests so both the root package and scoped packages participate in validation.
- It also fails closed when a fixed member manifest or README cannot be resolved, detects duplicate package identities and set mismatches, and preserves the existing visible `agent-inspect-vscode` skip and nonfatal behavior for packages without enforceable canonical support policy.
-The root README now includes its existing canonical `Stable` declaration, and the support level maintenance path documents both root and scoped package READMEs.
- This is a focused follow up to #284. It does not change package maturity policy or reopen the support policy decisions completed in #168.

**Linked issue (required):** #168

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change, `package-readmes:check` passed while validating only 17 fixed group package READMEs:

```text
[package-readmes:check] OK (17 fixed-group package READMEs, 1 unpublished skipped: agent-inspect-vscode)
```
<img width="913" height="256" alt="2026-08-28-063005" src="https://github.com/user-attachments/assets/4565dd51-fffc-4dc6-8878-92d918d66729" />

After resolving fixed members through package identity and including the root package, the same check covers all 18 fixed group READMEs while preserving the existing unpublished package skip:

```text
[package-readmes:check] OK (18 fixed-group package READMEs, 1 unpublished skipped: agent-inspect-vscode)
```

### Screenshot 2: After
<img width="1156" height="250" alt="2026-08-28-062938" src="https://github.com/user-attachments/assets/6db8ad5a-0311-48cb-a8c2-36b6fabd0377" />

Regression coverage includes six filesystem cases covering complete fixed group resolution, root README resolution, missing manifests, missing READMEs, duplicate package identities, set mismatches, and preservation of existing ungoverned support policy behavior.

## Product boundaries

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

```text
pnpm exec vitest run scripts/package-readme-coverage.test.mjs
PASS, 6/6

pnpm package-readmes:check
PASS, fixed group README coverage increased from 17 to 18
1 unpublished skip remains: agent-inspect-vscode

pnpm typecheck
PASS

pnpm test
PASS, 265 files and 1901 tests

git diff --check
PASS

pnpm docs:commands
PASS

pnpm docs:links
PASS
```

`pnpm docs:check` still fails because of the existing 6.17.4 / 6.17.3 public truth drift.

`pnpm repo:health` still fails because `docs/README.md` on the starting commit reports 6.17.3.

Both failures reproduce from the starting commit `5311084` and are unrelated to this change.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes
- [x] `git diff --check` clean