### PR TITLE
fix(cli): recover tail after log truncation

### DIFF
--- a/packages/cli/src/tail.ts
+++ b/packages/cli/src/tail.ts
@@ -135,6 +135,11 @@ async function followFile(
       throw new Error(`Failed to stat file: ${filePath} (${msg})`);
     }
 
+    if (next.size < pos) {
+      pos = 0;
+      carry = "";
+    }
+
     if (next.size > pos) {
       const fh = await open(filePath, "r");
       try {

--- a/packages/cli/test/tail.test.ts
+++ b/packages/cli/test/tail.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -84,6 +84,65 @@ describe("tail", () => {
     expect(obj).toHaveProperty("trees");
     expect(obj).toHaveProperty("summary");
     writeSpy.mockRestore();
+  });
+
+  it("continues ingesting after truncation and clears buffered partial lines", async () => {
+    const file = path.join(tmpDir, "tail-follow.jsonl");
+    const beforeRunId = "before-truncate";
+    const afterRunId = "after-truncate";
+    const beforeEvent = JSON.stringify({
+      event: "proactive.job.started",
+      decisionId: beforeRunId,
+      timestamp: 1,
+    });
+    const afterEvent = JSON.stringify({
+      event: "proactive.job.started",
+      decisionId: afterRunId,
+      timestamp: 2,
+    });
+
+    await writeFile(file, " ".repeat(4096), "utf-8");
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => true as any);
+    const tailPromise = tail({
+      file,
+      format: "json",
+      json: true,
+      warnings: "none",
+      noClear: true,
+      refresh: "10",
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await appendFile(file, `${beforeEvent}\n`, "utf-8");
+      await vi.waitFor(
+        () => {
+          const output = writeSpy.mock.calls.map((call) => String(call[0])).join("");
+          expect(output).toContain(beforeRunId);
+        },
+        { timeout: 1_500, interval: 10 },
+      );
+
+      await appendFile(file, '{"event":"proactive.job', "utf-8");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await writeFile(file, `${afterEvent}\n`, "utf-8");
+
+      await vi.waitFor(
+        () => {
+          const output = writeSpy.mock.calls.map((call) => String(call[0])).join("");
+          expect(output).toContain(afterRunId);
+        },
+        { timeout: 1_500, interval: 10 },
+      );
+    } finally {
+      process.emit("SIGINT");
+      await tailPromise;
+      writeSpy.mockRestore();
+    }
   });
 
   it("invalid --refresh fails clearly", async () => {
@@ -196,4 +255,3 @@ describe("tail", () => {
     writeSpy.mockRestore();
   });
 });
-


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

`agent-inspect tail` currently keeps its previous byte offset when the watched log file is truncated to a smaller size. Since the follow loop only reads when the current file size grows beyond that offset, subsequent events can be skipped until the file exceeds its previous size.

This change detects an observed file size regression, resets the follow offset to the beginning of the current file, and clears any buffered partial line from the previous contents before normal ingestion continues.

The fix is intentionally scoped to truncation recovery based on an observed size decrease. It does not add inode tracking or claim complete rename and recreate rotation support.

**Linked issue (required):** #298

Closes #298

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Test / regression coverage
- [ ] Example / recipe / fixture
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this fix, the regression test reproduces the stale offset behavior:

1. Start following an existing log file from EOF.
2. Append a valid event and confirm it is ingested.
3. Leave a partial line buffered.
4. Truncate the watched file and replace its contents with a smaller valid event.
5. The new event is not ingested because the previous byte offset remains larger than the current file size.

The regression test fails against the previous implementation and passes with this change.

**Screenshot 1: regression before and after**

<img width="644" height="377" alt="image" src="https://github.com/user-attachments/assets/6bff4272-88ed-4414-9052-fce1044ed011" />

<img width="600" height="321" alt="2026-08-29-164933" src="https://github.com/user-attachments/assets/de3c2138-76bd-45fd-a963-b983413418c2" />

The focused `tail` suite also passes with all 12 tests:

```text
packages/cli/test/tail.test.ts
12/12 passed
```

**Screenshot 2: focused tail suite**

<img width="635" height="385" alt="image" src="https://github.com/user-attachments/assets/5a56619b-2bb4-4f03-af46-58f09ce59fc0" />

The recovery only resets the byte offset and buffered partial line state. The existing tail session, accumulator state, and consumed line numbering remain intact.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

<!-- Paste the commands you ran and their results -->

Focused regression:

```bash
pnpm exec vitest run packages/cli/test/tail.test.ts -t "continues ingesting after truncation and clears buffered partial lines"
```

Result:

```text
FAIL before the fix
PASS after the fix
```

Focused tail suite:

```bash
pnpm exec vitest run packages/cli/test/tail.test.ts
```

Result:

```text
12/12 passed
```

Full validation:

```bash
pnpm typecheck
pnpm test
pnpm test:all
pnpm fixtures:check
pnpm pack:smoke
git diff --check
```

Results:

```text
build: PASS
typecheck: PASS
tests: PASS
coverage: PASS
fixtures: PASS
linked versions: PASS
size: PASS, 12.02 kB / 120 kB
package smoke: PASS
packed OpenAI Agents: PASS
quickstart: PASS
semantic loop: PASS
swarm loop: PASS
Evidence golden paths: PASS
git diff --check: PASS
```

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes, not applicable because this change does not alter the public API or CLI contract
- [x] `git diff --check` clean