### PR TITLE
test(mcp-server): add MCP protocol-state fixture corpus

### DIFF
--- a/fixtures/mcp/README.md
+++ b/fixtures/mcp/README.md
@@ -1,3 +1,4 @@
 # MCP fixtures
 
 - `coding-agent-loop.v1.example.json` — locked catalog for the v6.11 coding-agent debug loop RFC ([docs/CODING-AGENT-LOOP.md](../../docs/CODING-AGENT-LOOP.md)).
+- `protocol-states.v1.json` — synthetic protocol-state corpus (initialize, notifications, ping, tools/list, tools/call, and malformed / unknown requests) driven through the read-only MCP protocol handler. No network, no writes.

--- a/fixtures/mcp/protocol-states.v1.json
+++ b/fixtures/mcp/protocol-states.v1.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "1.0",
+  "description": "Synthetic MCP protocol-state corpus for the read-only server. Drives handleMcpProtocolLine; no network, no writes. Each case supplies a request (object) or rawLine (string) and an expected outcome.",
+  "protocolVersion": "2024-11-05",
+  "cases": [
+    {
+      "name": "initialize negotiates protocol version",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "protocolVersion": "2024-11-05",
+          "capabilities": {},
+          "clientInfo": { "name": "corpus-client", "version": "1" }
+        }
+      },
+      "expect": {
+        "kind": "result",
+        "resultContains": {
+          "protocolVersion": "2024-11-05",
+          "capabilities": { "tools": { "listChanged": false } }
+        }
+      }
+    },
+    {
+      "name": "initialized notification has no reply",
+      "request": { "jsonrpc": "2.0", "method": "notifications/initialized" },
+      "expect": { "kind": "none" }
+    },
+    {
+      "name": "ping returns an empty result",
+      "request": { "jsonrpc": "2.0", "id": 2, "method": "ping" },
+      "expect": { "kind": "result", "resultEquals": {} }
+    },
+    {
+      "name": "tools/list returns the read-only tool set",
+      "request": { "jsonrpc": "2.0", "id": 3, "method": "tools/list" },
+      "expect": { "kind": "result", "toolsNonEmpty": true }
+    },
+    {
+      "name": "tools/call with an unknown tool is a non-fatal result error",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": { "name": "definitely-not-a-tool", "arguments": {} }
+      },
+      "expect": { "kind": "result", "resultIsError": true }
+    },
+    {
+      "name": "missing method is an invalid request",
+      "request": { "jsonrpc": "2.0", "id": 5 },
+      "expect": { "kind": "error", "code": -32600 }
+    },
+    {
+      "name": "unknown method is method-not-found",
+      "request": { "jsonrpc": "2.0", "id": 6, "method": "resources/list" },
+      "expect": { "kind": "error", "code": -32601 }
+    },
+    {
+      "name": "malformed JSON is a parse error",
+      "rawLine": "{ this is not valid json",
+      "expect": { "kind": "error", "code": -32700 }
+    }
+  ]
+}

--- a/packages/mcp-server/test/protocol-state-corpus.test.ts
+++ b/packages/mcp-server/test/protocol-state-corpus.test.ts
@@ -1,0 +1,95 @@
+/**
+ * MCP protocol-state corpus.
+ *
+ * Drives the read-only MCP protocol handler through a synthetic corpus of
+ * protocol states (initialize, notifications, ping, tools/list, tools/call, and
+ * malformed / unknown requests) and asserts each response shape. No network and
+ * no writes; the handler runs against a path-contained read-only context.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { handleMcpProtocolLine, type ProtocolSession } from "../src/protocol.js";
+import { READ_ONLY_TOOLS, createMcpServerContext } from "../src/tools.js";
+
+interface ProtocolCase {
+  name: string;
+  request?: unknown;
+  rawLine?: string;
+  expect: {
+    kind: "result" | "error" | "none";
+    code?: number;
+    resultEquals?: unknown;
+    resultContains?: Record<string, unknown>;
+    resultIsError?: boolean;
+    toolsNonEmpty?: boolean;
+  };
+}
+
+const corpusPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../fixtures/mcp/protocol-states.v1.json",
+);
+const corpus = JSON.parse(readFileSync(corpusPath, "utf8")) as {
+  cases: ProtocolCase[];
+};
+
+function session(lines: string[]): ProtocolSession {
+  return {
+    context: createMcpServerContext({ traceDir: "." }),
+    serverName: "@agent-inspect/mcp-server",
+    serverVersion: "0.0.0-test",
+    write: (line) => lines.push(line),
+    inflight: new Map(),
+  };
+}
+
+describe("MCP protocol-state corpus", () => {
+  it("has cases", () => {
+    expect(corpus.cases.length).toBeGreaterThan(0);
+  });
+
+  for (const testCase of corpus.cases) {
+    it(testCase.name, async () => {
+      const line =
+        testCase.rawLine !== undefined ? testCase.rawLine : JSON.stringify(testCase.request);
+      const out: string[] = [];
+      await handleMcpProtocolLine(session(out), line);
+
+      if (testCase.expect.kind === "none") {
+        expect(out).toHaveLength(0);
+        return;
+      }
+
+      expect(out).toHaveLength(1);
+      const body = JSON.parse(out[0]!) as {
+        result?: Record<string, unknown>;
+        error?: { code: number };
+      };
+
+      if (testCase.expect.kind === "error") {
+        expect(body.error?.code).toBe(testCase.expect.code);
+        return;
+      }
+
+      // result
+      expect(body.result).toBeDefined();
+      if (testCase.expect.resultEquals !== undefined) {
+        expect(body.result).toEqual(testCase.expect.resultEquals);
+      }
+      if (testCase.expect.resultContains !== undefined) {
+        expect(body.result).toMatchObject(testCase.expect.resultContains);
+      }
+      if (testCase.expect.resultIsError !== undefined) {
+        expect(body.result?.isError).toBe(testCase.expect.resultIsError);
+      }
+      if (testCase.expect.toolsNonEmpty) {
+        expect(Array.isArray(body.result?.tools)).toBe(true);
+        expect((body.result?.tools as unknown[]).length).toBe(READ_ONLY_TOOLS.length);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds a synthetic, network-free corpus of read-only MCP protocol states plus a generic runner that drives `handleMcpProtocolLine` through each and asserts the response shape.

## Fixture (`fixtures/mcp/protocol-states.v1.json`)

Each case supplies a `request` (object) or `rawLine` (string) and an expected outcome (`result` / `error` / `none`):

- `initialize` — negotiates protocol version, `capabilities.tools.listChanged: false`
- `notifications/initialized` — no reply
- `ping` — empty result
- `tools/list` — returns the read-only tool set
- `tools/call` with an unknown tool — non-fatal `result.isError: true`
- missing method → `-32600`, unknown method → `-32601`, malformed JSON → `-32700`

## Notes

No network and no writes; the handler runs against a path-contained read-only context. Built independently of any external tool (fully synthetic). Registered in `fixtures/mcp/README`; `fixtures:check` and `tsc` pass.

Closes #165