### PR TITLE
fix(docs): bind canonical prose support rows

### DIFF
--- a/packages/core/test/docs/package-readme-support-rule.test.ts
+++ b/packages/core/test/docs/package-readme-support-rule.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const rulePath = new URL(
+  "../../../../scripts/lib/package-readme-support-rule.mjs",
+  import.meta.url,
+).href;
+
+type GoverningSupportRow = { level: string; label: string };
+type SupportRuleModule = {
+  parseSupportRows(markdown: string): GoverningSupportRow[];
+  resolveSupportPackages(label: string): string[];
+  buildSupportMatrixLevels(markdown: string): Map<string, GoverningSupportRow>;
+  supportLevelDisagreement(
+    matrixLevels: Map<string, GoverningSupportRow>,
+    packageName: string,
+    declaredLevel: string,
+  ): GoverningSupportRow | null;
+};
+
+const {
+  parseSupportRows,
+  resolveSupportPackages,
+  buildSupportMatrixLevels,
+  supportLevelDisagreement,
+} = (await import(rulePath)) as SupportRuleModule;
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const supportLevels = readFileSync(path.join(repoRoot, "docs/SUPPORT-LEVELS.md"), "utf8");
+const matrixLevels = buildSupportMatrixLevels(supportLevels);
+
+const proseBoundPackages = [
+  "@agent-inspect/ai-sdk",
+  "@agent-inspect/openai-agents",
+  "@agent-inspect/langchain",
+  "@agent-inspect/vitest",
+  "@agent-inspect/jest",
+];
+
+describe("package README canonical support rules", () => {
+  it("parses canonical prose rows without requiring backticked package identifiers", () => {
+    expect(parseSupportRows(supportLevels)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: expect.stringMatching(/^Official adapters/),
+          level: "Supported",
+        }),
+        { label: "Vitest / Jest reporters", level: "Supported" },
+      ]),
+    );
+  });
+
+  it("preserves explicit backticked package bindings", () => {
+    expect(matrixLevels.get("@agent-inspect/harness")).toEqual({
+      label: "`@agent-inspect/harness`",
+      level: "Supported",
+    });
+  });
+
+  it.each(proseBoundPackages)("accepts %s when its README matches canonical support", (name) => {
+    expect(matrixLevels.get(name)?.level).toBe("Supported");
+    expect(supportLevelDisagreement(matrixLevels, name, "Supported")).toBeNull();
+  });
+
+  it.each(proseBoundPackages)("rejects %s when its README drifts from canonical support", (name) => {
+    expect(supportLevelDisagreement(matrixLevels, name, "Beta")).toEqual(
+      expect.objectContaining({ level: "Supported" }),
+    );
+  });
+
+  it("takes prose-bound maturity from the canonical row instead of the allowlist", () => {
+    const changedMatrix = buildSupportMatrixLevels(
+      "| Official adapters (ai-sdk, openai-agents, langchain / LangGraph fidelity classes) | Beta |",
+    );
+
+    expect(changedMatrix.get("@agent-inspect/ai-sdk")?.level).toBe("Beta");
+  });
+
+  it("does not infer package identities for unrelated canonical prose rows", () => {
+    expect(resolveSupportPackages("TraceContract API")).toEqual([]);
+    expect(resolveSupportPackages("Workspace / bundles / observed outcomes / Evidence v2")).toEqual(
+      [],
+    );
+  });
+
+  it.each([
+    "@agent-inspect/mcp",
+    "@agent-inspect/tui",
+    "@agent-inspect/eval",
+    "@agent-inspect/guardrails",
+    "@agent-inspect/circuit",
+  ])("keeps %s unresolved", (name) => {
+    expect(matrixLevels.has(name)).toBe(false);
+  });
+});

--- a/scripts/lib/package-readme-support-rule.mjs
+++ b/scripts/lib/package-readme-support-rule.mjs
@@ -1,0 +1,51 @@
+const SUPPORT_PROSE_SURFACE_PACKAGES = new Map([
+  [
+    "Official adapters (ai-sdk, openai-agents, langchain / LangGraph fidelity classes)",
+    [
+      "@agent-inspect/ai-sdk",
+      "@agent-inspect/openai-agents",
+      "@agent-inspect/langchain",
+    ],
+  ],
+  ["Vitest / Jest reporters", ["@agent-inspect/vitest", "@agent-inspect/jest"]],
+]);
+
+/** Parse structurally valid two-column support rows without inferring package identity. */
+export function parseSupportRows(markdown) {
+  return [
+    ...markdown.matchAll(
+      /^[ \t]*\|[ \t]*([^|\r\n]+?)[ \t]*\|[ \t]*(\w+)[ \t]*\|[ \t]*$/gm,
+    ),
+  ].map(([, label, level]) => ({ label: label.trim(), level }));
+}
+
+/** Resolve only explicit package identifiers and allowlisted canonical prose surfaces. */
+export function resolveSupportPackages(label) {
+  const packageNames = new Set();
+  for (const [, name] of label.matchAll(/`(@?[a-z0-9/@-]+)`/g)) {
+    packageNames.add(name);
+  }
+
+  const normalizedLabel = label.replace(/\*\*/g, "").trim();
+  for (const name of SUPPORT_PROSE_SURFACE_PACKAGES.get(normalizedLabel) ?? []) {
+    packageNames.add(name);
+  }
+  return [...packageNames];
+}
+
+/** Build package bindings while keeping every maturity value document-driven. */
+export function buildSupportMatrixLevels(markdown) {
+  const matrixLevels = new Map();
+  for (const { label, level } of parseSupportRows(markdown)) {
+    for (const name of resolveSupportPackages(label)) {
+      if (!matrixLevels.has(name)) matrixLevels.set(name, { level, label });
+    }
+  }
+  return matrixLevels;
+}
+
+/** Return the governing row only when a package README claim disagrees with it. */
+export function supportLevelDisagreement(matrixLevels, packageName, declaredLevel) {
+  const governing = matrixLevels.get(packageName);
+  return governing && governing.level !== declaredLevel ? governing : null;
+}

--- a/scripts/validate-package-readmes.mjs
+++ b/scripts/validate-package-readmes.mjs
@@ -11,6 +11,11 @@ import { readFileSync, existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  buildSupportMatrixLevels,
+  supportLevelDisagreement,
+} from "./lib/package-readme-support-rule.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const failures = [];
 
@@ -27,17 +32,7 @@ if (canonicalLevels.size === 0) {
   failures.push(`${supportLevelsRel}: could not parse the Definitions table`);
 }
 
-/**
- * Package-matrix rows, keyed by every package name the row mentions. A row may
- * name several ("Official adapters (ai-sdk, openai-agents, langchain ...)"), so
- * a package is governed by any row that names it.
- */
-const matrixLevels = new Map();
-for (const [, label, level] of supportLevels.matchAll(/^\|\s*([^|]*`[^|]*)\|\s*(\w+)\s*\|$/gm)) {
-  for (const [, name] of label.matchAll(/`(@?[a-z0-9/@-]+)`/g)) {
-    if (!matrixLevels.has(name)) matrixLevels.set(name, { level, label: label.trim() });
-  }
-}
+const matrixLevels = buildSupportMatrixLevels(supportLevels);
 
 /**
  * Surfaces NETWORK-BEHAVIOR.md records as making network calls.
@@ -113,11 +108,11 @@ for (const { name, rel, text } of readmes) {
       );
     }
 
-    const governing = matrixLevels.get(name);
-    if (governing && governing.level !== level) {
+    const disagreement = supportLevelDisagreement(matrixLevels, name, level);
+    if (disagreement) {
       failures.push(
-        `${rel}: declares "${level}" but ${supportLevelsRel} rates it "${governing.level}" ` +
-          `via the row "${governing.label}". Change the README, or promote the package in ` +
+        `${rel}: declares "${level}" but ${supportLevelsRel} rates it "${disagreement.level}" ` +
+          `via the row "${disagreement.label}". Change the README, or promote the package in ` +
           `${supportLevelsRel} — they must not disagree.`,
       );
     }


### PR DESCRIPTION
## Summary

The package README validator currently only builds support bindings from canonical rows whose labels contain backticked package identifiers.

That skips existing prose rows such as `Official adapters` and `Vitest / Jest reporters`, so several package README support claims remain unenforced even though `docs/SUPPORT-LEVELS.md` already defines their canonical maturity.

This change separates canonical row parsing from package identity resolution, adds explicit one to many bindings for those unambiguous prose surfaces, and keeps support maturity fully document driven.

It also adds regression coverage for matching claims, support drift, unresolved packages, and unrelated prose rows that must not acquire package bindings.

**Linked issue (required):** #168

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change:

```text
node scripts/validate-package-readmes.mjs

[package-readmes:check] OK (17 fixed-group package READMEs, 1 unpublished skipped: agent-inspect-vscode)
[package-readmes:check] note: 10 package(s) declare a level that docs/SUPPORT-LEVELS.md does not name, so it is unenforced: @agent-inspect/ai-sdk, @agent-inspect/circuit, @agent-inspect/eval, @agent-inspect/guardrails, @agent-inspect/jest, @agent-inspect/langchain, @agent-inspect/mcp, @agent-inspect/openai-agents, @agent-inspect/tui, @agent-inspect/vitest

exit=0
```

The canonical support matrix already defines:

```text
Official adapters
Vitest / Jest reporters
```

but those rows contain no backticked package identifiers, so the existing support parser skips them before package identity resolution.

The new bindings cover:

```text
@agent-inspect/ai-sdk
@agent-inspect/openai-agents
@agent-inspect/langchain
@agent-inspect/vitest
@agent-inspect/jest
```

Support maturity is still read from `docs/SUPPORT-LEVELS.md`. No maturity value is hardcoded in the package binding map.

The following packages intentionally remain unresolved because the canonical documentation does not currently provide a clear package level binding:

```text
@agent-inspect/circuit
@agent-inspect/eval
@agent-inspect/guardrails
@agent-inspect/mcp
@agent-inspect/tui
```

Regression coverage also verifies that unrelated prose rows do not gain package bindings.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

Repository validation script and regression tests only. No published package runtime is changed.

## Validation

Focused package README validation:

```bash
node scripts/validate-package-readmes.mjs
```

Regression tests cover:

```text
Official adapter canonical matches
Official adapter support drift
OpenAI Agents canonical matches and drift
LangChain canonical matches and drift
Vitest reporter canonical matches and drift
Jest reporter canonical matches and drift
Unresolved package remains unresolved
Unrelated prose row does not acquire a package binding
```

Additional validation:

```bash
pnpm typecheck
pnpm test
git diff --check
```

`pnpm docs:check` is currently blocked by the unrelated public truth version drift tracked in #304:

```text
PUBLIC-PRODUCT-FACTS.json version 6.17.3 must match root 6.17.4
PUBLIC-PRODUCT-FACTS.json statusLine must mention 6.17.4
apps/website/lib/product.ts version must match root 6.17.4
README should mention current release 6.17.4
PUBLIC-CLAIM-LEDGER.json lastReviewedVersion 6.17.3 must match root 6.17.4
```

The package README validator itself runs independently and is unaffected.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and no Changesets, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] Tests added or updated for behavior changes
- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean

No public API or documented runtime behavior changes are required for this validator fix.