### PR TITLE
test(ai-sdk): add no-key packed consumer golden path

### DIFF
--- a/docs/AI-SDK-ADOPTION.md
+++ b/docs/AI-SDK-ADOPTION.md
@@ -106,4 +106,20 @@ npx agent-inspect check .agent-inspect/<run>.jsonl
 - [ai-sdk-local-telemetry](../../examples/recipes/ai-sdk-local-telemetry/)
 - [ai-sdk-next-route](../../examples/recipes/ai-sdk-next-route/)
 
+## No-key packed consumer check
+
+After building the repository, run the clean packed-consumer path directly:
+
+```bash
+pnpm build
+node scripts/packed-ai-sdk-e2e.mjs
+```
+
+The same check participates in `pnpm pack:smoke`. It installs the packed root
+and `@agent-inspect/ai-sdk` tarballs with the supported `ai` peer in a clean
+temporary consumer, then verifies provider-independent telemetry integration
+through a deterministic AI SDK mock model. It uses no provider package, API
+key, or live provider call, and asserts that metadata-only evidence excludes
+the fixture prompt and output.
+
 See also [ADAPTERS.md](./ADAPTERS.md) and [ADAPTER-CONFORMANCE.md](./ADAPTER-CONFORMANCE.md).

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "prepublishOnly": "AGENT_INSPECT_REPO_HEALTH_SKIP_VERSION=1 pnpm run prepublish:checks",
     "prepack": "pnpm run clean && pnpm run build",
     "pack:dry-run": "pnpm run build && npm pack --dry-run",
-    "pack:smoke": "pnpm run build && node scripts/package-smoke.mjs && node scripts/packed-openai-agents-e2e.mjs && node scripts/packed-quickstart-e2e.mjs && node scripts/packed-semantic-loop-e2e.mjs && node scripts/packed-swarm-loop-e2e.mjs && node scripts/evidence-ci-golden-paths.mjs",
+    "pack:smoke": "pnpm run build && node scripts/package-smoke.mjs && node scripts/packed-openai-agents-e2e.mjs && node scripts/packed-ai-sdk-e2e.mjs && node scripts/packed-quickstart-e2e.mjs && node scripts/packed-semantic-loop-e2e.mjs && node scripts/packed-swarm-loop-e2e.mjs && node scripts/evidence-ci-golden-paths.mjs",
     "linked-versions:check": "node scripts/check-linked-versions.mjs",
     "docs:commands": "node scripts/validate-doc-commands.mjs",
     "docs:links": "node scripts/validate-doc-links.mjs",

--- a/scripts/packed-ai-sdk-e2e.mjs
+++ b/scripts/packed-ai-sdk-e2e.mjs
@@ -1,0 +1,361 @@
+/**
+ * Packed AI SDK no-key consumer E2E.
+ * Run from repo root after build: node scripts/packed-ai-sdk-e2e.mjs
+ */
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const adapterDir = path.join(root, "packages", "ai-sdk");
+const traceDirName = ".agent-inspect-runs";
+const AI_SDK_RUN_NAME = "ai-sdk-packed-fixture";
+const AI_SDK_EXPECTED_PERSISTED_FACTS = [
+  AI_SDK_RUN_NAME,
+  "@agent-inspect/ai-sdk",
+  "fixture-provider",
+  "fixture-generate",
+];
+const AI_SDK_EXPECTED_VIEW_FACTS = [
+  AI_SDK_RUN_NAME,
+  "ai-sdk-step-0",
+  "llm",
+];
+const AI_SDK_FORBIDDEN_FACTS = [
+  "packed fixture prompt",
+  "packed fixture answer",
+];
+
+function fail(message, detail = "") {
+  throw new Error(
+    `[packed-ai-sdk-e2e] ${message}${detail ? `\n${detail}` : ""}`,
+  );
+}
+
+// npm/pnpm and .bin entries are cmd shims on Windows.
+function spawnCli(command, args, options = {}) {
+  const useShell =
+    process.platform === "win32" && !command.toLowerCase().endsWith(".exe");
+  const safeArgs = useShell
+    ? args.map((arg) => (/[\s&|<>()^]/.test(arg) ? `"${arg}"` : arg))
+    : args;
+  return spawnSync(command, safeArgs, {
+    encoding: "utf8",
+    shell: useShell,
+    ...options,
+  });
+}
+
+function run(label, command, args, options = {}) {
+  const result = spawnCli(command, args, options);
+  if (result.status !== 0) {
+    fail(
+      `${label} failed`,
+      `${result.error?.message ?? ""}\n${result.stdout || ""}\n${result.stderr || ""}`.trim(),
+    );
+  }
+  return result;
+}
+
+function packPackage(label, packageDir, tarballDir) {
+  const before = new Set(readdirSync(tarballDir));
+  run(
+    label,
+    "pnpm",
+    ["--dir", packageDir, "pack", "--pack-destination", tarballDir],
+    {
+      env: {
+        ...process.env,
+        npm_config_json: "false",
+        NPM_CONFIG_JSON: "false",
+      },
+    },
+  );
+  const created = readdirSync(tarballDir).filter(
+    (file) => file.endsWith(".tgz") && !before.has(file),
+  );
+  if (created.length !== 1) {
+    fail(`${label} did not produce exactly one new tarball`, created.join(", "));
+  }
+  return path.join(tarballDir, created[0]);
+}
+
+function parseJson(label, output) {
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    fail(`${label} did not emit valid JSON`, `${error}\n${output}`);
+  }
+}
+
+function installPackedConsumer(consumerDir, packageSpecs) {
+  run(
+    "packed consumer install",
+    "npm",
+    ["install", "--ignore-scripts", ...packageSpecs],
+    { cwd: consumerDir },
+  );
+}
+
+function resolvePackedCli(consumerDir) {
+  const bin = path.join(consumerDir, "node_modules", ".bin", "agent-inspect");
+  if (!existsSync(bin)) fail("packed CLI binary missing after install");
+  return bin;
+}
+
+function readRunsFromListJson(json) {
+  const runs = Array.isArray(json) ? json : json?.runs;
+  if (!Array.isArray(runs)) {
+    fail("packed CLI list --json emitted an unsupported run collection");
+  }
+  return runs;
+}
+
+function selectSingleRun(runs, predicate, failureLabel) {
+  const matches = runs.filter(predicate);
+  if (matches.length !== 1) {
+    fail(
+      `${failureLabel}: expected exactly one matching run, found ${matches.length}`,
+      JSON.stringify(runs, null, 2),
+    );
+  }
+  return matches[0];
+}
+
+function runPackedList(bin, traceDir, options) {
+  const result = run(
+    "packed CLI list --json",
+    bin,
+    ["list", "--dir", traceDir, "--json"],
+    options,
+  );
+  return readRunsFromListJson(parseJson("packed CLI list --json", result.stdout));
+}
+
+function runPackedView(bin, runId, traceDir, options) {
+  const result = run(
+    "packed CLI view --json",
+    bin,
+    ["view", runId, "--dir", traceDir, "--json"],
+    options,
+  );
+  return parseJson("packed CLI view --json", result.stdout);
+}
+
+function readPackedTrace(consumerDir, traceDir, runId) {
+  return readFileSync(path.join(consumerDir, traceDir, `${runId}.jsonl`), "utf8");
+}
+
+function assertSerializedIncludes(label, serialized, expectedFacts) {
+  for (const expected of expectedFacts) {
+    if (!serialized.includes(expected)) {
+      fail(`${label} is missing ${expected}`, serialized);
+    }
+  }
+}
+
+function assertSerializedExcludes(label, serialized, forbiddenFacts) {
+  for (const forbidden of forbiddenFacts) {
+    if (serialized.includes(forbidden)) {
+      fail(`${label} unexpectedly includes ${forbidden}`, serialized);
+    }
+  }
+}
+
+function readAiSdkPeerRange() {
+  const manifest = parseJson(
+    "@agent-inspect/ai-sdk package.json",
+    readFileSync(path.join(adapterDir, "package.json"), "utf8"),
+  );
+  const peerRange = manifest.peerDependencies?.ai;
+  if (typeof peerRange !== "string" || peerRange.trim() === "") {
+    fail("@agent-inspect/ai-sdk has no supported ai peer range");
+  }
+  return peerRange;
+}
+
+function withoutAiProviderCredentials() {
+  const env = { ...process.env, AGENT_INSPECT_SILENT: "true" };
+  for (const name of [
+    "ANTHROPIC_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "COHERE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "OPENAI_API_KEY",
+    "TOGETHER_AI_API_KEY",
+    "XAI_API_KEY",
+  ]) {
+    delete env[name];
+  }
+  return env;
+}
+
+function writeAiSdkConsumerFixture(consumerDir) {
+  const consumerScript = path.join(consumerDir, "capture.mjs");
+  writeFileSync(
+    consumerScript,
+    `import { generateText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { agentInspect } from "@agent-inspect/ai-sdk";
+
+const integration = agentInspect({
+  traceDir: ${JSON.stringify(traceDirName)},
+  runName: ${JSON.stringify(AI_SDK_RUN_NAME)},
+  capture: "metadata-only",
+});
+
+const result = await generateText({
+  model: new MockLanguageModelV3({
+    provider: "fixture-provider",
+    modelId: "fixture-generate",
+    doGenerate: {
+      content: [{ type: "text", text: "packed fixture answer" }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 4, noCache: 4, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 3, text: 3, reasoning: 0 },
+      },
+      response: {
+        id: "fixture-generate-response",
+        modelId: "fixture-generate",
+        timestamp: new Date("2026-08-29T00:00:00.000Z"),
+      },
+      warnings: [],
+    },
+  }),
+  prompt: "packed fixture prompt",
+  experimental_telemetry: {
+    isEnabled: true,
+    recordInputs: false,
+    recordOutputs: false,
+    integrations: [integration],
+  },
+});
+
+if (result.text !== "packed fixture answer") {
+  throw new Error(\`unexpected mock result: \${result.text}\`);
+}
+
+await integration.flush();
+await integration.close();
+
+const diagnostics = integration.getDiagnostics();
+if (
+  diagnostics.writeFailures ||
+  diagnostics.lifecycleWarnings ||
+  diagnostics.flushFailures ||
+  diagnostics.closeFailures
+) {
+  throw new Error(\`unexpected integration diagnostics: \${JSON.stringify(diagnostics)}\`);
+}
+`,
+  );
+  return consumerScript;
+}
+
+const peerRange = readAiSdkPeerRange();
+const tarballDir = mkdtempSync(path.join(os.tmpdir(), "agent-inspect-ai-sdk-pack-"));
+const consumerDir = mkdtempSync(
+  path.join(os.tmpdir(), "agent-inspect-ai-sdk-consumer-"),
+);
+
+try {
+  const rootTarball = packPackage("root package pack", root, tarballDir);
+  const adapterTarball = packPackage("AI SDK adapter pack", adapterDir, tarballDir);
+
+  writeFileSync(
+    path.join(consumerDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "agent-inspect-ai-sdk-packed-smoke",
+        private: true,
+        type: "module",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  installPackedConsumer(consumerDir, [
+    rootTarball,
+    adapterTarball,
+    `ai@${peerRange}`,
+  ]);
+
+  const consumerScript = writeAiSdkConsumerFixture(consumerDir);
+  const installedAiVersion = parseJson(
+    "installed ai package.json",
+    readFileSync(path.join(consumerDir, "node_modules", "ai", "package.json"), "utf8"),
+  ).version;
+  const runtimeEnv = withoutAiProviderCredentials();
+  run(`AI SDK ${installedAiVersion} mock capture`, process.execPath, [consumerScript], {
+    cwd: consumerDir,
+    env: runtimeEnv,
+  });
+
+  const bin = resolvePackedCli(consumerDir);
+  const commandOptions = { cwd: consumerDir, env: runtimeEnv };
+  const runs = runPackedList(bin, traceDirName, commandOptions);
+  const selectedRun = selectSingleRun(
+    runs,
+    (run) => run?.name === AI_SDK_RUN_NAME,
+    "AI SDK run discovery",
+  );
+  if (typeof selectedRun.runId !== "string" || selectedRun.runId.trim() === "") {
+    fail("AI SDK run discovery returned no runId", JSON.stringify(selectedRun));
+  }
+
+  const viewJson = runPackedView(
+    bin,
+    selectedRun.runId,
+    traceDirName,
+    commandOptions,
+  );
+  const serializedView = JSON.stringify(viewJson);
+  assertSerializedIncludes(
+    "packed CLI view --json",
+    serializedView,
+    [selectedRun.runId, ...AI_SDK_EXPECTED_VIEW_FACTS],
+  );
+
+  const persistedTrace = readPackedTrace(
+    consumerDir,
+    traceDirName,
+    selectedRun.runId,
+  );
+  assertSerializedIncludes(
+    "persisted AI SDK trace",
+    persistedTrace,
+    AI_SDK_EXPECTED_PERSISTED_FACTS,
+  );
+  assertSerializedExcludes(
+    "persisted AI SDK trace",
+    persistedTrace,
+    AI_SDK_FORBIDDEN_FACTS,
+  );
+
+  console.log(
+    "[packed-ai-sdk-e2e] OK: pack -> install -> mock generateText -> capture -> list -> view",
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  rmSync(tarballDir, { recursive: true, force: true });
+  rmSync(consumerDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Adds a no-key packed consumer golden path for `@agent-inspect/ai-sdk`.

- The new check packs the root package and AI SDK adapter into real tarballs, installs them in a clean temporary consumer, runs a deterministic `MockLanguageModelV3` fixture through `generateText()`, persists metadata-only evidence, and verifies the generated run through the packed CLI.

- This covers the `@agent-inspect/ai-sdk` packed consumer slice of #213.

- The existing package smoke verifies that the packed AI SDK adapter can be installed and imported, but it does not exercise the full consumer path from AI SDK telemetry through local persistence and packed CLI inspection.

- This change adds that missing path using the existing no-network AI SDK mock boundary.

It verifies:

```text
pack
→ clean consumer install
→ MockLanguageModelV3
→ generateText()
→ AI SDK telemetry integration
→ local metadata-only persistence
→ flush and close
→ diagnostics
→ packed CLI list
→ packed CLI view
```

The generated run ID is discovered through the packed CLI rather than assumed to be deterministic.

No provider package, API key, provider call, upload, runtime behavior, public API, schema, version, Changeset, or workflow change is introduced.

**Linked issue (required):** #213

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change, `@agent-inspect/ai-sdk` had packed package surface coverage, but no clean consumer path proving that AI SDK telemetry could produce local persisted evidence that remained discoverable and inspectable through the packed AgentInspect CLI.

The new `scripts/packed-ai-sdk-e2e.mjs` locks in:

```text
pack
→ clean install
→ MockLanguageModelV3
→ generateText()
→ metadata-only capture
→ packed CLI list
→ packed CLI view
```

### Focused packed consumer verification

The focused AI SDK packed consumer path passes independently with real package tarballs and a clean temporary consumer.

<img width="634" height="149" alt="2026-08-30-210230" src="https://github.com/user-attachments/assets/a742bc63-1aea-4f36-b6c8-f8cc6d638ce4" />

> Paste the screenshot showing the successful focused AI SDK packed consumer verification here.

### Persistence and privacy verification

The fixture verifies successful persistence lifecycle handling and checks the raw persisted JSONL to confirm that the fixture prompt and generated output are not stored by the metadata-only path.

<img width="703" height="121" alt="2026-08-30-211433" src="https://github.com/user-attachments/assets/6e8819f4-7440-4358-9d46-badaa3424122" />


> Paste the screenshot showing diagnostics, privacy assertions, or the relevant successful verification output here.

The regression coverage verifies that:

```text
agent-inspect and @agent-inspect/ai-sdk install from packed tarballs
the AI SDK integration runs without provider credentials
the supported mock telemetry lifecycle produces local evidence
flush and close complete without instrumentation failures
diagnostics report no persistence failures
the packed CLI discovers the generated run
the packed CLI can inspect the discovered run
the persisted JSONL does not contain the fixture prompt or generated output
```

The fixture uses no provider package and no live provider call.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

Files changed:

```text
scripts/packed-ai-sdk-e2e.mjs
package.json
docs/AI-SDK-ADOPTION.md
```

No `packages/ai-sdk` runtime source is changed.

## Validation

```bash
pnpm build
# PASS

node --check scripts/packed-ai-sdk-e2e.mjs
# PASS

node scripts/packed-ai-sdk-e2e.mjs
# PASS

pnpm test:all
# PASS
# 264 test files
# 1,895 tests

pnpm size
# PASS
# 12.02 kB / 120 kB

git diff --check
# PASS

pnpm docs:commands
# PASS

pnpm docs:links
# PASS
```

`pnpm docs:check` remains blocked by existing upstream public truth version drift. The current upstream 6.17.4 checkout still contains 6.17.3 references in the public facts, README, and website product metadata. This is unrelated to the AI SDK packed consumer change.

`pnpm pack:smoke` is also blocked before the new AI SDK E2E is reached. The existing `scripts/package-smoke.mjs` fails in the local runner due to the current `npx --no-install` runner context and empty `npm pack --silent` output behavior.

The new AI SDK packed consumer path passes independently:

```bash
node scripts/packed-ai-sdk-e2e.mjs
```

No unrelated baseline failure is modified in this PR.

Node 24 also emits the existing Windows `shell: true` DEP0190 warning from the current CLI shim execution pattern. This PR does not expand into process runner refactoring.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII
- [x] Trace/log samples in the PR were redacted or generated from fixtures

The packed consumer uses `MockLanguageModelV3` only.

No provider package is installed and no provider client is created.

Common provider credentials are removed from the runtime environment as defense in depth.

The raw persisted JSONL is checked directly to confirm that the fixture prompt and generated output are not stored by the metadata-only path.

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why
- [x] Tests added or updated for behavior changes
- [x] Docs updated for the new packed consumer verification path
- [x] `git diff --check` clean