### PR TITLE
fix(cli): make browser opening cross-platform

### DIFF
--- a/packages/cli/src/browser-open.ts
+++ b/packages/cli/src/browser-open.ts
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+
+export interface BrowserOpenResult {
+  ok: boolean;
+  detail?: string;
+}
+
+/** Open a URL or file URL in the platform's default browser without waiting for it to exit. */
+export function openInDefaultBrowser(target: string): Promise<BrowserOpenResult> {
+  const platform = process.platform;
+  const command =
+    platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args =
+    platform === "win32" ? ["/c", "start", "", target] : [target];
+
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(command, args, {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: platform === "win32",
+      });
+
+      child.once("spawn", () => {
+        try {
+          child.unref();
+          resolve({ ok: true });
+        } catch (error) {
+          resolve({
+            ok: false,
+            detail: error instanceof Error ? error.message : String(error),
+          });
+        }
+      });
+      child.once("error", (error) => {
+        resolve({
+          ok: false,
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } catch (error) {
+      resolve({
+        ok: false,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}

--- a/packages/cli/src/bundle-open.ts
+++ b/packages/cli/src/bundle-open.ts
@@ -1,9 +1,10 @@
 import { access, readFile, stat } from "node:fs/promises";
-import { spawn } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { verifyEvidenceDirectory } from "@agent-inspect/core/advanced";
+
+import { openInDefaultBrowser } from "./browser-open.js";
 
 export interface BundleOpenCommandOptions {
   json?: boolean;
@@ -30,41 +31,6 @@ async function resolveHtmlPath(root: string): Promise<string> {
   throw new Error(
     `No evidence.html found under ${root}. Pass a bundle directory or .html path.`,
   );
-}
-
-function openLocalFile(filePath: string): Promise<{ ok: boolean; detail: string }> {
-  const fileUrl = pathToFileURL(filePath).href;
-  const platform = process.platform;
-  const command =
-    platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
-  const args =
-    platform === "darwin"
-      ? [filePath]
-      : platform === "win32"
-        ? ["/c", "start", "", filePath]
-        : [filePath];
-
-  return new Promise((resolve) => {
-    try {
-      const child = spawn(command, args, {
-        detached: true,
-        stdio: "ignore",
-      });
-      child.on("error", (error) => {
-        resolve({
-          ok: false,
-          detail: `${error instanceof Error ? error.message : String(error)}; open manually: ${fileUrl}`,
-        });
-      });
-      child.unref();
-      resolve({ ok: true, detail: fileUrl });
-    } catch (error) {
-      resolve({
-        ok: false,
-        detail: `${error instanceof Error ? error.message : String(error)}; open manually: ${fileUrl}`,
-      });
-    }
-  });
 }
 
 /**
@@ -150,23 +116,24 @@ export async function bundleOpenCommand(
     // html-only open still allowed after verify when sidecar exists elsewhere
   }
 
-  const opened = await openLocalFile(htmlPath);
+  const fileUrl = pathToFileURL(htmlPath).href;
+  const opened = await openInDefaultBrowser(fileUrl);
   if (options.json) {
     console.log(
       writeJson({
         ok: opened.ok,
         path: htmlPath,
         opened: opened.ok,
-        detail: opened.detail,
+        detail: opened.ok ? fileUrl : `${opened.detail ?? "unknown error"}; open manually: ${fileUrl}`,
       }).trimEnd(),
     );
   } else if (opened.ok) {
     console.log(`Opened local Evidence: ${htmlPath}`);
-    console.log(`URL: ${opened.detail}`);
+    console.log(`URL: ${fileUrl}`);
   } else {
     console.error(`[AgentInspect] Could not open browser automatically.`);
     console.error(`Open this file locally: ${htmlPath}`);
-    console.error(opened.detail);
+    console.error(`${opened.detail ?? "unknown error"}; open manually: ${fileUrl}`);
   }
 
   if (!opened.ok) {

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -1,5 +1,7 @@
 import { startViewerServer } from "@agent-inspect/viewer";
 
+import { openInDefaultBrowser } from "./browser-open.js";
+
 export interface ServeCommandOptions {
   dir?: string;
   host?: string;
@@ -41,8 +43,11 @@ export async function serveCommand(options: ServeCommandOptions = {}): Promise<v
   if (options.open === true && host !== "127.0.0.1" && host !== "localhost") {
     console.warn("Skipping browser open for non-local host binding.");
   } else if (options.open === true) {
-    const openMod = await import("node:child_process");
-    openMod.exec(`open ${info.url}`, () => {});
+    const opened = await openInDefaultBrowser(info.url);
+    if (!opened.ok) {
+      console.warn("Viewer started, but the browser could not be opened automatically.");
+      console.warn(`Open manually: ${info.url}`);
+    }
   }
 
   await new Promise<void>(() => {

--- a/packages/cli/src/studio-cmd.ts
+++ b/packages/cli/src/studio-cmd.ts
@@ -1,5 +1,7 @@
 import type * as Studio from "@agent-inspect/studio";
 
+import { openInDefaultBrowser } from "./browser-open.js";
+
 const PACKAGE = "@agent-inspect/studio";
 
 export interface StudioCommandOptions {
@@ -222,8 +224,11 @@ export async function studioCommand(options: StudioCommandOptions = {}): Promise
   if (options.open === true && info.host !== "127.0.0.1" && info.host !== "localhost") {
     console.warn("Skipping browser open for non-local host binding.");
   } else if (options.open === true) {
-    const openMod = await import("node:child_process");
-    openMod.exec(`open ${info.url}`, () => {});
+    const opened = await openInDefaultBrowser(info.url);
+    if (!opened.ok) {
+      console.warn("Studio started, but the browser could not be opened automatically.");
+      console.warn(`Open manually: ${info.url}`);
+    }
   }
 
   await new Promise<void>(() => {

--- a/packages/cli/test/browser-open-commands.test.ts
+++ b/packages/cli/test/browser-open-commands.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { openBrowserMock, startStudioServerMock, startViewerServerMock } = vi.hoisted(() => ({
+  openBrowserMock: vi.fn(async () => ({ ok: true })),
+  startStudioServerMock: vi.fn(),
+  startViewerServerMock: vi.fn(),
+}));
+
+vi.mock("../src/browser-open.js", () => ({
+  openInDefaultBrowser: openBrowserMock,
+}));
+
+vi.mock("@agent-inspect/viewer", () => ({
+  startViewerServer: startViewerServerMock,
+}));
+
+vi.mock("@agent-inspect/studio", () => ({
+  startStudioServer: startStudioServerMock,
+}));
+
+import { serveCommand } from "../src/serve.js";
+import { studioCommand } from "../src/studio-cmd.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  openBrowserMock.mockClear();
+  openBrowserMock.mockResolvedValue({ ok: true });
+  startStudioServerMock.mockReset();
+  startViewerServerMock.mockReset();
+});
+
+describe("browser-open host guards", () => {
+  it("opens the viewer for a local host", async () => {
+    startViewerServerMock.mockResolvedValue({
+      host: "127.0.0.1",
+      mode: "traces",
+      traceDir: ".agent-inspect",
+      url: "http://127.0.0.1:7331",
+    });
+
+    void serveCommand({ open: true });
+
+    await vi.waitFor(() => {
+      expect(openBrowserMock).toHaveBeenCalledWith("http://127.0.0.1:7331");
+    });
+  });
+
+  it("skips the viewer launcher for a non-local host", async () => {
+    startViewerServerMock.mockResolvedValue({
+      host: "0.0.0.0",
+      mode: "traces",
+      traceDir: ".agent-inspect",
+      url: "http://0.0.0.0:7331",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    void serveCommand({ host: "0.0.0.0", open: true });
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith("Skipping browser open for non-local host binding.");
+    });
+    expect(openBrowserMock).not.toHaveBeenCalled();
+  });
+
+  it("opens Studio for a local host", async () => {
+    startStudioServerMock.mockResolvedValue({
+      host: "localhost",
+      url: "http://localhost:7332",
+    });
+
+    void studioCommand({ host: "localhost", open: true });
+
+    await vi.waitFor(() => {
+      expect(openBrowserMock).toHaveBeenCalledWith("http://localhost:7332");
+    });
+  });
+
+  it("skips the Studio launcher for a non-local host", async () => {
+    startStudioServerMock.mockResolvedValue({
+      host: "0.0.0.0",
+      url: "http://0.0.0.0:7332",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    void studioCommand({ host: "0.0.0.0", open: true });
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith("Skipping browser open for non-local host binding.");
+    });
+    expect(openBrowserMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/browser-open.test.ts
+++ b/packages/cli/test/browser-open.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+import { openInDefaultBrowser } from "../src/browser-open.js";
+
+function mockChildEvent(event: "spawn" | "error", error?: Error) {
+  const child = Object.assign(new EventEmitter(), { unref: vi.fn() });
+  spawnMock.mockImplementationOnce(() => {
+    queueMicrotask(() => child.emit(event, error));
+    return child;
+  });
+  return child;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  spawnMock.mockReset();
+});
+
+describe("openInDefaultBrowser", () => {
+  const platformCases: Array<{
+    platform: NodeJS.Platform;
+    command: string;
+    args: string[];
+    windowsHide: boolean;
+  }> = [
+    {
+      platform: "darwin",
+      command: "open",
+      args: ["https://example.test/viewer"],
+      windowsHide: false,
+    },
+    {
+      platform: "win32",
+      command: "cmd",
+      args: ["/c", "start", "", "https://example.test/viewer"],
+      windowsHide: true,
+    },
+    {
+      platform: "linux",
+      command: "xdg-open",
+      args: ["https://example.test/viewer"],
+      windowsHide: false,
+    },
+  ];
+
+  it.each(platformCases)(
+    "uses the $platform platform launcher",
+    async ({ platform, command, args, windowsHide }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const child = mockChildEvent("spawn");
+
+      await expect(openInDefaultBrowser("https://example.test/viewer")).resolves.toEqual({
+        ok: true,
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(command, args, {
+        detached: true,
+        stdio: "ignore",
+        windowsHide,
+      });
+      expect(child.unref).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("returns launch errors without throwing", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const child = mockChildEvent("error", new Error("xdg-open unavailable"));
+
+    await expect(openInDefaultBrowser("https://example.test/viewer")).resolves.toEqual({
+      ok: false,
+      detail: "xdg-open unavailable",
+    });
+    expect(child.unref).not.toHaveBeenCalled();
+  });
+
+  it("returns synchronous spawn failures without throwing", async () => {
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error("spawn failed");
+    });
+
+    await expect(openInDefaultBrowser("https://example.test/viewer")).resolves.toEqual({
+      ok: false,
+      detail: "spawn failed",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`serve --open` and `studio --open` previously invoked the macOS `open` command on every platform. On Windows and most Linux environments, the server could start successfully while the browser launch failed silently.

This PR extracts the existing platform-specific launch behavior into a shared CLI helper and reuses it across `serve --open`, `studio --open`, and `bundle open`.

The shared launcher selects the platform-appropriate command:

```text
macOS    open
Windows  cmd /c start
Linux    xdg-open
```

It also handles process creation through the child process `spawn` and `error` events instead of silently discarding launcher failures.

The existing local-host guard remains unchanged for `serve` and `studio`, and browser launch failures remain non-fatal so a failed launcher does not stop an otherwise healthy local server.

Focused regression coverage locks the platform command selection, launcher success and failure paths, and command-level local-host behavior.

**Linked issue (required):** #312 

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change, both `serve --open` and `studio --open` launched the browser with:

```ts
exec(`open ${info.url}`, () => {});
```

This relies on the macOS `open` command and does not provide a portable launcher on Windows or most Linux environments.

After this change, the CLI uses the shared platform-specific launcher while preserving the existing local-host restrictions.

### Windows native verification

Command:

```powershell
node packages/cli/dist/index.cjs serve --open
```

The viewer started at:

```text
http://127.0.0.1:7337/
```

and the default browser automatically opened the same URL.

<!-- Screenshot 1: Windows terminal showing `serve --open` and http://127.0.0.1:7337/ -->

<img width="916" height="92" alt="2026-08-31-034023" src="https://github.com/user-attachments/assets/e8abb214-0eb3-41cd-8103-307dec9141fa" />

<!-- Screenshot 2: Default browser automatically opened to http://127.0.0.1:7337/ and showing the AgentInspect local viewer -->

<img width="766" height="295" alt="2026-08-31-034034" src="https://github.com/user-attachments/assets/8c480df7-bbca-45b4-82d5-73819deb07f7" />

### Focused regression coverage

```text
Test Files  2 passed (2)
Tests       9 passed (9)
```

<!-- Screenshot 3: Focused Vitest run showing browser-open-commands.test.ts, browser-open.test.ts, and 9/9 tests passing -->

<img width="832" height="217" alt="2026-08-31-034135" src="https://github.com/user-attachments/assets/bd2a173a-4dbc-4b22-9101-723e2db76a58" />

The focused coverage verifies:

- macOS uses `open`
- Windows uses `cmd /c start`
- Linux uses `xdg-open`
- successful launcher process creation
- launcher error handling
- `serve` local and non-local host behavior
- `studio` local and non-local host behavior

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

Focused regression tests:

```bash
pnpm exec vitest run -c vitest.config.ts packages/cli/test/browser-open.test.ts packages/cli/test/browser-open-commands.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       9 passed (9)
```

Full validation:

```text
pnpm typecheck
PASS

pnpm build
PASS

pnpm test:coverage
PASS

pnpm test:all
PASS
266 files, 1,904 tests passed

pnpm fixtures:check
PASS

pnpm size
PASS
12.02 kB / 120 kB

git diff --check
PASS
```

`pnpm pack:smoke` completed its build step, but the existing script could not parse the blank stdout returned by `npm pack --silent` under npm 11.6.2.

The package operation was checked independently with:

```bash
npm pack --dry-run --json
```

Result:

```text
PASS
```

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean

No documentation change is included because the existing `--open` CLI surface and intended behavior are unchanged. This PR fixes the platform-specific implementation without introducing a new CLI option or public API.