### PR TITLE
test(demo): cover fail-closed bundle verification

### DIFF
--- a/packages/cli/test/demo-verify.test.ts
+++ b/packages/cli/test/demo-verify.test.ts
@@ -1,0 +1,182 @@
+import { spawnSync } from "node:child_process";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+const sourceScript = path.join(repoRoot, "scripts/demo-verify.mjs");
+const sampleIds = ["sample-a", "sample-b"];
+
+describe("demo:verify prerequisites", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-demo-verify-"));
+    await createFixtureRepo(tmpRoot);
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fails closed when the CLI artifact is missing", () => {
+    const result = runVerifier(tmpRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("AI_DEMO_VERIFY_CLI_MISSING");
+    expect(result.stdout).not.toContain("[demo:verify] OK");
+  });
+
+  it(
+    "verifies every manifest sample when the CLI artifact is present",
+    async () => {
+      await writeFakeCli(tmpRoot);
+
+      const result = runVerifier(tmpRoot);
+      const calls = await readInvocations(tmpRoot);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("[demo:verify] OK");
+      expect(calls).toHaveLength(sampleIds.length);
+      expect(calls.map((args) => args.slice(0, 2))).toEqual(
+        sampleIds.map(() => ["bundle", "verify"]),
+      );
+      expect(calls.map((args) => path.basename(path.dirname(args[2])))).toEqual(
+        sampleIds,
+      );
+    },
+  );
+
+  it("fails when verification fails for any manifest sample", async () => {
+    await writeFakeCli(tmpRoot);
+
+    const result = runVerifier(tmpRoot, "sample-b");
+    const calls = await readInvocations(tmpRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("bundle verify failed for sample-b");
+    expect(result.stdout).not.toContain("[demo:verify] OK");
+    expect(calls).toHaveLength(sampleIds.length);
+  });
+});
+
+async function createFixtureRepo(root: string): Promise<void> {
+  await mkdir(path.join(root, "scripts"), { recursive: true });
+  await copyFile(sourceScript, path.join(root, "scripts/demo-verify.mjs"));
+  await writeFixtureFile(
+    root,
+    "package.json",
+    `${JSON.stringify({ version: "1.0.0", type: "module" }, null, 2)}\n`,
+  );
+  await writeFixtureFile(
+    root,
+    "examples/evidence/demo-manifest.json",
+    `${JSON.stringify(
+      {
+        packageVersion: "1.0.0",
+        samples: sampleIds.map((id) => ({
+          id,
+          files: ["evidence/evidence.json"],
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  for (const id of sampleIds) {
+    await writeFixtureFile(
+      root,
+      `examples/evidence/${id}/evidence/evidence.json`,
+      "{}\n",
+    );
+  }
+
+  await writeFixtureFile(
+    root,
+    "docs/assets/showcase/provenance.json",
+    `${JSON.stringify(
+      {
+        packageVersion: "1.0.0",
+        assets: ["debug-tree", "check-pass-fail", "evidence-bundle"].map((id) => ({
+          id,
+          caption: `${id} caption`,
+          transcript: `${id} transcript`,
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  for (const relativePath of [
+    "docs/assets/showcase/gif/debug-tree.gif",
+    "docs/assets/showcase/gif/check-pass-fail.gif",
+    "docs/assets/showcase/gif/evidence-bundle.gif",
+    "docs/assets/showcase/diagrams/value-loop.svg",
+  ]) {
+    await writeFixtureFile(root, relativePath, "fixture\n");
+  }
+}
+
+async function writeFakeCli(root: string): Promise<void> {
+  await writeFixtureFile(
+    root,
+    "packages/cli/dist/index.cjs",
+    [
+      'const { appendFileSync } = require("node:fs");',
+      "const args = process.argv.slice(2);",
+      'appendFileSync(process.env.DEMO_VERIFY_INVOCATIONS, `${JSON.stringify(args)}\\n`);',
+      "if (process.env.DEMO_VERIFY_FAIL_SAMPLE &&",
+      "    args.some((arg) => arg.includes(process.env.DEMO_VERIFY_FAIL_SAMPLE))) {",
+      "  process.exit(1);",
+      "}",
+      'process.stdout.write("{\\"ok\\":true}\\n");',
+      "",
+    ].join("\n"),
+  );
+}
+
+function runVerifier(root: string, failSample?: string) {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    DEMO_VERIFY_INVOCATIONS: path.join(root, "invocations.jsonl"),
+  };
+  if (failSample) env.DEMO_VERIFY_FAIL_SAMPLE = failSample;
+
+  return spawnSync(process.execPath, [path.join(root, "scripts/demo-verify.mjs")], {
+    cwd: root,
+    encoding: "utf-8",
+    env,
+  });
+}
+
+async function readInvocations(root: string): Promise<string[][]> {
+  const text = await readFile(path.join(root, "invocations.jsonl"), "utf-8");
+  return text
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as string[]);
+}
+
+async function writeFixtureFile(
+  root: string,
+  relativePath: string,
+  contents: string,
+): Promise<void> {
+  const target = path.join(root, relativePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, contents, "utf-8");
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

**Linked issue (required):** #300

- Add focused regression coverage for the `demo:verify` behavior already on `main`.

- Cover the missing CLI prerequisite, verification of every manifest sample, and propagation of bundle verification failures using an isolated temporary repository and fake CLI.

- Keep this follow-up tests only, with no production, workflow, package, or runtime changes.

- This is the tests-only follow-up discussed in #301 after the fail-closed `demo:verify` behavior landed separately on `main`.

- The new regression suite executes the real `scripts/demo-verify.mjs` against an isolated temporary repository and locks three existing behaviors:

1. A missing CLI artifact fails closed with `AI_DEMO_VERIFY_CLI_MISSING`.
2. A present CLI runs bundle verification for every manifest sample.
3. A bundle verification failure for any sample makes the overall gate fail.

The fixture uses synthetic data and a fake CLI, and does not modify or depend on the checkout's real CLI artifact.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

<!-- For bug fixes: how the bug reproduces and how this PR was verified against it.
     For tests/fixtures: what regression the coverage locks in. -->

The focused suite locks the current `demo:verify` contract without changing production behavior.

Covered cases:

```text
fails closed when the CLI artifact is missing
verifies every manifest sample when the CLI artifact is present
fails when verification fails for any manifest sample
```

**Screenshot 1: focused regression suite, 3/3 passing**

<img width="834" height="343" alt="2026-09-01-055343" src="https://github.com/user-attachments/assets/6db3eca2-b735-4307-b197-be22b1d15db6" />

The test runs the verifier in an isolated temporary repository with synthetic manifest data and a fake CLI.

**Screenshot 2: tests-only scope, one file changed**

<img width="887" height="101" alt="2026-09-01-055533" src="https://github.com/user-attachments/assets/0a8aa9df-4883-41de-86ed-deefe26e39b9" />


```text
packages/cli/test/demo-verify.test.ts | 182 ++++++++++++++++++++++++++++++++
1 file changed, 182 insertions(+)
```

No production source, workflow, package metadata, lockfile, or runtime behavior is changed.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

<!-- Paste the commands you ran and their results -->

```bash
pnpm vitest run demo-verify.test.ts
# PASS: 1 file, 3 tests

pnpm typecheck
# PASS

pnpm build
# PASS

git diff --check
# PASS
```

`pnpm test` includes the new regression suite successfully. The full run reaches 268 files and 1930 tests, with one existing Windows baseline failure in `public-truth-sync.test.ts`.

That existing test invokes `mv`, which is unavailable in the Windows test environment, so the CLI artifact is not actually moved as the test expects. This is unrelated to this tests-only change and is not modified here.

Final scope checks:

```text
git status --short
# only packages/cli/test/demo-verify.test.ts

package.json
# unchanged

pnpm-lock.yaml
# unchanged
```

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`), not applicable because this PR adds regression coverage only
- [x] `git diff --check` clean