### PR TITLE
feat(core): add causal requiredOrder modes

### DIFF
--- a/apps/website/public/docs/trace-contracts.md
+++ b/apps/website/public/docs/trace-contracts.md
@@ -24,13 +24,14 @@ Contracts compile to deterministic check rules for common cases:
 → contract.tool.order.1: B before C
 ```
 
-Each pair compares the **first occurrence** (start/encounter order in the evaluated event stream):
+`requiredOrderMode` selects one ordering relation for every generated pair:
 
 - unlisted intermediate tools are allowed;
-- later repetitions do not invalidate an earlier valid first-occurrence order;
 - TraceContract `requiredOrder` **implies presence** — every listed name is added to the effective required-tool set;
-- this is **not** causal happens-before; overlapping intervals emit a non-failing `tool.order.overlap` warning;
-- combine ordering with `maxCalls` or custom rules when repeated calls matter.
+- `first` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
+- `happens-before` requires the first `before` occurrence to finish before the first `after` occurrence starts;
+- `all-occurrences` requires every `before` occurrence to finish before every `after` occurrence starts (`max(before.end) <= min(after.start)`);
+- causal modes fail when a required interval boundary cannot be resolved instead of falling back to encounter order.
 
 Examples for `requiredOrder: ["retrieve", "generate"]`:
 
@@ -44,6 +45,10 @@ Examples for `requiredOrder: ["retrieve", "generate"]`:
 
 Low-level `createToolOrderingRule({ before, after })` alone may still pass when an endpoint is missing (compositional). TraceContract `requiredOrder` does not.
 
+For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first` warns while `happens-before` fails.
+
+Immediate or positional `all-pairs` matching is not implemented. It requires separate occurrence-pairing and cardinality semantics.
+
 ### Experimental Vitest / Jest matchers (shipped)
 
 | Package | Export | Matchers |
@@ -55,7 +60,7 @@ These are **Experimental** — API names may evolve. There is no `expectTrace(..
 
 See [API.md](./API.md), [TRACE-FACTS.md](./TRACE-FACTS.md), and `packages/core/src/checks/contract.ts`.
 
-## Rule kinds (shipped vs planned)
+## Rule kinds (shipped and planned)
 
 TraceContract rules fall into distinct categories. Mixing them incorrectly is a common source of false failures (see GitHub #308 and #309).
 
@@ -67,16 +72,15 @@ Unconditional path invariant: every named tool must appear **at least once** in 
 - **Do not** use for steps that legitimate shortcuts may skip (for example cache hits that bypass `retrieve`).
 - When a shortcut is valid but you still need evidence of the outcome, prefer `observations.required` until `alternatives.anyOf` ships (6.20.0).
 
-### `tools.requiredOrder` (shipped — first-occurrence / start-encounter)
+### `tools.requiredOrder` (shipped — selectable ordering modes)
 
-Legacy first-start / encounter ordering. The evaluator walks the trace and checks that each listed tool's **first occurrence** appears after the previous tool's first occurrence.
+The evaluator expands each list into adjacent pairs and applies one `requiredOrderMode` to every pair.
 
 - TraceContract `requiredOrder` **implies presence** of every listed tool (unioned into `tools.required`).
-- Default mode is **first-occurrence** start/encounter order — **not** causal happens-before.
-- Overlapping intervals that still satisfy start order emit a non-failing overlap warning.
-- **Planned (6.20.0, GitHub #308):**
-  - `requiredOrderMode: "happens-before"` — first before must **end** before first after **starts**
-  - `requiredOrderMode: "all-occurrences"` — every before must end before every after starts
+- `requiredOrderMode: "first"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
+- `requiredOrderMode: "happens-before"` requires the first before to **end** before the first after **starts**; overlap fails.
+- `requiredOrderMode: "all-occurrences"` requires every before to end before every after starts; any cross-boundary overlap or later before fails.
+- Missing interval boundaries fail closed in the two causal modes.
 
 ### `observations.required` (shipped)
 
@@ -89,10 +93,8 @@ Document only; **do not** use these fields in contracts today:
 | Planned field | Purpose | GitHub |
 |---------------|---------|--------|
 | `alternatives.anyOf` | One of several deterministic valid paths (one level, no nested groups, no predicates) | #309 |
-| `requiredOrderMode: "happens-before"` | Causal completion-before-start ordering | #308 |
-| `requiredOrderMode: "all-occurrences"` | Strict ordering across all tool occurrences | #308 |
 
-API shape for both requires maintainer approval before external PR lands. @HsienW volunteered on #308 for `requiredOrderMode` implementation.
+The `alternatives.anyOf` API shape requires maintainer approval before an external PR lands.
 
 ## Workaround until 6.20.0
 
@@ -113,7 +115,7 @@ contract:
     required: [cache_hit_or_retrieve_evidence]
 ```
 
-With first-occurrence ordering, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see worked example below).
+With `requiredOrderMode: "first"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
 
 ## What is not shipped (yet)
 

--- a/apps/website/public/docs/trace-contracts.md
+++ b/apps/website/public/docs/trace-contracts.md
@@ -28,7 +28,7 @@ Contracts compile to deterministic check rules for common cases:
 
 - unlisted intermediate tools are allowed;
 - TraceContract `requiredOrder` **implies presence** — every listed name is added to the effective required-tool set;
-- `first` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
+- `first-occurrence` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
 - `happens-before` requires the first `before` occurrence to finish before the first `after` occurrence starts;
 - `all-occurrences` requires every `before` occurrence to finish before every `after` occurrence starts (`max(before.end) <= min(after.start)`);
 - causal modes fail when a required interval boundary cannot be resolved instead of falling back to encounter order.
@@ -45,9 +45,11 @@ Examples for `requiredOrder: ["retrieve", "generate"]`:
 
 Low-level `createToolOrderingRule({ before, after })` alone may still pass when an endpoint is missing (compositional). TraceContract `requiredOrder` does not.
 
-For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first` warns while `happens-before` fails.
+For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first-occurrence` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first-occurrence` warns while `happens-before` fails.
 
 Immediate or positional `all-pairs` matching is not implemented. It requires separate occurrence-pairing and cardinality semantics.
+
+These modes do not introduce a general temporal DSL, persisted schema changes, or network behavior.
 
 ### Experimental Vitest / Jest matchers (shipped)
 
@@ -77,7 +79,7 @@ Unconditional path invariant: every named tool must appear **at least once** in 
 The evaluator expands each list into adjacent pairs and applies one `requiredOrderMode` to every pair.
 
 - TraceContract `requiredOrder` **implies presence** of every listed tool (unioned into `tools.required`).
-- `requiredOrderMode: "first"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
+- `requiredOrderMode: "first-occurrence"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
 - `requiredOrderMode: "happens-before"` requires the first before to **end** before the first after **starts**; overlap fails.
 - `requiredOrderMode: "all-occurrences"` requires every before to end before every after starts; any cross-boundary overlap or later before fails.
 - Missing interval boundaries fail closed in the two causal modes.
@@ -115,7 +117,7 @@ contract:
     required: [cache_hit_or_retrieve_evidence]
 ```
 
-With `requiredOrderMode: "first"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
+With `requiredOrderMode: "first-occurrence"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
 
 ## What is not shipped (yet)
 

--- a/docs/TRACE-CONTRACTS.md
+++ b/docs/TRACE-CONTRACTS.md
@@ -24,13 +24,14 @@ Contracts compile to deterministic check rules for common cases:
 → contract.tool.order.1: B before C
 ```
 
-Each pair compares the **first occurrence** (start/encounter order in the evaluated event stream):
+`requiredOrderMode` selects one ordering relation for every generated pair:
 
 - unlisted intermediate tools are allowed;
-- later repetitions do not invalidate an earlier valid first-occurrence order;
 - TraceContract `requiredOrder` **implies presence** — every listed name is added to the effective required-tool set;
-- this is **not** causal happens-before; overlapping intervals emit a non-failing `tool.order.overlap` warning;
-- combine ordering with `maxCalls` or custom rules when repeated calls matter.
+- `first` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
+- `happens-before` requires the first `before` occurrence to finish before the first `after` occurrence starts;
+- `all-occurrences` requires every `before` occurrence to finish before every `after` occurrence starts (`max(before.end) <= min(after.start)`);
+- causal modes fail when a required interval boundary cannot be resolved instead of falling back to encounter order.
 
 Examples for `requiredOrder: ["retrieve", "generate"]`:
 
@@ -44,6 +45,10 @@ Examples for `requiredOrder: ["retrieve", "generate"]`:
 
 Low-level `createToolOrderingRule({ before, after })` alone may still pass when an endpoint is missing (compositional). TraceContract `requiredOrder` does not.
 
+For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first` warns while `happens-before` fails.
+
+Immediate or positional `all-pairs` matching is not implemented. It requires separate occurrence-pairing and cardinality semantics.
+
 ### Experimental Vitest / Jest matchers (shipped)
 
 | Package | Export | Matchers |
@@ -55,7 +60,7 @@ These are **Experimental** — API names may evolve. There is no `expectTrace(..
 
 See [API.md](./API.md), [TRACE-FACTS.md](./TRACE-FACTS.md), and `packages/core/src/checks/contract.ts`.
 
-## Rule kinds (shipped vs planned)
+## Rule kinds (shipped and planned)
 
 TraceContract rules fall into distinct categories. Mixing them incorrectly is a common source of false failures (see GitHub #308 and #309).
 
@@ -67,16 +72,15 @@ Unconditional path invariant: every named tool must appear **at least once** in 
 - **Do not** use for steps that legitimate shortcuts may skip (for example cache hits that bypass `retrieve`).
 - When a shortcut is valid but you still need evidence of the outcome, prefer `observations.required` until `alternatives.anyOf` ships (6.20.0).
 
-### `tools.requiredOrder` (shipped — first-occurrence / start-encounter)
+### `tools.requiredOrder` (shipped — selectable ordering modes)
 
-Legacy first-start / encounter ordering. The evaluator walks the trace and checks that each listed tool's **first occurrence** appears after the previous tool's first occurrence.
+The evaluator expands each list into adjacent pairs and applies one `requiredOrderMode` to every pair.
 
 - TraceContract `requiredOrder` **implies presence** of every listed tool (unioned into `tools.required`).
-- Default mode is **first-occurrence** start/encounter order — **not** causal happens-before.
-- Overlapping intervals that still satisfy start order emit a non-failing overlap warning.
-- **Planned (6.20.0, GitHub #308):**
-  - `requiredOrderMode: "happens-before"` — first before must **end** before first after **starts**
-  - `requiredOrderMode: "all-occurrences"` — every before must end before every after starts
+- `requiredOrderMode: "first"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
+- `requiredOrderMode: "happens-before"` requires the first before to **end** before the first after **starts**; overlap fails.
+- `requiredOrderMode: "all-occurrences"` requires every before to end before every after starts; any cross-boundary overlap or later before fails.
+- Missing interval boundaries fail closed in the two causal modes.
 
 ### `observations.required` (shipped)
 
@@ -89,10 +93,8 @@ Document only; **do not** use these fields in contracts today:
 | Planned field | Purpose | GitHub |
 |---------------|---------|--------|
 | `alternatives.anyOf` | One of several deterministic valid paths (one level, no nested groups, no predicates) | #309 |
-| `requiredOrderMode: "happens-before"` | Causal completion-before-start ordering | #308 |
-| `requiredOrderMode: "all-occurrences"` | Strict ordering across all tool occurrences | #308 |
 
-API shape for both requires maintainer approval before external PR lands. @HsienW volunteered on #308 for `requiredOrderMode` implementation.
+The `alternatives.anyOf` API shape requires maintainer approval before an external PR lands.
 
 ## Workaround until 6.20.0
 
@@ -113,7 +115,7 @@ contract:
     required: [cache_hit_or_retrieve_evidence]
 ```
 
-With first-occurrence ordering, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see worked example below).
+With `requiredOrderMode: "first"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
 
 ## What is not shipped (yet)
 

--- a/docs/TRACE-CONTRACTS.md
+++ b/docs/TRACE-CONTRACTS.md
@@ -28,7 +28,7 @@ Contracts compile to deterministic check rules for common cases:
 
 - unlisted intermediate tools are allowed;
 - TraceContract `requiredOrder` **implies presence** — every listed name is added to the effective required-tool set;
-- `first` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
+- `first-occurrence` (default) compares first occurrences in start/encounter order; later repetitions do not invalidate an earlier valid order, and interval overlap emits a non-failing `tool.order.overlap` warning;
 - `happens-before` requires the first `before` occurrence to finish before the first `after` occurrence starts;
 - `all-occurrences` requires every `before` occurrence to finish before every `after` occurrence starts (`max(before.end) <= min(after.start)`);
 - causal modes fail when a required interval boundary cannot be resolved instead of falling back to encounter order.
@@ -45,9 +45,11 @@ Examples for `requiredOrder: ["retrieve", "generate"]`:
 
 Low-level `createToolOrderingRule({ before, after })` alone may still pass when an endpoint is missing (compositional). TraceContract `requiredOrder` does not.
 
-For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first` warns while `happens-before` fails.
+For the repeated trace `retrieve → generate → retrieve`, omitted mode and explicit `first-occurrence` pass, while `all-occurrences` fails because the last `retrieve` does not finish before the earliest `generate` starts. For overlapping first calls, `first-occurrence` warns while `happens-before` fails.
 
 Immediate or positional `all-pairs` matching is not implemented. It requires separate occurrence-pairing and cardinality semantics.
+
+These modes do not introduce a general temporal DSL, persisted schema changes, or network behavior.
 
 ### Experimental Vitest / Jest matchers (shipped)
 
@@ -77,7 +79,7 @@ Unconditional path invariant: every named tool must appear **at least once** in 
 The evaluator expands each list into adjacent pairs and applies one `requiredOrderMode` to every pair.
 
 - TraceContract `requiredOrder` **implies presence** of every listed tool (unioned into `tools.required`).
-- `requiredOrderMode: "first"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
+- `requiredOrderMode: "first-occurrence"` is the default first-occurrence start/encounter relation; overlapping intervals emit a non-failing warning.
 - `requiredOrderMode: "happens-before"` requires the first before to **end** before the first after **starts**; overlap fails.
 - `requiredOrderMode: "all-occurrences"` requires every before to end before every after starts; any cross-boundary overlap or later before fails.
 - Missing interval boundaries fail closed in the two causal modes.
@@ -115,7 +117,7 @@ contract:
     required: [cache_hit_or_retrieve_evidence]
 ```
 
-With `requiredOrderMode: "first"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
+With `requiredOrderMode: "first-occurrence"`, `retrieve → generate → retrieve` still **passes** when both retrieves are present (see the ordering example above). Use `all-occurrences` when every retrieve must complete before generation starts.
 
 ## What is not shipped (yet)
 

--- a/packages/core/src/checks/contract.ts
+++ b/packages/core/src/checks/contract.ts
@@ -62,25 +62,34 @@ export interface TraceContractToolRules {
   allowed?: string[];
   maxCalls?: number;
   /**
-   * Required tool order as adjacent first-occurrence pairs (start/encounter order).
+   * Required tool order expanded into adjacent pairs.
    *
    * `[A, B, C]` expands to “A before B” and “B before C”, each comparing the
-   * first occurrence of the named tool. Unlisted intermediate tools are
-   * allowed. Later repetitions do not invalidate an earlier valid order.
+   * selected `requiredOrderMode` to every pair. Unlisted intermediate tools
+   * are allowed.
    *
    * TraceContract `requiredOrder` **implies presence**: every listed name is
    * added to the effective required-tool set. Low-level `createToolOrderingRule`
    * alone may still pass vacuously when an endpoint is missing.
    *
-   * This is **not** causal happens-before. Overlapping intervals emit a
-   * non-failing overlap warning. Planned modes (6.20.0, GitHub #308):
-   * `happens-before`, `all-occurrences`.
+   * The default `first` mode preserves first-occurrence encounter ordering;
+   * overlapping intervals emit a non-failing warning. `happens-before`
+   * requires the first before event to finish before the first after event
+   * starts. `all-occurrences` applies that causal boundary to every occurrence.
    *
    * @see docs/TRACE-CONTRACTS.md
    * @beta Available through `agent-inspect/checks`. Additive changes may ship
    * in minor releases; breaking changes require a future major.
    */
   requiredOrder?: string[];
+  /**
+   * Ordering semantics applied to every adjacent pair in `requiredOrder`.
+   * Causal modes fail closed when a required interval boundary is unavailable.
+   *
+   * @defaultValue `"first"`
+   * @beta Available through `agent-inspect/checks`.
+   */
+  requiredOrderMode?: "first" | "happens-before" | "all-occurrences";
 }
 
 export interface TraceContractLlmRules {
@@ -195,6 +204,7 @@ function contractToRules(contract: TraceContract): TraceCheckRule[] {
 
   if (contract.tools) {
     const order = contract.tools.requiredOrder ?? [];
+    const requiredOrderMode = contract.tools.requiredOrderMode ?? "first";
     const required = [
       ...new Set([
         ...(contract.tools.required ?? []),
@@ -220,6 +230,7 @@ function contractToRules(contract: TraceContract): TraceCheckRule[] {
           before: order[i]!,
           after: order[i + 1]!,
           id: `contract.tool.order.${i}`,
+          mode: requiredOrderMode,
         }),
       );
     }

--- a/packages/core/src/checks/contract.ts
+++ b/packages/core/src/checks/contract.ts
@@ -72,10 +72,10 @@ export interface TraceContractToolRules {
    * added to the effective required-tool set. Low-level `createToolOrderingRule`
    * alone may still pass vacuously when an endpoint is missing.
    *
-   * The default `first` mode preserves first-occurrence encounter ordering;
-   * overlapping intervals emit a non-failing warning. `happens-before`
-   * requires the first before event to finish before the first after event
-   * starts. `all-occurrences` applies that causal boundary to every occurrence.
+   * The default `first-occurrence` mode preserves first-occurrence encounter
+   * ordering; overlapping intervals emit a non-failing warning. `happens-before`
+   * requires the first before event to finish before the first after event starts.
+   * `all-occurrences` applies that causal boundary to every occurrence.
    *
    * @see docs/TRACE-CONTRACTS.md
    * @beta Available through `agent-inspect/checks`. Additive changes may ship
@@ -86,10 +86,10 @@ export interface TraceContractToolRules {
    * Ordering semantics applied to every adjacent pair in `requiredOrder`.
    * Causal modes fail closed when a required interval boundary is unavailable.
    *
-   * @defaultValue `"first"`
+   * @defaultValue `"first-occurrence"`
    * @beta Available through `agent-inspect/checks`.
    */
-  requiredOrderMode?: "first" | "happens-before" | "all-occurrences";
+  requiredOrderMode?: "first-occurrence" | "happens-before" | "all-occurrences";
 }
 
 export interface TraceContractLlmRules {
@@ -204,7 +204,7 @@ function contractToRules(contract: TraceContract): TraceCheckRule[] {
 
   if (contract.tools) {
     const order = contract.tools.requiredOrder ?? [];
-    const requiredOrderMode = contract.tools.requiredOrderMode ?? "first";
+    const requiredOrderMode = contract.tools.requiredOrderMode ?? "first-occurrence";
     const required = [
       ...new Set([
         ...(contract.tools.required ?? []),

--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -355,6 +355,16 @@ export interface ToolOrderingRuleOptions {
    * adjacent pairs use unique ids such as `contract.tool.order.0`.
    */
   id?: string;
+  /**
+   * Ordering semantics. `first` preserves first-occurrence encounter ordering,
+   * `happens-before` requires the first before event to finish before the first
+   * after event starts, and `all-occurrences` applies that causal boundary to
+   * every matching occurrence.
+   *
+   * @defaultValue `"first"`
+   * @experimental Available through `agent-inspect/checks`.
+   */
+  mode?: "first" | "happens-before" | "all-occurrences";
 }
 
 /**
@@ -1754,6 +1764,7 @@ export function createToolUsageRule(options: ToolUsageRuleOptions): TraceCheckRu
  */
 export function createToolOrderingRule(options: ToolOrderingRuleOptions): TraceCheckRule {
   const ruleId = options.id ?? "tool.order";
+  const mode = options.mode ?? "first";
   return {
     id: ruleId,
     category: "tool",
@@ -1766,7 +1777,8 @@ export function createToolOrderingRule(options: ToolOrderingRuleOptions): TraceC
       if (beforeIndex === undefined || afterIndex === undefined) {
         return [];
       }
-      if (beforeIndex >= afterIndex) {
+
+      if (mode === "first" && beforeIndex >= afterIndex) {
         return [
           failFinding(
             ruleId,
@@ -1782,6 +1794,143 @@ export function createToolOrderingRule(options: ToolOrderingRuleOptions): TraceC
       const afterEvent = tools[afterIndex]!;
       const beforeEnd = eventEndMs(beforeEvent);
       const afterStart = eventStartMs(afterEvent);
+
+      if (mode === "happens-before") {
+        const expected = {
+          before: options.before,
+          after: options.after,
+          mode,
+          relation: "before.end <= after.start",
+        };
+        if (options.before === options.after) {
+          return [
+            failFinding(
+              ruleId,
+              `Tool ${options.before} cannot causally happen before itself.`,
+              [eventEvidence(beforeEvent)],
+              expected,
+              { code: "tool.order.same-tool" },
+            ),
+          ];
+        }
+        if (beforeEnd === undefined || afterStart === undefined) {
+          return [
+            failFinding(
+              ruleId,
+              `Tool order ${options.before} before ${options.after} could not establish causal timing.`,
+              [eventEvidence(beforeEvent), eventEvidence(afterEvent)],
+              expected,
+              {
+                code: "tool.order.interval-unresolved",
+                beforeEndResolved: beforeEnd !== undefined,
+                afterStartResolved: afterStart !== undefined,
+              },
+            ),
+          ];
+        }
+        if (beforeEnd > afterStart) {
+          return [
+            failFinding(
+              ruleId,
+              `Tool ${options.before} must finish before ${options.after} starts.`,
+              [eventEvidence(beforeEvent), eventEvidence(afterEvent)],
+              expected,
+              {
+                beforeEndedAt: new Date(beforeEnd).toISOString(),
+                afterStartedAt: new Date(afterStart).toISOString(),
+              },
+            ),
+          ];
+        }
+        return [];
+      }
+
+      if (mode === "all-occurrences") {
+        const beforeEvents = tools.filter((event) => toolName(event) === options.before);
+        const afterEvents = tools.filter((event) => toolName(event) === options.after);
+        const expected = {
+          before: options.before,
+          after: options.after,
+          mode,
+          relation: "max(before.end) <= min(after.start)",
+        };
+        if (options.before === options.after) {
+          return [
+            failFinding(
+              ruleId,
+              `Tool ${options.before} cannot causally happen before itself.`,
+              [eventEvidence(beforeEvent)],
+              expected,
+              { code: "tool.order.same-tool" },
+            ),
+          ];
+        }
+
+        let latestBefore: { event: PersistedInspectEvent; end: number } | undefined;
+        let earliestAfter: { event: PersistedInspectEvent; start: number } | undefined;
+        let missingBeforeEnds = 0;
+        let missingAfterStarts = 0;
+        let firstMissingBefore: PersistedInspectEvent | undefined;
+        let firstMissingAfter: PersistedInspectEvent | undefined;
+
+        for (const event of beforeEvents) {
+          const end = eventEndMs(event);
+          if (end === undefined) {
+            missingBeforeEnds += 1;
+            firstMissingBefore ??= event;
+          } else if (latestBefore === undefined || end > latestBefore.end) {
+            latestBefore = { event, end };
+          }
+        }
+        for (const event of afterEvents) {
+          const start = eventStartMs(event);
+          if (start === undefined) {
+            missingAfterStarts += 1;
+            firstMissingAfter ??= event;
+          } else if (earliestAfter === undefined || start < earliestAfter.start) {
+            earliestAfter = { event, start };
+          }
+        }
+
+        if (
+          missingBeforeEnds > 0 ||
+          missingAfterStarts > 0 ||
+          latestBefore === undefined ||
+          earliestAfter === undefined
+        ) {
+          return [
+            failFinding(
+              ruleId,
+              `Tool order ${options.before} before ${options.after} could not establish all causal intervals.`,
+              [firstMissingBefore, firstMissingAfter]
+                .filter((event): event is PersistedInspectEvent => event !== undefined)
+                .map((event) => eventEvidence(event)),
+              expected,
+              {
+                code: "tool.order.interval-unresolved",
+                missingBeforeEnds,
+                missingAfterStarts,
+              },
+            ),
+          ];
+        }
+        if (latestBefore.end > earliestAfter.start) {
+          return [
+            failFinding(
+              ruleId,
+              `Every ${options.before} tool call must finish before any ${options.after} tool call starts.`,
+              [eventEvidence(latestBefore.event), eventEvidence(earliestAfter.event)],
+              expected,
+              {
+                latestBeforeEndedAt: new Date(latestBefore.end).toISOString(),
+                earliestAfterStartedAt: new Date(earliestAfter.start).toISOString(),
+              },
+            ),
+          ];
+        }
+        return [];
+      }
+
       if (
         beforeEnd !== undefined &&
         afterStart !== undefined &&

--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -356,15 +356,15 @@ export interface ToolOrderingRuleOptions {
    */
   id?: string;
   /**
-   * Ordering semantics. `first` preserves first-occurrence encounter ordering,
-   * `happens-before` requires the first before event to finish before the first
-   * after event starts, and `all-occurrences` applies that causal boundary to
-   * every matching occurrence.
+   * Ordering semantics. `first-occurrence` preserves first-occurrence encounter
+   * ordering, `happens-before` requires the first before event to finish before
+   * the first after event starts, and `all-occurrences` applies that causal
+   * boundary to every matching occurrence.
    *
-   * @defaultValue `"first"`
+   * @defaultValue `"first-occurrence"`
    * @experimental Available through `agent-inspect/checks`.
    */
-  mode?: "first" | "happens-before" | "all-occurrences";
+  mode?: "first-occurrence" | "happens-before" | "all-occurrences";
 }
 
 /**
@@ -1764,7 +1764,7 @@ export function createToolUsageRule(options: ToolUsageRuleOptions): TraceCheckRu
  */
 export function createToolOrderingRule(options: ToolOrderingRuleOptions): TraceCheckRule {
   const ruleId = options.id ?? "tool.order";
-  const mode = options.mode ?? "first";
+  const mode = options.mode ?? "first-occurrence";
   return {
     id: ruleId,
     category: "tool",
@@ -1778,7 +1778,7 @@ export function createToolOrderingRule(options: ToolOrderingRuleOptions): TraceC
         return [];
       }
 
-      if (mode === "first" && beforeIndex >= afterIndex) {
+      if (mode === "first-occurrence" && beforeIndex >= afterIndex) {
         return [
           failFinding(
             ruleId,

--- a/packages/core/test/checks.test.ts
+++ b/packages/core/test/checks.test.ts
@@ -422,11 +422,15 @@ describe("built-in run, tool, and LLM checks", () => {
       { read },
       { rules: [createToolOrderingRule({ before: "retrieve", after: "generate" })] },
     );
-    const explicitFirst = runTraceChecks(
+    const explicitFirstOccurrence = runTraceChecks(
       { read },
       {
         rules: [
-          createToolOrderingRule({ before: "retrieve", after: "generate", mode: "first" }),
+          createToolOrderingRule({
+            before: "retrieve",
+            after: "generate",
+            mode: "first-occurrence",
+          }),
         ],
       },
     );
@@ -445,7 +449,7 @@ describe("built-in run, tool, and LLM checks", () => {
 
     expect(defaultResult.status).toBe("pass");
     expect(defaultResult.findings[0]?.actual).toMatchObject({ code: "tool.order.overlap" });
-    expect(explicitFirst.findings).toEqual(defaultResult.findings);
+    expect(explicitFirstOccurrence.findings).toEqual(defaultResult.findings);
     expect(happensBefore.status).toBe("fail");
     expect(happensBefore.findings[0]).toMatchObject({
       ruleId: "tool.order",

--- a/packages/core/test/checks.test.ts
+++ b/packages/core/test/checks.test.ts
@@ -399,6 +399,205 @@ describe("built-in run, tool, and LLM checks", () => {
     expect(missingBefore.status).toBe("pass");
   });
 
+  it("supports causal first-occurrence ordering without changing default overlap warnings", () => {
+    const retrieve = persisted("causal-retrieve", {
+      kind: "TOOL",
+      name: "tool:retrieve",
+      attributes: { toolName: "retrieve" },
+      timestamp: "2026-06-26T00:00:00.000Z",
+      startedAt: "2026-06-26T00:00:00.000Z",
+      endedAt: "2026-06-26T00:00:03.000Z",
+    });
+    const generate = persisted("causal-generate", {
+      kind: "TOOL",
+      name: "tool:generate",
+      attributes: { toolName: "generate" },
+      timestamp: "2026-06-26T00:00:02.000Z",
+      startedAt: "2026-06-26T00:00:02.000Z",
+      endedAt: "2026-06-26T00:00:04.000Z",
+    });
+    const read = readResult([retrieve, generate]);
+
+    const defaultResult = runTraceChecks(
+      { read },
+      { rules: [createToolOrderingRule({ before: "retrieve", after: "generate" })] },
+    );
+    const explicitFirst = runTraceChecks(
+      { read },
+      {
+        rules: [
+          createToolOrderingRule({ before: "retrieve", after: "generate", mode: "first" }),
+        ],
+      },
+    );
+    const happensBefore = runTraceChecks(
+      { read },
+      {
+        rules: [
+          createToolOrderingRule({
+            before: "retrieve",
+            after: "generate",
+            mode: "happens-before",
+          }),
+        ],
+      },
+    );
+
+    expect(defaultResult.status).toBe("pass");
+    expect(defaultResult.findings[0]?.actual).toMatchObject({ code: "tool.order.overlap" });
+    expect(explicitFirst.findings).toEqual(defaultResult.findings);
+    expect(happensBefore.status).toBe("fail");
+    expect(happensBefore.findings[0]).toMatchObject({
+      ruleId: "tool.order",
+      status: "fail",
+      expected: { mode: "happens-before", relation: "before.end <= after.start" },
+      actual: {
+        beforeEndedAt: "2026-06-26T00:00:03.000Z",
+        afterStartedAt: "2026-06-26T00:00:02.000Z",
+      },
+    });
+
+    const exactBoundary = runTraceChecks(
+      {
+        read: readResult([
+          { ...retrieve, endedAt: "2026-06-26T00:00:02.000Z" },
+          generate,
+        ]),
+      },
+      {
+        rules: [
+          createToolOrderingRule({
+            before: "retrieve",
+            after: "generate",
+            mode: "happens-before",
+          }),
+        ],
+      },
+    );
+    expect(exactBoundary.status).toBe("pass");
+  });
+
+  it("enforces all-occurrences ordering and fails closed on missing causal intervals", () => {
+    const retrieve1 = persisted("all-retrieve-1", {
+      kind: "TOOL",
+      name: "tool:retrieve",
+      attributes: { toolName: "retrieve" },
+      timestamp: "2026-06-26T00:00:00.000Z",
+      startedAt: "2026-06-26T00:00:00.000Z",
+      endedAt: "2026-06-26T00:00:01.000Z",
+    });
+    const generate = persisted("all-generate", {
+      kind: "TOOL",
+      name: "tool:generate",
+      attributes: { toolName: "generate" },
+      timestamp: "2026-06-26T00:00:02.000Z",
+      startedAt: "2026-06-26T00:00:02.000Z",
+      endedAt: "2026-06-26T00:00:03.000Z",
+    });
+    const retrieve2 = persisted("all-retrieve-2", {
+      kind: "TOOL",
+      name: "tool:retrieve",
+      attributes: { toolName: "retrieve" },
+      timestamp: "2026-06-26T00:00:04.000Z",
+      startedAt: "2026-06-26T00:00:04.000Z",
+      endedAt: "2026-06-26T00:00:05.000Z",
+    });
+    const repeated = runTraceChecks(
+      { read: readResult([retrieve1, generate, retrieve2]) },
+      {
+        rules: [
+          createToolOrderingRule({
+            before: "retrieve",
+            after: "generate",
+            mode: "all-occurrences",
+          }),
+        ],
+      },
+    );
+    expect(repeated.status).toBe("fail");
+    expect(repeated.findings[0]).toMatchObject({
+      expected: { mode: "all-occurrences", relation: "max(before.end) <= min(after.start)" },
+      actual: {
+        latestBeforeEndedAt: "2026-06-26T00:00:05.000Z",
+        earliestAfterStartedAt: "2026-06-26T00:00:02.000Z",
+      },
+      evidence: [{ eventId: "all-retrieve-2" }, { eventId: "all-generate" }],
+    });
+
+    const valid = runTraceChecks(
+      {
+        read: readResult([
+          retrieve1,
+          {
+            ...retrieve2,
+            timestamp: "2026-06-26T00:00:01.000Z",
+            startedAt: "2026-06-26T00:00:01.000Z",
+            endedAt: "2026-06-26T00:00:02.000Z",
+          },
+          {
+            ...generate,
+            timestamp: "2026-06-26T00:00:02.000Z",
+            startedAt: "2026-06-26T00:00:02.000Z",
+          },
+        ]),
+      },
+      {
+        rules: [
+          createToolOrderingRule({
+            before: "retrieve",
+            after: "generate",
+            mode: "all-occurrences",
+          }),
+        ],
+      },
+    );
+    expect(valid.status).toBe("pass");
+
+    const unresolvedRetrieve = persisted("unresolved-retrieve", {
+      kind: "TOOL",
+      name: "tool:retrieve",
+      attributes: { toolName: "retrieve" },
+      timestamp: "2026-06-26T00:00:00.000Z",
+    });
+    for (const mode of ["happens-before", "all-occurrences"] as const) {
+      const unresolved = runTraceChecks(
+        { read: readResult([unresolvedRetrieve, generate]) },
+        { rules: [createToolOrderingRule({ before: "retrieve", after: "generate", mode })] },
+      );
+      expect(unresolved.status).toBe("fail");
+      expect(unresolved.findings[0]?.actual).toMatchObject({
+        code: "tool.order.interval-unresolved",
+      });
+
+      const missingEndpoint = runTraceChecks(
+        { read: readResult([generate]) },
+        { rules: [createToolOrderingRule({ before: "retrieve", after: "generate", mode })] },
+      );
+      expect(missingEndpoint.status).toBe("pass");
+      expect(missingEndpoint.findings).toEqual([]);
+    }
+  });
+
+  it("fails causal same-tool ordering deterministically", () => {
+    const retrieve = persisted("same-retrieve", {
+      kind: "TOOL",
+      name: "tool:retrieve",
+      attributes: { toolName: "retrieve" },
+      timestamp: "2026-06-26T00:00:00.000Z",
+      startedAt: "2026-06-26T00:00:00.000Z",
+      endedAt: "2026-06-26T00:00:00.000Z",
+    });
+
+    for (const mode of ["happens-before", "all-occurrences"] as const) {
+      const result = runTraceChecks(
+        { read: readResult([retrieve]) },
+        { rules: [createToolOrderingRule({ before: "retrieve", after: "retrieve", mode })] },
+      );
+      expect(result.status).toBe("fail");
+      expect(result.findings[0]?.actual).toMatchObject({ code: "tool.order.same-tool" });
+    }
+  });
+
   it("reports required, forbidden, allowed, ordered, failed, and retried tool violations", () => {
     const forbidden = persisted("event-a", {
       kind: "TOOL",

--- a/packages/core/test/checks/contract.test.ts
+++ b/packages/core/test/checks/contract.test.ts
@@ -26,6 +26,22 @@ function persisted(
   };
 }
 
+function tool(
+  eventId: string,
+  name: string,
+  startedAt: string,
+  endedAt: string,
+): PersistedInspectEvent {
+  return persisted(eventId, {
+    kind: "TOOL",
+    name: `tool:${name}`,
+    attributes: { toolName: name },
+    timestamp: startedAt,
+    startedAt,
+    endedAt,
+  });
+}
+
 function node(event: PersistedInspectEvent): InspectNode {
   return {
     event: {
@@ -174,6 +190,170 @@ describe("trace contract", () => {
       const failed = failFindings(result);
       expect(failed).toHaveLength(1);
       expect(failed[0]?.message).toContain("incomplete running events");
+    });
+  });
+
+  describe("tools.requiredOrder modes", () => {
+    const retrieve1 = tool(
+      "retrieve-1",
+      "retrieve",
+      "2026-07-11T00:00:00.000Z",
+      "2026-07-11T00:00:01.000Z",
+    );
+    const generate = tool(
+      "generate-1",
+      "generate",
+      "2026-07-11T00:00:02.000Z",
+      "2026-07-11T00:00:03.000Z",
+    );
+    const retrieve2 = tool(
+      "retrieve-2",
+      "retrieve",
+      "2026-07-11T00:00:04.000Z",
+      "2026-07-11T00:00:05.000Z",
+    );
+
+    it("preserves omitted-mode and explicit first semantics for repeated calls", () => {
+      const read = readResult("ok", [retrieve1, generate, retrieve2]);
+      const omitted = evaluateTraceContract(
+        { read },
+        defineTraceContract({ tools: { requiredOrder: ["retrieve", "generate"] } }),
+      );
+      const explicit = evaluateTraceContract(
+        { read },
+        defineTraceContract({
+          tools: { requiredOrder: ["retrieve", "generate"], requiredOrderMode: "first" },
+        }),
+      );
+
+      expect(omitted.status).toBe("pass");
+      expect(explicit.findings).toEqual(omitted.findings);
+      expect(explicit.ruleExecutions).toEqual(omitted.ruleExecutions);
+    });
+
+    it("propagates causal modes to the generated adjacent rule", () => {
+      const overlapGenerate = {
+        ...generate,
+        startedAt: "2026-07-11T00:00:00.500Z",
+        timestamp: "2026-07-11T00:00:00.500Z",
+      };
+      const happensBefore = evaluateTraceContract(
+        { read: readResult("ok", [retrieve1, overlapGenerate]) },
+        defineTraceContract({
+          tools: {
+            requiredOrder: ["retrieve", "generate"],
+            requiredOrderMode: "happens-before",
+          },
+        }),
+      );
+      const allOccurrences = evaluateTraceContract(
+        { read: readResult("ok", [retrieve1, generate, retrieve2]) },
+        defineTraceContract({
+          tools: {
+            requiredOrder: ["retrieve", "generate"],
+            requiredOrderMode: "all-occurrences",
+          },
+        }),
+      );
+
+      expect(failFindings(happensBefore)).toEqual([
+        expect.objectContaining({
+          ruleId: "contract.tool.order.0",
+          expected: expect.objectContaining({ mode: "happens-before" }),
+        }),
+      ]);
+      expect(failFindings(allOccurrences)).toEqual([
+        expect.objectContaining({
+          ruleId: "contract.tool.order.0",
+          expected: expect.objectContaining({ mode: "all-occurrences" }),
+        }),
+      ]);
+    });
+
+    it("keeps requiredOrder implied presence in every mode", () => {
+      for (const mode of ["first", "happens-before", "all-occurrences"] as const) {
+        const result = evaluateTraceContract(
+          { read: readResult("ok", [generate]) },
+          defineTraceContract({
+            tools: { requiredOrder: ["retrieve", "generate"], requiredOrderMode: mode },
+          }),
+        );
+        expect(result.status).toBe("fail");
+        expect(failFindings(result).map((finding) => finding.ruleId)).toContain("tool.usage");
+        expect(failFindings(result).map((finding) => finding.ruleId)).not.toContain(
+          "contract.tool.order.0",
+        );
+      }
+    });
+
+    it("applies all-occurrences mode independently to every adjacent pair", () => {
+      const a1 = tool(
+        "a-1",
+        "a",
+        "2026-07-11T00:00:00.000Z",
+        "2026-07-11T00:00:01.000Z",
+      );
+      const b1 = tool(
+        "b-1",
+        "b",
+        "2026-07-11T00:00:02.000Z",
+        "2026-07-11T00:00:03.000Z",
+      );
+      const c1 = tool(
+        "c-1",
+        "c",
+        "2026-07-11T00:00:04.000Z",
+        "2026-07-11T00:00:05.000Z",
+      );
+      const contract = defineTraceContract({
+        tools: {
+          requiredOrder: ["a", "b", "c"],
+          requiredOrderMode: "all-occurrences",
+        },
+      });
+
+      const firstPairFails = evaluateTraceContract(
+        {
+          read: readResult("ok", [
+            a1,
+            b1,
+            tool(
+              "a-2",
+              "a",
+              "2026-07-11T00:00:06.000Z",
+              "2026-07-11T00:00:07.000Z",
+            ),
+            c1,
+          ]),
+        },
+        contract,
+      );
+      const secondPairFails = evaluateTraceContract(
+        {
+          read: readResult("ok", [
+            a1,
+            b1,
+            c1,
+            tool(
+              "b-2",
+              "b",
+              "2026-07-11T00:00:06.000Z",
+              "2026-07-11T00:00:07.000Z",
+            ),
+          ]),
+        },
+        contract,
+      );
+
+      expect(failFindings(firstPairFails).map((finding) => finding.ruleId)).toEqual([
+        "contract.tool.order.0",
+      ]);
+      expect(failFindings(secondPairFails).map((finding) => finding.ruleId)).toEqual([
+        "contract.tool.order.1",
+      ]);
+      expect(firstPairFails.ruleExecutions.map((execution) => execution.ruleId)).toEqual(
+        expect.arrayContaining(["contract.tool.order.0", "contract.tool.order.1"]),
+      );
     });
   });
 });

--- a/packages/core/test/checks/contract.test.ts
+++ b/packages/core/test/checks/contract.test.ts
@@ -213,7 +213,7 @@ describe("trace contract", () => {
       "2026-07-11T00:00:05.000Z",
     );
 
-    it("preserves omitted-mode and explicit first semantics for repeated calls", () => {
+    it("preserves omitted-mode and explicit first-occurrence semantics for repeated calls", () => {
       const read = readResult("ok", [retrieve1, generate, retrieve2]);
       const omitted = evaluateTraceContract(
         { read },
@@ -222,7 +222,10 @@ describe("trace contract", () => {
       const explicit = evaluateTraceContract(
         { read },
         defineTraceContract({
-          tools: { requiredOrder: ["retrieve", "generate"], requiredOrderMode: "first" },
+          tools: {
+            requiredOrder: ["retrieve", "generate"],
+            requiredOrderMode: "first-occurrence",
+          },
         }),
       );
 
@@ -271,7 +274,11 @@ describe("trace contract", () => {
     });
 
     it("keeps requiredOrder implied presence in every mode", () => {
-      for (const mode of ["first", "happens-before", "all-occurrences"] as const) {
+      for (const mode of [
+        "first-occurrence",
+        "happens-before",
+        "all-occurrences",
+      ] as const) {
         const result = evaluateTraceContract(
           { read: readResult("ok", [generate]) },
           defineTraceContract({


### PR DESCRIPTION
## Summary

- Add opt in `happens-before` and `all-occurrences` modes for `requiredOrder` while preserving the existing first occurrence behavior as the default.

- The new modes reuse the existing tool interval timing, implied presence, and unique adjacent rule IDs without changing the `requiredOrder: string[]` shape, persisted schemas, or runtime behavior.

```ts
requiredOrderMode: "happens-before"
```
- requires the first earlier tool occurrence to finish before the first later tool occurrence starts.
```ts
requiredOrderMode: "all-occurrences"
```
- requires every earlier tool occurrence to finish before every later tool occurrence starts.

- For multi tool chains, the selected mode is propagated to each adjacent ordering rule while preserving the current contract.tool.order.N IDs.

- The default behavior remains unchanged. First occurrence encounter ordering still applies when no mode is supplied, interval overlap remains a non failing warning, and low level createToolOrderingRule() checks remain compositional when either endpoint is absent.

- Focused regression coverage locks causal ordering, repeated calls, overlap handling, multi step chains, unique rule IDs, and TraceContract implied presence semantics.

**Linked issue (required):** #308

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [x] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan maintainer approval required)

## Reproduction / evidence

The existing default remains compatible with repeated calls such as:

```text
retrieve
generate
retrieve
```

With no `requiredOrderMode`, the first `retrieve` still precedes the first `generate`, so the ordering check passes.

With:

```ts
requiredOrderMode: "happens-before"
```

the first matching pair must satisfy:

```text
end(first retrieve) <= start(first generate)
```

An interval overlap that remains a warning under the default mode becomes a failure when `happens-before` is explicitly requested.

With:

```ts
requiredOrderMode: "all-occurrences"
```

the ordering requirement becomes:

```text
max(end(all retrieve calls)) <= min(start(all generate calls))
```

This catches repeated call cases where a later `retrieve` does not finish before generation begins.

For a longer contract:

```ts
requiredOrder: ["retrieve", "rerank", "generate"],
requiredOrderMode: "all-occurrences",
```

the selected mode is propagated to both existing adjacent rules:

```text
contract.tool.order.0
retrieve -> rerank

contract.tool.order.1
rerank -> generate
```

The focused regressions cover:

- existing first occurrence behavior
- explicit causal ordering
- interval overlap handling
- repeated calls
- multi step ordering chains
- implied presence at the TraceContract layer
- unique adjacent rule IDs
- low level missing endpoint behavior

<img width="766" height="165" alt="螢幕擷取畫面 2026-09-01 185505" src="https://github.com/user-attachments/assets/fabd5cbe-1523-4b6a-8660-40ea6553fa33" />

## Product boundaries (check all that apply)

- [x] Local-first only no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli` — ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

The final diff is limited to:

```text
packages/core/src/checks/index.ts
packages/core/src/checks/contract.ts
packages/core/test/checks.test.ts
packages/core/test/checks/contract.test.ts
docs/TRACE-CONTRACTS.md
apps/website/public/docs/trace-contracts.md
```

No package export surface, dependency, adapter, persisted schema, or runtime network behavior is changed.

## Validation

```bash
pnpm exec vitest run packages/core/test/checks.test.ts packages/core/test/checks/contract.test.ts
# passed, 37/37 tests

pnpm typecheck
# passed

# Core ESM / CJS / DTS build
# passed

git diff --check
# clean

pnpm test:all
# 267/268 test files passed
# 1934/1935 tests passed
```

The remaining `test:all` failure is isolated to the untouched Windows case:

```text
packages/core/test/public-truth-sync.test.ts
demo-verify fail-closed
fails with AI_DEMO_VERIFY_CLI_MISSING when CLI dist is absent
```

That test expected a nonzero process status but received `0`.

This PR does not modify `packages/core/test/public-truth-sync.test.ts` or the demo verification path.

## Data safety

- [x] Synthetic data only no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets** maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes (`docs/TRACE-CONTRACTS.md` and the mirrored website TraceContract docs)
- [x] `git diff --check` clean