### PR TITLE
docs(mcp-server): add Glama score badge

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -5,6 +5,8 @@ Read-only MCP server for the **local coding-agent debug loop**: list runs, summa
 
 **Support level:** Preview — see [SUPPORT-LEVELS.md](https://github.com/rajudandigam/agent-inspect/blob/main/docs/SUPPORT-LEVELS.md).
 
+[![agent-inspect MCP server](https://glama.ai/mcp/servers/rajudandigam/agent-inspect/badges/score.svg)](https://glama.ai/mcp/servers/rajudandigam/agent-inspect)
+
 ## When to use
 
 - Let Cursor, Claude Code, Codex, Gemini, or other MCP clients inspect local `.agent-inspect/` evidence


### PR DESCRIPTION
Adds the Glama score badge for the AgentInspect MCP server to  (docs-only).