### PR TITLE
docs(evidence): add reproducible repair evidence recipe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 examples/evidence/**/evidence/*.json text eol=lf
 examples/evidence/**/evidence/*.jsonl text eol=lf
 examples/evidence/**/evidence/*.html text eol=lf
+examples/recipes/reproducible-repair-evidence/fixtures/*.json text eol=lf
+examples/recipes/reproducible-repair-evidence/fixtures/*.jsonl text eol=lf
+examples/recipes/reproducible-repair-evidence/fixtures/*.txt text eol=lf
+examples/recipes/reproducible-repair-evidence/fixtures/*.patch text eol=lf

--- a/docs/SUPPORT-REPRODUCTION.md
+++ b/docs/SUPPORT-REPRODUCTION.md
@@ -21,6 +21,8 @@ Use these sources in order of preference:
 
 Remove unrelated runs, prompts, tool calls, and metadata before creating the bundle. The existing [shareable bundle recipe](../examples/recipes/shareable-bundle-basic/README.md) demonstrates the same Evidence v2 workflow; no separate support script is required.
 
+For repository repair or debugging handoffs, the [reproducible repair evidence recipe](../examples/recipes/reproducible-repair-evidence/README.md) shows how callers can integrity-bind a repository revision, validation procedure, proposed patch, and recorded validation output as Evidence v2 files. This caller-owned envelope is optional and does not make Evidence verification a replay or repair-correctness check.
+
 ## Create the reproduction bundle
 
 List local runs and identify the minimized reproduction:

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -38,7 +38,7 @@ Pick by the job you are doing. Every cell below is derived from the recipe's own
 [NETWORK-BEHAVIOR.md](../../docs/NETWORK-BEHAVIOR.md) — nothing here is asserted
 independently of those sources.
 
-**All 40 recipes need no API key and make no network calls.** They are mocks-only and
+**All 42 recipes need no API key and make no network calls.** They are mocks-only and
 local by construction; the two MCP rows note where network enters once a recipe is
 pointed at something real, per NETWORK-BEHAVIOR.md.
 
@@ -75,6 +75,7 @@ pointed at something real, per NETWORK-BEHAVIOR.md.
 | [rag-pipeline](rag-pipeline) | Debug a RAG pipeline | `agent-inspect` | No | No network | Stable | `pnpm --filter agent-inspect-recipe-rag-pipeline start` |
 | [read-only-mcp-server](read-only-mcp-server) | Read evidence through MCP | `@agent-inspect/mcp-server`<br>`agent-inspect` | No | Exposes local evidence to a connected client (share-profile boundary) | Preview | `pnpm --filter agent-inspect-recipe-read-only-mcp-server start` |
 | [redact-share-safe-file](redact-share-safe-file) | Share a trace safely | `@agent-inspect/redact` | No | No network | Stable | `pnpm --filter agent-inspect-recipe-redact-share-safe-file start` |
+| [reproducible-repair-evidence](reproducible-repair-evidence) | Bind repository repair provenance to Evidence v2 | `agent-inspect/advanced` | No | No network | Supported <sup>Workspace / bundles / observed outcomes / Evidence v2</sup> | `pnpm --filter agent-inspect-recipe-reproducible-repair-evidence start` |
 | [retry-fallback](retry-fallback) | Understand model fallback | `agent-inspect` | No | No network | Stable | `pnpm --filter agent-inspect-recipe-retry-fallback start` |
 | [runtime-and-ingestion](runtime-and-ingestion) | Ingest traces from any format | `agent-inspect` | No | No network | Stable | `pnpm --filter agent-inspect-recipe-runtime-and-ingestion start` |
 | [shareable-bundle-basic](shareable-bundle-basic) | Build a shareable bundle | `agent-inspect` | No | No network | Supported <sup>Workspace / bundles / observed outcomes / Evidence v2</sup> | `pnpm --filter agent-inspect-recipe-shareable-bundle-basic start` |
@@ -128,6 +129,7 @@ each package README's `**Support level:**` line, except where a recipe uses a fe
 | [guardrails-basic](guardrails-basic) | v2.5 deterministic guardrail samples | `@agent-inspect/guardrails`, phrase/PII/injection rules | yes | no |
 | [circuit-breaker-basic](circuit-breaker-basic) | v2.5 circuit repetition analysis | `@agent-inspect/circuit`, tool/args repetition | yes | no |
 | [read-only-mcp-server](read-only-mcp-server) | v2.6 read-only MCP trace tools | `@agent-inspect/mcp-server`, list/search/check tools | yes | no |
+| [reproducible-repair-evidence](reproducible-repair-evidence) | Bind caller-owned repository repair provenance | Evidence v2 manifest, source and artifact hashes, integrity verification | yes | no |
 | [workspace-basic](workspace-basic) | v4.0 local trace workspace | `agent-inspect/workspace`, create/status | yes | no |
 
 ## Multi-run sessions (v2.4)

--- a/examples/recipes/reproducible-repair-evidence/.gitignore
+++ b/examples/recipes/reproducible-repair-evidence/.gitignore
@@ -1,0 +1,1 @@
+.generated-evidence/

--- a/examples/recipes/reproducible-repair-evidence/README.md
+++ b/examples/recipes/reproducible-repair-evidence/README.md
@@ -1,0 +1,110 @@
+# Reproducible repair evidence
+
+This recipe packages a failed synthetic trace together with caller-owned repository and validation context as Evidence v2. It uses the public `agent-inspect/advanced` API, performs no network I/O, and needs no API key.
+
+## What this demonstrates
+
+Two repository revisions can produce the same structural failure trajectory while a proposed patch only applies in one checkout. A normal Evidence bundle can be internally valid in either case. This recipe packages the repository revision, validation procedure, proposed patch, and recorded check output so the Evidence manifest integrity-binds the exact repair context to the trace.
+
+`reproduction.json` is an illustrative, recipe-owned envelope. It is not an AgentInspect persisted schema, public interface, or canonical repair manifest format.
+
+## Why bundle integrity alone is insufficient
+
+Integrity verification confirms that the packaged files match `evidence.json`. It does not checkout the repository revision, recreate a dirty working tree, apply `repair.patch`, execute the recorded validation command, or certify replay or repair correctness.
+
+The executable assertion keeps the failed trace unchanged while replacing only the synthetic repository commit in memory. The failed trace hash remains the same, while the `reproduction.json` hash and serialized Evidence manifest change.
+
+## How to run
+
+From the repository root:
+
+```bash
+pnpm build
+pnpm --filter agent-inspect-recipe-reproducible-repair-evidence start
+```
+
+## Expected output
+
+```text
+Reproducible repair evidence: pass
+Run: repair-example-run
+Files checked: 4
+Bound artifacts: check-output.txt, failed-trace.jsonl, repair.patch, reproduction.json
+Revision binding: pass
+Environment allowlist: 0 variables
+Replay executed: no
+Evidence directory: .generated-evidence
+```
+
+## Artifacts
+
+The generated `.generated-evidence/` directory contains:
+
+- `failed-trace.jsonl`: the fixed failed synthetic trajectory.
+- `reproduction.json`: caller-owned repository, validation, toolchain, lockfile, environment, and sandbox context.
+- `repair.patch`: a fixed synthetic unified diff.
+- `check-output.txt`: recorded synthetic validation output; the recipe does not execute the command.
+- `evidence.json`: the Evidence v2 manifest that hashes the four artifacts.
+
+All paths inside the fixtures are relative. Fixed timestamps, IDs, versions, bytes, and file ordering keep the generated manifest deterministic.
+
+## Reproduction envelope
+
+The fixture records a synthetic commit, clean working-tree flag, exact command and arguments, relative working directory, exit code, timeout, fixed toolchain versions, and synthetic lockfile hash. A real repair harness can add its own bounded dirty-tree digest when the dirty state materially affects reproduction; this recipe deliberately does not define such a digest algorithm.
+
+## Environment allowlist
+
+This synthetic recipe allowlists no environment variables:
+
+```json
+{
+  "allowlist": [],
+  "values": {}
+}
+```
+
+Real harnesses should record only variables that materially affect reproduction. The allowlist must be explicit: never capture `process.env` wholesale, `PATH`, home-directory variables, tokens, or provider keys.
+
+## Revision-A / revision-B walkthrough
+
+The committed `reproduction.json` represents revision A. The recipe clones it in memory, substitutes a second fixed synthetic commit for revision B, and builds a second manifest without writing another Evidence directory. It asserts that the trace hash is identical and the reproduction artifact hash differs. This proves revision binding, not patch applicability.
+
+## Integrity verification walkthrough
+
+The recipe calls `verifyEvidenceDirectory(...)` programmatically. From this recipe directory, the generated directory can also be checked with the existing CLI:
+
+```bash
+npx agent-inspect bundle verify ./.generated-evidence
+```
+
+This verifies the manifest shape, listed-file presence, hashes, and Evidence provenance fields. `bundle verify` does not replay the repair.
+
+## Patch-digest-only variant
+
+This example packages `repair.patch`. When packaging the patch itself is inappropriate, a harness can instead put a caller-owned patch digest in `reproduction.json`. AgentInspect will integrity-bind that file but does not define or validate patch semantics.
+
+## Sandbox/container metadata
+
+`sandbox` is `null` because this synthetic fixture uses no container. When execution depends on a sandbox, callers can record bounded metadata such as:
+
+```json
+{
+  "sandbox": {
+    "containerImageDigest": "sha256:00131015cd6b7056cb5a327581fb48ebc9aef1f1f6384f2a440a59cca1348bcf",
+    "resourceLimits": {
+      "cpu": 2,
+      "memoryBytes": 2147483648
+    }
+  }
+}
+```
+
+This remains caller-owned metadata; AgentInspect does not inspect the host or validate the container digest.
+
+## What this does not prove
+
+The recipe does not checkout a revision, snapshot a repository, reconstruct dirty state, apply a patch, install packages, run the recorded command, create a sandbox, upload Evidence, or claim that a repair is correct or replayable.
+
+## Windows notes
+
+The recipe uses Node.js APIs and `import.meta.url`; it requires no Bash, `chmod`, Docker, shell pipeline, or Unix temporary path. `.gitattributes` pins every hashed fixture to LF so Evidence hashes remain stable across platforms.

--- a/examples/recipes/reproducible-repair-evidence/expected-output.txt
+++ b/examples/recipes/reproducible-repair-evidence/expected-output.txt
@@ -1,0 +1,8 @@
+Reproducible repair evidence: pass
+Run: repair-example-run
+Files checked: 4
+Bound artifacts: check-output.txt, failed-trace.jsonl, repair.patch, reproduction.json
+Revision binding: pass
+Environment allowlist: 0 variables
+Replay executed: no
+Evidence directory: .generated-evidence

--- a/examples/recipes/reproducible-repair-evidence/fixtures/check-output.txt
+++ b/examples/recipes/reproducible-repair-evidence/fixtures/check-output.txt
@@ -1,0 +1,2 @@
+PASS synthetic repair validation
+1 check passed

--- a/examples/recipes/reproducible-repair-evidence/fixtures/failed-trace.jsonl
+++ b/examples/recipes/reproducible-repair-evidence/fixtures/failed-trace.jsonl
@@ -1,0 +1,4 @@
+{"schemaVersion":"0.1","event":"run_started","timestamp":1735689600000,"runId":"repair-example-run","name":"synthetic-repair-validation","startTime":1735689600000,"metadata":{"fixture":"reproducible-repair-evidence","synthetic":true}}
+{"schemaVersion":"0.1","event":"step_started","timestamp":1735689600010,"runId":"repair-example-run","stepId":"validate-repair","name":"validate-repair","type":"tool","startTime":1735689600010,"metadata":{"command":"node scripts/validate-repair.mjs"}}
+{"schemaVersion":"0.1","event":"step_completed","timestamp":1735689600020,"runId":"repair-example-run","stepId":"validate-repair","status":"error","endTime":1735689600020,"durationMs":10,"error":{"message":"Synthetic validation observed an incorrect result"}}
+{"schemaVersion":"0.1","event":"run_completed","timestamp":1735689600030,"runId":"repair-example-run","status":"error","endTime":1735689600030,"durationMs":30,"error":{"message":"Synthetic repair validation failed"}}

--- a/examples/recipes/reproducible-repair-evidence/fixtures/repair.patch
+++ b/examples/recipes/reproducible-repair-evidence/fixtures/repair.patch
@@ -1,0 +1,9 @@
+diff --git a/src/math.ts b/src/math.ts
+index 1111111..2222222 100644
+--- a/src/math.ts
++++ b/src/math.ts
+@@ -1,3 +1,3 @@
+ export function add(left: number, right: number): number {
+-  return left - right;
++  return left + right;
+ }

--- a/examples/recipes/reproducible-repair-evidence/fixtures/reproduction.json
+++ b/examples/recipes/reproducible-repair-evidence/fixtures/reproduction.json
@@ -1,0 +1,30 @@
+{
+  "repository": {
+    "commit": "0123456789abcdef0123456789abcdef01234567",
+    "workingTree": {
+      "dirty": false
+    }
+  },
+  "validation": {
+    "command": "node",
+    "args": [
+      "scripts/validate-repair.mjs"
+    ],
+    "cwd": ".",
+    "exitCode": 0,
+    "timeoutMs": 30000
+  },
+  "toolchain": {
+    "node": "22.14.0",
+    "packageManager": "pnpm@9.15.0"
+  },
+  "lockfile": {
+    "path": "pnpm-lock.yaml",
+    "sha256": "d8a0b5cb41f969e2d33dc10769aececdcc0ae694b6222f7fc7ba2153a5dd1f91"
+  },
+  "environment": {
+    "allowlist": [],
+    "values": {}
+  },
+  "sandbox": null
+}

--- a/examples/recipes/reproducible-repair-evidence/package.json
+++ b/examples/recipes/reproducible-repair-evidence/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agent-inspect-recipe-reproducible-repair-evidence",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "agent-inspect": "workspace:*",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/recipes/reproducible-repair-evidence/src/index.ts
+++ b/examples/recipes/reproducible-repair-evidence/src/index.ts
@@ -1,0 +1,139 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  EVIDENCE_MANIFEST_FILENAME,
+  buildEvidenceManifest,
+  parseEvidenceManifestJson,
+  serializeEvidenceManifest,
+  sha256Hex,
+  verifyEvidenceDirectory,
+} from "agent-inspect/advanced";
+
+const runId = "repair-example-run";
+const createdAt = "2025-01-01T00:00:00.000Z";
+const revisionB = "89abcdef0123456789abcdef0123456789abcdef";
+const boundArtifactPaths = [
+  "check-output.txt",
+  "failed-trace.jsonl",
+  "repair.patch",
+  "reproduction.json",
+] as const;
+
+const sourceDir = path.dirname(fileURLToPath(import.meta.url));
+const recipeDir = path.resolve(sourceDir, "..");
+const fixturesDir = path.join(recipeDir, "fixtures");
+const evidenceDir = path.join(recipeDir, ".generated-evidence");
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const files = await Promise.all(
+  boundArtifactPaths.map(async (relativePath) => ({
+    path: relativePath,
+    content: await readFile(path.join(fixturesDir, relativePath)),
+  })),
+);
+
+function requireFile(relativePath: (typeof boundArtifactPaths)[number]) {
+  const file = files.find((candidate) => candidate.path === relativePath);
+  if (!file) throw new Error(`Missing ${relativePath} fixture.`);
+  return file;
+}
+
+const failedTrace = requireFile("failed-trace.jsonl");
+const reproduction = requireFile("reproduction.json");
+
+function buildManifest(packagedFiles: typeof files) {
+  return buildEvidenceManifest({
+    generatorName: "reproducible-repair-evidence-recipe",
+    generatorVersion: "1.0.0",
+    runIds: [runId],
+    traceSchemaVersions: ["0.1"],
+    sourceHashes: [{ runId, algorithm: "sha256", hash: sha256Hex(failedTrace.content) }],
+    redactionProfile: "share",
+    assessmentStatus: "SAFE WITH WARNINGS",
+    files: packagedFiles,
+    createdAt,
+  });
+}
+
+await rm(evidenceDir, { recursive: true, force: true });
+await mkdir(evidenceDir, { recursive: true });
+await Promise.all(
+  files.map((file) => writeFile(path.join(evidenceDir, file.path), file.content)),
+);
+
+const manifestA = buildManifest(files);
+const serializedManifestA = serializeEvidenceManifest(manifestA);
+await writeFile(
+  path.join(evidenceDir, EVIDENCE_MANIFEST_FILENAME),
+  serializedManifestA,
+  "utf8",
+);
+
+const parsedManifest = parseEvidenceManifestJson(
+  await readFile(path.join(evidenceDir, EVIDENCE_MANIFEST_FILENAME), "utf8"),
+);
+const actualPaths = parsedManifest.files.map((file) => file.path).sort();
+assert(
+  JSON.stringify(actualPaths) === JSON.stringify(boundArtifactPaths),
+  `Unexpected bound artifacts: ${actualPaths.join(", ")}`,
+);
+
+type ReproductionEnvelope = {
+  repository: { commit: string };
+  environment: { allowlist: string[]; values: Record<string, string> };
+};
+
+const reproductionA = JSON.parse(reproduction.content.toString("utf8")) as ReproductionEnvelope;
+assert(
+  reproductionA.environment.allowlist.length === 0 &&
+    Object.keys(reproductionA.environment.values).length === 0,
+  "The synthetic reproduction must use an explicit empty environment allowlist.",
+);
+
+const reproductionForRevisionB = structuredClone(reproductionA);
+reproductionForRevisionB.repository.commit = revisionB;
+const reproductionB = `${JSON.stringify(reproductionForRevisionB, null, 2)}\n`;
+const filesB = files.map((file) =>
+  file.path === "reproduction.json" ? { ...file, content: Buffer.from(reproductionB) } : file,
+);
+const manifestB = buildManifest(filesB);
+
+const hashFor = (
+  manifest: typeof manifestA,
+  relativePath: (typeof boundArtifactPaths)[number],
+) => manifest.files.find((file) => file.path === relativePath)?.sha256;
+
+assert(
+  hashFor(manifestA, "failed-trace.jsonl") === hashFor(manifestB, "failed-trace.jsonl"),
+  "The same failed trace must retain the same hash across revisions.",
+);
+assert(
+  hashFor(manifestA, "reproduction.json") !== hashFor(manifestB, "reproduction.json"),
+  "Changing the repository revision must change the reproduction artifact hash.",
+);
+assert(
+  serializedManifestA !== serializeEvidenceManifest(manifestB),
+  "Changing the repository revision must change the Evidence manifest.",
+);
+
+const verification = await verifyEvidenceDirectory(evidenceDir);
+if (!verification.ok) {
+  for (const issue of verification.issues) {
+    console.error(`${issue.code}: ${issue.message}`);
+  }
+  throw new Error("Generated Evidence directory failed integrity verification.");
+}
+
+console.log("Reproducible repair evidence: pass");
+console.log(`Run: ${runId}`);
+console.log(`Files checked: ${verification.checkedFiles}`);
+console.log(`Bound artifacts: ${actualPaths.join(", ")}`);
+console.log("Revision binding: pass");
+console.log(`Environment allowlist: ${reproductionA.environment.allowlist.length} variables`);
+console.log("Replay executed: no");
+console.log("Evidence directory: .generated-evidence");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,15 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/recipes/reproducible-repair-evidence:
+    dependencies:
+      agent-inspect:
+        specifier: workspace:*
+        version: link:../../..
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+
   examples/recipes/retry-fallback:
     dependencies:
       agent-inspect:

--- a/scripts/validate-recipes.mjs
+++ b/scripts/validate-recipes.mjs
@@ -36,6 +36,7 @@ const RECIPES = [
   "harness-adapter-local",
   "eval-local-checks",
   "redact-share-safe-file",
+  "reproducible-repair-evidence",
   "eval-ci-artifacts",
   "mcp-client-tracing",
   "guardrails-basic",


### PR DESCRIPTION
## Summary

- This adds a deterministic `reproducible-repair-evidence` recipe that binds a failed synthetic trace, caller-owned reproduction metadata, a proposed patch, and recorded validation output into Evidence v2.

- The recipe demonstrates repository revision binding with the same failed trace while keeping integrity verification separate from replay, patch application, and validation execution. It also documents explicit environment allowlisting, optional sandbox metadata, Windows-safe LF handling, and support reproduction guidance without changing runtime behavior or persisted schemas.

- Evidence v2 can verify that packaged artifacts match their manifest, but trace integrity alone does not identify the repository state a repair was produced against.

- The new recipe packages and hashes:
  - a failed synthetic trace
  - caller-owned repository and validation metadata
  - a proposed synthetic patch
  - recorded validation output

- It also compares two synthetic repository revisions using the same failed trace. The trace hash remains unchanged while the `reproduction.json` hash changes, demonstrating that repository provenance becomes part of the integrity-bound repair envelope.

- The example uses the existing `agent-inspect/advanced` Evidence APIs only. It does not checkout a repository, apply the patch, execute the recorded validation command, or certify replay.

- The recipe is provider-free, network-free, deterministic, and verified on Windows.

**Linked issue (required):** #316

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] Documentation only
- [x] Example / recipe / fixture
- [ ] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Run the recipe with:

```bash
pnpm --filter agent-inspect-recipe-reproducible-repair-evidence start
```

The recipe verifies that all four caller-owned artifacts are present in the generated Evidence manifest and that the generated Evidence directory passes programmatic verification.

It also performs a deterministic repository revision binding check using:

```text
same failed trace
same proposed patch
same recorded validation output
different synthetic repository revision
```

The failed trace hash remains identical while the `reproduction.json` hash changes.

This demonstrates the repository-state gap described in #316 without implementing repository replay.

Focused recipe result on Windows:

```text
Reproducible repair evidence: pass
Run: repair-example-run
Files checked: 4
Bound artifacts: check-output.txt, failed-trace.jsonl, repair.patch, reproduction.json
Revision binding: pass
Environment allowlist: 0 variables
Replay executed: no
Evidence directory: .generated-evidence
```

<img width="1011" height="228" alt="2026-09-04-024707" src="https://github.com/user-attachments/assets/eef165cf-f504-4712-abe7-c7d28c4dd4ed" />

The generated Evidence directory was also verified through the existing CLI:

```bash
pnpm exec agent-inspect bundle verify .\.generated-evidence
```

Result:

```text
Evidence verify: pass (4 file(s) checked)
Assessment: SAFE WITH WARNINGS
```

`SAFE WITH WARNINGS` is the recorded assessment status. The Evidence integrity verification itself passes.

<img width="1075" height="107" alt="2026-09-04-025215" src="https://github.com/user-attachments/assets/b46d6dfb-4624-4cc8-9d87-fc7be3dfcbf6" />

Integrity verification confirms that the packaged files match the Evidence manifest. It does not:

```text
checkout the recorded repository revision
reconstruct the recorded working tree
apply repair.patch
execute the recorded validation command
validate patch applicability
certify that the repair can be replayed
```

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [ ] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [ ] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [x] Docs / fixtures / recipes / community only

The workspace lockfile changes only to register the new private recipe package and its existing workspace dependencies.

## Validation

The focused recipe and repository checks were run successfully on Windows.

```bash
Focused recipe runtime: PASS
Evidence CLI verify: PASS, 4 files checked
Deterministic manifest digest: PASS across repeated runs
pnpm build: PASS
pnpm typecheck: PASS
pnpm recipes:check: PASS, 42 recipes
pnpm fixtures:check: PASS
pnpm docs:check: PASS
pnpm repo:health: PASS
pnpm size: PASS, 12.02 kB / 120 kB
LF, host-data, expected-output, whitespace, and git diff checks: PASS
```
pnpm test:all reached the test phase with:
```bash
1,938 tests passed
4 tests failed
```

The four failures are pre-existing Windows Studio symlink tests that fail with EPERM while creating symlinks. They are unrelated to the files changed by this recipe.

Because `pnpm test:all` stopped on those existing Windows failures before later gates completed, pnpm size was also run separately and passed.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

This recipe uses synthetic fixture data only and does not require credentials or provider keys.

`reproduction.json` explicitly allowlists zero environment variables:

```json
{
  "environment": {
    "allowlist": [],
    "values": {}
  }
}
```

The recipe does not capture `process.env`, host paths, usernames, provider configuration, or other machine-specific environment data.

The repository revision, lockfile digest, patch, validation output, and optional container metadata documented by the recipe are synthetic.

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

The new recipe reuses the existing workspace `agent-inspect` package and existing `tsx` tooling.

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes (no shipped runtime behavior changes; the recipe includes focused deterministic assertions)
- [x] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`) (no public API change; recipe and support reproduction docs are updated)
- [x] `git diff --check` clean