### PR TITLE
fix(search): conjunctive --name + --status run filters (#323)

### DIFF
--- a/.changeset/fix-search-name-status-conjunctive-323.md
+++ b/.changeset/fix-search-name-status-conjunctive-323.md
@@ -19,4 +19,4 @@
 "@agent-inspect/vitest": patch
 ---
 
-Fix `search --name` + `--status` so run-level filters are applied conjunctively and status-only hits no longer bypass a non-matching name (#323). Raise Vitest test/hook timeouts so consumer-compat and API-surface fixtures do not flake under coverage on CI.
+Fix `search --name` + `--status` so run-level filters are applied conjunctively and status-only hits no longer bypass a non-matching name (#323). Unblock CI after Vitest 3 coverage hangs: serialize local `npm install` in compat fixtures, exclude those suites from coverage workers, and run them as a separate non-coverage CI step.

--- a/.changeset/fix-search-name-status-conjunctive-323.md
+++ b/.changeset/fix-search-name-status-conjunctive-323.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": patch
+"@agent-inspect/adapter-sdk": patch
+"@agent-inspect/ai-sdk": patch
+"@agent-inspect/circuit": patch
+"@agent-inspect/eval": patch
+"@agent-inspect/guardrails": patch
+"@agent-inspect/harness": patch
+"@agent-inspect/index-sqlite": patch
+"@agent-inspect/jest": patch
+"@agent-inspect/langchain": patch
+"@agent-inspect/mcp": patch
+"@agent-inspect/mcp-server": patch
+"@agent-inspect/openai-agents": patch
+"@agent-inspect/redact": patch
+"@agent-inspect/studio": patch
+"@agent-inspect/tui": patch
+"@agent-inspect/viewer": patch
+"@agent-inspect/vitest": patch
+---
+
+Fix `search --name` + `--status` so run-level filters are applied conjunctively and status-only hits no longer bypass a non-matching name (#323).

--- a/.changeset/fix-search-name-status-conjunctive-323.md
+++ b/.changeset/fix-search-name-status-conjunctive-323.md
@@ -19,4 +19,4 @@
 "@agent-inspect/vitest": patch
 ---
 
-Fix `search --name` + `--status` so run-level filters are applied conjunctively and status-only hits no longer bypass a non-matching name (#323).
+Fix `search --name` + `--status` so run-level filters are applied conjunctively and status-only hits no longer bypass a non-matching name (#323). Raise Vitest test/hook timeouts so consumer-compat and API-surface fixtures do not flake under coverage on CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
+      # npm-install consumer fixtures hang under coverage workers; run them without coverage first.
+      - run: pnpm exec vitest run packages/core/test/consumer-compat.test.ts packages/core/test/package-exports-compat.test.ts packages/core/test/api-surface-snapshot.test.ts
       - run: pnpm run test:coverage
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      # npm-install consumer fixtures hang under coverage workers; run them without coverage first.
-      - run: pnpm exec vitest run packages/core/test/consumer-compat.test.ts packages/core/test/package-exports-compat.test.ts packages/core/test/api-surface-snapshot.test.ts
+      # npm-install consumer fixtures flake under coverage parallelism; run them single-worker without coverage.
+      - run: pnpm exec vitest run --no-file-parallelism --maxWorkers=1 packages/core/test/consumer-compat.test.ts packages/core/test/package-exports-compat.test.ts packages/core/test/api-surface-snapshot.test.ts
       - run: pnpm run test:coverage
       - uses: actions/upload-artifact@v4
         if: always()

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -208,36 +208,41 @@ function matchRunLevel(
     statusFilter?: string;
   },
 ): TraceSearchResult[] {
+  // Step-oriented filters are handled only by matchStepLevel.
   if (opts.stepTypeFilter || opts.toolQuery) return [];
-  const out: TraceSearchResult[] = [];
-  const fields: string[] = [];
 
-  if (opts.statusFilter && m.status === opts.statusFilter) {
-    fields.push("run.status");
-  }
-  if (opts.nameQuery && nameMatches(m.name ?? m.runId, opts.nameQuery)) {
-    fields.push("run.name");
+  // Structured run filters are conjunctive: every supplied filter must match.
+  // Previously status/name/duration were OR'd via field accumulation, so
+  // `--name missing --status error` could still emit a status-only run hit (#323).
+  if (opts.statusFilter && m.status !== opts.statusFilter) return [];
+  if (opts.nameQuery && !nameMatches(m.name ?? m.runId, opts.nameQuery)) {
+    return [];
   }
   if (
     opts.durationFilter &&
-    durationMatches(m.durationMs, opts.durationFilter)
+    !durationMatches(m.durationMs, opts.durationFilter)
   ) {
-    fields.push("run.durationMs");
+    return [];
   }
 
-  if (fields.length === 0) return out;
+  const fields: string[] = [];
+  if (opts.statusFilter) fields.push("run.status");
+  if (opts.nameQuery) fields.push("run.name");
+  if (opts.durationFilter) fields.push("run.durationMs");
+  if (fields.length === 0) return [];
 
-  out.push({
-    runId: m.runId,
-    runName: m.name,
-    runStatus: m.status,
-    timestamp: m.startedAt,
-    durationMs: m.durationMs,
-    matchReason: `run match: ${fields.join(", ")}`,
-    matchedFields: fields,
-    filePath: m.filePath,
-  });
-  return out;
+  return [
+    {
+      runId: m.runId,
+      runName: m.name,
+      runStatus: m.status,
+      timestamp: m.startedAt,
+      durationMs: m.durationMs,
+      matchReason: `run match: ${fields.join(", ")}`,
+      matchedFields: fields,
+      filePath: m.filePath,
+    },
+  ];
 }
 
 function matchStepLevel(

--- a/packages/core/test/api-surface-snapshot.test.ts
+++ b/packages/core/test/api-surface-snapshot.test.ts
@@ -112,7 +112,14 @@ describe.skipIf(!distPresent)("published API surface snapshot (#211)", () => {
         const install = withNpmInstallLock(() =>
           spawnSync(
             "npm",
-            ["install", "--no-save", "--ignore-scripts", repoRoot],
+            [
+              "install",
+              "--no-save",
+              "--ignore-scripts",
+              "--no-audit",
+              "--no-fund",
+              repoRoot,
+            ],
             {
               cwd: projectDir,
               encoding: "utf8",

--- a/packages/core/test/api-surface-snapshot.test.ts
+++ b/packages/core/test/api-surface-snapshot.test.ts
@@ -13,6 +13,8 @@ import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 
+import { withNpmInstallLock } from "./helpers/npm-install-lock.js";
+
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, "../../..");
 const snapshotPath = path.join(
@@ -107,14 +109,16 @@ describe.skipIf(!distPresent)("published API surface snapshot (#211)", () => {
           ].join("\n"),
         );
 
-        const install = spawnSync(
-          "npm",
-          ["install", "--no-save", "--ignore-scripts", repoRoot],
-          {
-            cwd: projectDir,
-            encoding: "utf8",
-            shell: process.platform === "win32",
-          },
+        const install = withNpmInstallLock(() =>
+          spawnSync(
+            "npm",
+            ["install", "--no-save", "--ignore-scripts", repoRoot],
+            {
+              cwd: projectDir,
+              encoding: "utf8",
+              shell: process.platform === "win32",
+            },
+          ),
         );
         expect(install.status, install.stdout + install.stderr).toBe(0);
 

--- a/packages/core/test/consumer-compat.test.ts
+++ b/packages/core/test/consumer-compat.test.ts
@@ -31,7 +31,7 @@ function installFixture(fixtureName: string): string {
   tmpRoots.push(dir);
   cpSync(path.join(fixturesRoot, fixtureName), dir, { recursive: true });
   withNpmInstallLock(() => {
-    execSync(`npm install "${repoRoot}"`, {
+    execSync(`npm install --no-audit --no-fund "${repoRoot}"`, {
       cwd: dir,
       stdio: "pipe",
       encoding: "utf-8",

--- a/packages/core/test/consumer-compat.test.ts
+++ b/packages/core/test/consumer-compat.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 import { afterAll, describe, expect, it } from "vitest";
 
+import { withNpmInstallLock } from "./helpers/npm-install-lock.js";
+
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, "../../..");
 const fixturesRoot = path.join(repoRoot, "test", "consumer-fixtures");
@@ -28,10 +30,12 @@ function installFixture(fixtureName: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), `agent-inspect-${fixtureName}-`));
   tmpRoots.push(dir);
   cpSync(path.join(fixturesRoot, fixtureName), dir, { recursive: true });
-  execSync(`npm install "${repoRoot}"`, {
-    cwd: dir,
-    stdio: "pipe",
-    encoding: "utf-8",
+  withNpmInstallLock(() => {
+    execSync(`npm install "${repoRoot}"`, {
+      cwd: dir,
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
   });
   return dir;
 }

--- a/packages/core/test/helpers/npm-install-lock.ts
+++ b/packages/core/test/helpers/npm-install-lock.ts
@@ -1,0 +1,40 @@
+import { closeSync, openSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const lockPath = path.join(tmpdir(), "agent-inspect-npm-install.lock");
+
+function sleepMs(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* busy-wait: sync lock wait without adding deps */
+  }
+}
+
+/**
+ * Serialize local `npm install <repo>` across Vitest workers.
+ * Concurrent installs of the same workspace path hang/flake under coverage.
+ */
+export function withNpmInstallLock<T>(fn: () => T): T {
+  const deadline = Date.now() + 5 * 60_000;
+  while (Date.now() < deadline) {
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockPath, "wx");
+    } catch {
+      sleepMs(100);
+      continue;
+    }
+    try {
+      return fn();
+    } finally {
+      closeSync(fd);
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  throw new Error(`Timed out waiting for npm install lock at ${lockPath}`);
+}

--- a/packages/core/test/package-exports-compat.test.ts
+++ b/packages/core/test/package-exports-compat.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 import { afterAll, describe, expect, it } from "vitest";
 
+import { withNpmInstallLock } from "./helpers/npm-install-lock.js";
+
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, "../../..");
 const tscBin = path.join(repoRoot, "node_modules", "typescript", "bin", "tsc");
@@ -54,10 +56,12 @@ function runTsc(projectDir: string): void {
 }
 
 function installAgentInspect(consumerDir: string): void {
-  execSync(`npm install "${repoRoot}"`, {
-    cwd: consumerDir,
-    stdio: "pipe",
-    encoding: "utf-8",
+  withNpmInstallLock(() => {
+    execSync(`npm install "${repoRoot}"`, {
+      cwd: consumerDir,
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
   });
 }
 

--- a/packages/core/test/package-exports-compat.test.ts
+++ b/packages/core/test/package-exports-compat.test.ts
@@ -57,7 +57,7 @@ function runTsc(projectDir: string): void {
 
 function installAgentInspect(consumerDir: string): void {
   withNpmInstallLock(() => {
-    execSync(`npm install "${repoRoot}"`, {
+    execSync(`npm install --no-audit --no-fund "${repoRoot}"`, {
       cwd: consumerDir,
       stdio: "pipe",
       encoding: "utf-8",

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -32,6 +32,33 @@ describe("searchTraces", () => {
     expect(results.some((r) => r.runId === "minimal-error")).toBe(true);
   });
 
+  it("applies --name and --status conjunctively at run level (#323)", async () => {
+    const metas = [
+      await extractMetadata(path.join(fixturesDir, "minimal-error.jsonl")),
+      await extractMetadata(path.join(fixturesDir, "minimal-success.jsonl")),
+    ];
+    const mismatched = await searchTraces(metas, {
+      traceDir: fixturesDir,
+      name: "definitely_not_matching_xyz",
+      status: "error",
+    });
+    expect(mismatched).toEqual([]);
+
+    const matched = await searchTraces(metas, {
+      traceDir: fixturesDir,
+      name: "minimal-error",
+      status: "error",
+    });
+    expect(matched.some((r) => r.runId === "minimal-error")).toBe(true);
+    expect(
+      matched.every(
+        (r) =>
+          r.runStatus === "error" &&
+          (r.runName ?? r.runId).toLowerCase().includes("minimal-error"),
+      ),
+    ).toBe(true);
+  });
+
   it("finds tool steps by type", async () => {
     const metas = [
       await extractMetadata(path.join(fixturesDir, "tool-with-io.jsonl")),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -201,6 +201,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Consumer/compat fixtures run npm install + tsc; the Vitest 5s default
+    // flakes under coverage load on CI (main red after #319; blocks #324).
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     include: ["packages/**/*.test.ts"],
     exclude: ["**/dist/**", "**/node_modules/**", "docs/**", "examples/**"],
     coverage: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,14 @@ import { defineConfig } from "vitest/config";
 /** Config file lives at repo root so Vitest resolves `include` the same when cwd is a package. */
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 
+/** Coverage + many parallel `npm install <repo>` workers hang on CI; run those suites separately. */
+const coverageRun = process.argv.includes("--coverage");
+const npmInstallCompatTests = [
+  "**/consumer-compat.test.ts",
+  "**/package-exports-compat.test.ts",
+  "**/api-surface-snapshot.test.ts",
+] as const;
+
 const coreEntry = fileURLToPath(
   new URL("./packages/core/src/index.ts", import.meta.url),
 );
@@ -206,7 +214,13 @@ export default defineConfig({
     testTimeout: 60_000,
     hookTimeout: 60_000,
     include: ["packages/**/*.test.ts"],
-    exclude: ["**/dist/**", "**/node_modules/**", "docs/**", "examples/**"],
+    exclude: [
+      "**/dist/**",
+      "**/node_modules/**",
+      "docs/**",
+      "examples/**",
+      ...(coverageRun ? [...npmInstallCompatTests] : []),
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -209,10 +209,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    // Consumer/compat fixtures run npm install + tsc; the Vitest 5s default
-    // flakes under coverage load on CI (main red after #319; blocks #324).
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    // Consumer/compat fixtures run npm install + tsc; local installs currently
+    // take ~40s+ each, so the Vitest 5s/60s defaults flake on CI.
+    testTimeout: 180_000,
+    hookTimeout: 180_000,
     include: ["packages/**/*.test.ts"],
     exclude: [
       "**/dist/**",


### PR DESCRIPTION
## Summary
- Fix run-level `searchTraces` so `--name` and `--status` (and duration) are **conjunctive**, not OR'd via matched-field accumulation.
- Add regression coverage for the #323 repro (`definitely_not_matching_xyz` + `error` → empty).
- Patch Changeset for the next publish train (no release cut in this PR).

## Test plan
- [x] `pnpm exec vitest run packages/core/test/search.test.ts`
- [x] `pnpm exec vitest run packages/cli/test/search.test.ts`
- [ ] CI green on PR

Closes #323