### PR TITLE
fix(redact): cover high-confidence key-value credentials (#327)

### DIFF
--- a/.changeset/fix-key-value-secret-redact-327.md
+++ b/.changeset/fix-key-value-secret-redact-327.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": patch
+"@agent-inspect/adapter-sdk": patch
+"@agent-inspect/ai-sdk": patch
+"@agent-inspect/circuit": patch
+"@agent-inspect/eval": patch
+"@agent-inspect/guardrails": patch
+"@agent-inspect/harness": patch
+"@agent-inspect/index-sqlite": patch
+"@agent-inspect/jest": patch
+"@agent-inspect/langchain": patch
+"@agent-inspect/mcp": patch
+"@agent-inspect/mcp-server": patch
+"@agent-inspect/openai-agents": patch
+"@agent-inspect/redact": patch
+"@agent-inspect/studio": patch
+"@agent-inspect/tui": patch
+"@agent-inspect/viewer": patch
+"@agent-inspect/vitest": patch
+---
+
+Align high-confidence key/value credential redaction with verify-safe `key-value-secret` detection (for example `internal_token=<credential>`), keep path findings review-only, and document that redact remains best-effort (#327).

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -4,7 +4,11 @@
 
 AgentInspect traces, log-ingest outputs, and exports are local files. They may still contain sensitive metadata that you attached manually, collected from logs, or included through optional preview settings. Use this checklist before sharing an artifact in a GitHub issue, Discussion, PR, support thread, or public post.
 
-This guide is practical sharing guidance, not a guarantee that any artifact is safe to publish. Redaction profiles are **key-based safeguards**, not compliance-grade DLP.
+This guide is practical sharing guidance, not a guarantee that any artifact is safe to publish. Redaction profiles are **best-effort transformation**, not compliance-grade DLP or a safety certification. Always finish with `verify-safe` before sharing.
+
+Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and require human review. Org-specific patterns need programmatic custom detectors today; a bounded local CLI policy is proposed separately and is not yet supported.
+
+`strict` is a stricter **rule set** (more keys), not a promise that every input produces bytes different from `share`.
 
 ## Quick presets (v1.3.0+)
 

--- a/docs/SAFETY-POLICY.md
+++ b/docs/SAFETY-POLICY.md
@@ -92,9 +92,34 @@ Overrides are **opt-in**, **local**, and must not be framed as “making the pro
 ### Allowed override patterns
 
 1. **Extra sensitive keys** via `@agent-inspect/redact` `extraKeys` / `createRedactor({ extraKeys: [...] })` when your framework uses custom attribute names.
-2. **Custom detectors** via `detectors: [myDetector]` on `redact` / `createRedactor` for org-specific token shapes (keep detectors from emitting matched values into logs).
+2. **Custom detectors** via `detectors: [myDetector]` on `redact` / `createRedactor` for org-specific token shapes (keep detectors from emitting matched values into logs). Example (synthetic only):
+
+```ts
+import { redact, type RedactionDetector } from "@agent-inspect/redact";
+
+const houseDetector: RedactionDetector = {
+  id: "custom.houseCredential",
+  severity: "error",
+  matchKind: "value",
+  detect({ value }) {
+    if (typeof value !== "string") return [];
+    return /^house_credential=[A-Za-z0-9_-]{12,}$/.test(value)
+      ? [{ action: "replace" }]
+      : [];
+  },
+};
+
+redact(
+  { note: "house_credential=syntheticOnlyValue" },
+  { detectors: [houseDetector] },
+);
+```
+
+CLI custom policy files are **not** supported yet. Do not put secrets on the command line.
 3. **CLI size thresholds** on `scan` / `verify-safe` (`--max-string-length`, etc.) when oversized findings are false positives for your workload.
 4. **Bundle write override** with explicit `--allow-unsafe` after reviewing `verify-safe --explain` (records that the artifact was not share-gated).
+
+High-confidence built-in credentials (including bounded `token=` / `api_key=` / `internal_token=` forms) are covered by built-in redaction profiles. Context-sensitive findings such as private filesystem paths may remain verification-only when automatic erasure would create excessive false positives or destroy legitimate debugging context. `redact` remains best-effort; `verify-safe` remains the final automated local assessment before sharing.
 
 ### Disallowed
 

--- a/docs/implementation/CURRENT-TASK.md
+++ b/docs/implementation/CURRENT-TASK.md
@@ -5,8 +5,8 @@ executionMode: maintainer-reviewed
 namedTrain: agentinspect-feedback-integrity-v6.17.5-to-v6.22
 currentTrain: v6.17.7-redaction-dx-evidence
 trainStatus: in-progress
-currentChunk: chunk-0-authorize
-nextAction: "Chunk 1 — P0 high-confidence key-value credential redaction parity (issue A); leave Version Packages #326 open until P0 + DX + #325 land"
+currentChunk: chunk-1-p0-key-value-redact
+nextAction: "Chunk 2 — observe docs + check --forbid-tool alias; leave #326 open"
 canonicalRoadmap: docs/implementation/ROADMAP.md
 activePlan: docs/implementation/active/EXECUTION-PLAN.md
 pendingManualGate: ""

--- a/docs/implementation/active/EXECUTION-PLAN.md
+++ b/docs/implementation/active/EXECUTION-PLAN.md
@@ -37,8 +37,8 @@
 
 | Chunk | Status |
 | --- | --- |
-| `6.17.7-0-authorize` | in progress |
-| `6.17.7-1-p0-key-value-redact` | pending |
+| `6.17.7-0-authorize` | done (#332) |
+| `6.17.7-1-p0-key-value-redact` | in progress (#327) |
 | `6.17.7-2-observe-forbid-tool-dx` | pending |
 | `6.17.7-3-land-325` | pending |
 | `6.17.7-4-publish` | pending |

--- a/packages/cli/test/redact.test.ts
+++ b/packages/cli/test/redact.test.ts
@@ -85,4 +85,27 @@ describe("redact command", () => {
       redactCommand("-", {}, stdinFrom("{\"token\":\"secret\"}\nnot-json-secret\n")),
     ).rejects.toThrow("Input is not valid JSON or JSONL at line 2.");
   });
+
+  it("redacts high-confidence key/value credentials (#327)", async () => {
+    const file = await writeTrace(
+      tmp,
+      `${JSON.stringify({
+        schemaVersion: "0.2",
+        eventId: "event-kv",
+        runId: "run-kv-secret",
+        attributes: {
+          note: "internal_token=synthetic-house-secret-123456",
+          maxTokens: 4096,
+          lookalike: "secret=false",
+        },
+      })}\n`,
+    );
+    const output = path.join(tmp, "share.jsonl");
+    await redactCommand(file, { profile: "share", output });
+    const redacted = await readFile(output, "utf-8");
+    expect(redacted).toContain("[REDACTED]");
+    expect(redacted).not.toContain("synthetic-house-secret-123456");
+    expect(redacted).toContain("4096");
+    expect(redacted).toContain("secret=false");
+  });
 });

--- a/packages/cli/test/safety.test.ts
+++ b/packages/cli/test/safety.test.ts
@@ -156,6 +156,41 @@ describe("scan and verify-safe commands", () => {
     expect(verified.redactionSummary?.findings).toBeGreaterThan(0);
   });
 
+  it("redacts key/value credentials so artifact verify-safe no longer reports key-value-secret (#327)", async () => {
+    const secret = "internal_token=synthetic-house-secret-123456";
+    const file = await writeTrace(
+      tmp,
+      "kv-secret.jsonl",
+      jsonl(
+        event("event-a", {
+          attributes: {
+            note: secret,
+            pathHint: "/Users/synthetic/.ssh/id_rsa",
+          },
+        }),
+      ),
+    );
+
+    const scan = await runSafety(scanCommand, file);
+    expect(scan.findings?.some((f) => f.message?.includes("key-value-secret"))).toBe(true);
+
+    const verified = await runSafety(verifySafeCommand, file);
+    const artifactFindings = JSON.stringify(verified.artifactAssessment ?? verified);
+    expect(artifactFindings).not.toContain("synthetic-house-secret-123456");
+    expect(JSON.stringify(verified.findings ?? [])).not.toContain(
+      "synthetic-house-secret-123456",
+    );
+    // Path findings may remain verifier-only; credential KV must not remain on artifact.
+    const kvStillPresent = (verified.findings ?? []).some(
+      (f) =>
+        f.ruleId === "safety.secretPattern" &&
+        (f.message?.includes("key-value-secret") ?? false),
+    );
+    // After share redaction, verify-safe findings are from the artifact assessment path.
+    expect(verified.redactionSummary?.findings).toBeGreaterThan(0);
+    expect(kvStillPresent).toBe(false);
+  });
+
   it("explains findings without leaking matched values", async () => {
     const secret = "sk-explainSecretValue1234567890";
     const file = await writeTrace(

--- a/packages/core/src/checks/index.ts
+++ b/packages/core/src/checks/index.ts
@@ -675,7 +675,12 @@ const DEFAULT_SECRET_PATTERNS: readonly SafetySecretPattern[] = [
   { id: "openai-key", pattern: /sk-[A-Za-z0-9_-]{16,}/ },
   { id: "aws-access-key", pattern: /AKIA[0-9A-Z]{16}/ },
   { id: "github-token", pattern: /gh[opsu]_[A-Za-z0-9_]{20,}/ },
-  { id: "key-value-secret", pattern: /(api[_-]?key|token|password|secret)=\S{8,}/i },
+  // Keep in sync with packages/redact/src/key-value-secret.ts (KEY_VALUE_SECRET_PATTERN_SOURCE).
+  {
+    id: "key-value-secret",
+    pattern:
+      /\b(?:api[_-]?key|internal[_-]?token|access[_-]?token|auth[_-]?token|password|secret|token)=([^\s"'\\]{8,})/i,
+  },
 ];
 
 type EventValueEntry = {

--- a/packages/redact/README.md
+++ b/packages/redact/README.md
@@ -37,6 +37,10 @@ console.log(result.value, result.findings);
 
 - Pure local transformation; no network
 - Profiles: `local` · `share` · `strict`
+- Redaction is best-effort, not a safety certification — run `verify-safe` before sharing
+- High-confidence credentials (including bounded `token=` / `api_key=` / `internal_token=` forms) are covered by built-in profiles
+- Context-sensitive findings may still require review; CLI custom policies are not yet supported (use programmatic `detectors`)
+- `strict` adds more key rules; it does not guarantee different bytes from `share` on every input
 
 ## API
 

--- a/packages/redact/src/index.ts
+++ b/packages/redact/src/index.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { isCredentialSensitiveKey } from "./sensitive-key.js";
+import { valueContainsKeyValueSecret } from "./key-value-secret.js";
 
 export type RedactionProfile = "local" | "share" | "strict";
 
@@ -336,6 +337,17 @@ const credentialDetectors: readonly RedactionDetector[] = [
     severity: "error",
   }),
   {
+    id: "value.keyValueSecret",
+    severity: "error",
+    matchKind: "value",
+    detect(input) {
+      if (typeof input.value !== "string") return [];
+      return valueContainsKeyValueSecret(input.value)
+        ? [{ action: "replace", severity: "error", matchKind: "value" }]
+        : [];
+    },
+  },
+  {
     id: "value.creditCard",
     severity: "error",
     matchKind: "value",
@@ -636,3 +648,10 @@ export function createRedactor(options?: RedactorOptions): Redactor {
 export function redact<T = unknown>(value: T, options?: RedactOptions): RedactionResult<T> {
   return createRedactor(options).redact(value);
 }
+
+export {
+  KEY_VALUE_SECRET_PATTERN,
+  KEY_VALUE_SECRET_PATTERN_SOURCE,
+  valueContainsKeyValueSecret,
+} from "./key-value-secret.js";
+

--- a/packages/redact/src/key-value-secret.ts
+++ b/packages/redact/src/key-value-secret.ts
@@ -1,0 +1,24 @@
+/**
+ * High-confidence key/value credential forms shared with core
+ * `safety.secretPattern` / `key-value-secret` (keep sources in sync).
+ *
+ * Matches house-format credentials such as:
+ *   internal_token=<credential>
+ *   token=<credential>
+ *   api_key=<credential>
+ *
+ * Intentionally does **not** match metric/config lookalikes such as
+ * maxTokens=, tokenCount=, secret=false, or short placeholders.
+ */
+export const KEY_VALUE_SECRET_PATTERN_SOURCE =
+  String.raw`\b(?:api[_-]?key|internal[_-]?token|access[_-]?token|auth[_-]?token|password|secret|token)=([^\s"'\\]{8,})`;
+
+export const KEY_VALUE_SECRET_PATTERN = new RegExp(
+  KEY_VALUE_SECRET_PATTERN_SOURCE,
+  "i",
+);
+
+export function valueContainsKeyValueSecret(value: string): boolean {
+  KEY_VALUE_SECRET_PATTERN.lastIndex = 0;
+  return KEY_VALUE_SECRET_PATTERN.test(value);
+}

--- a/packages/redact/test/key-value-secret.test.ts
+++ b/packages/redact/test/key-value-secret.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  KEY_VALUE_SECRET_PATTERN_SOURCE,
+  redact,
+  valueContainsKeyValueSecret,
+} from "../src/index.js";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+describe("value.keyValueSecret (#327)", () => {
+  it.each([
+    "internal_token=synthetic-house-secret-123456",
+    "token=synthetic-house-secret-123456",
+    "api_key=synthetic-house-secret-123456",
+    "api-key=synthetic-house-secret-123456",
+    "access_token=synthetic-house-secret-123456",
+    "auth_token=synthetic-house-secret-123456",
+    "password=synthetic-house-secret-123456",
+    "secret=synthetic-house-secret-123456",
+    "note internal_token=synthetic-house-secret-123456 trailing",
+  ])("redacts %s", (value) => {
+    const result = redact({ value }, { profile: "share" });
+    expect(result.value).toEqual({ value: "[REDACTED]" });
+    expect(result.findings.some((f) => f.detector === "value.keyValueSecret")).toBe(
+      true,
+    );
+    expect(JSON.stringify(result)).not.toContain("synthetic-house-secret-123456");
+    expect(JSON.stringify(result.findings)).not.toContain(
+      "synthetic-house-secret-123456",
+    );
+  });
+
+  it.each([
+    "maxTokens=4096",
+    "tokenCount=128",
+    "secret=false",
+    "token=short",
+    "token=abcdefg",
+    "password=short1",
+    "ordinary prose about a token and a secret",
+    "agent-inspect@6.17.6",
+    "duration=500ms",
+  ])("does not redact lookalike %s", (value) => {
+    expect(valueContainsKeyValueSecret(value)).toBe(false);
+    const result = redact({ value }, { profile: "share" });
+    expect(result.value).toEqual({ value });
+    expect(result.findings.some((f) => f.detector === "value.keyValueSecret")).toBe(
+      false,
+    );
+  });
+
+  it("covers share and strict profiles for high-confidence credentials", () => {
+    const value = "internal_token=synthetic-house-secret-123456";
+    for (const profile of ["share", "strict"] as const) {
+      const result = redact({ meta: value }, { profile });
+      expect(result.value).toEqual({ meta: "[REDACTED]" });
+    }
+  });
+
+  it("keeps core safety.key-value-secret pattern source in sync", () => {
+    const checksSource = readFileSync(
+      path.join(repoRoot, "packages/core/src/checks/index.ts"),
+      "utf8",
+    );
+    expect(checksSource).toContain(KEY_VALUE_SECRET_PATTERN_SOURCE);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `value.keyValueSecret` detector for bounded `token=` / `api_key=` / `internal_token=` (etc.) forms
- Align core `key-value-secret` pattern source with `@agent-inspect/redact`
- Document redact = best-effort; verify-safe = final assessment; paths may stay verifier-only
- Patch Changeset for fixed package group

Closes #327

## Test plan
- [x] `pnpm exec vitest run packages/redact/test/key-value-secret.test.ts packages/redact/test/index.test.ts packages/cli/test/redact.test.ts packages/cli/test/safety.test.ts`
- [ ] CI green