### PR TITLE
fix(cli): strictly validate clean --keep counts

### DIFF
--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -18,13 +18,15 @@ export interface CleanOptions {
   yes?: boolean;
 }
 
+const DECIMAL_INTEGER_PATTERN = /^\d+$/;
+
 function parseKeep(raw?: string): number {
   const trimmed = typeof raw === "string" ? raw.trim() : "";
-  if (trimmed === "") {
+  if (!DECIMAL_INTEGER_PATTERN.test(trimmed)) {
     throw new Error(`Invalid --keep value: ${raw}. Provide a positive integer.`);
   }
-  const n = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(n) || n <= 0) {
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n <= 0) {
     throw new Error(`Invalid --keep value: ${raw}. Provide a positive integer.`);
   }
   return n;

--- a/packages/cli/test/clean.test.ts
+++ b/packages/cli/test/clean.test.ts
@@ -129,6 +129,20 @@ describe("clean", () => {
     logSpy.mockRestore();
   });
 
+  it("--keep accepts trimmed decimal counts with leading zeros", async () => {
+    const now = Date.now();
+    await writeTrace(traceDir, "run_leading_zero_old", "old", now - 20_000);
+    await writeTrace(traceDir, "run_leading_zero_new", "new", now - 10_000);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await clean({ dir: traceDir, keep: " 001 ", dryRun: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(process.exitCode).not.toBe(1);
+    expect(out).toContain("run_leading_zero_old.jsonl");
+    expect(out).not.toContain("run_leading_zero_new.jsonl");
+    logSpy.mockRestore();
+  });
+
   it("dry-run deletes nothing", async () => {
     const now = Date.now();
     await writeTrace(traceDir, "run_a", "a", now - 3_600_000);
@@ -176,11 +190,40 @@ describe("clean", () => {
     errSpy.mockRestore();
   });
 
-  it("invalid --keep fails clearly", async () => {
+  it("invalid --keep fails clearly without deleting traces", async () => {
+    const now = Date.now();
+    await writeTrace(traceDir, "run_invalid_keep_old", "old", now - 20_000);
+    await writeTrace(traceDir, "run_invalid_keep_new", "new", now - 10_000);
+
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await clean({ dir: traceDir, keep: "0", dryRun: true });
-    expect(process.exitCode).toBe(1);
-    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Invalid --keep"))).toBe(true);
+    const invalidValues = [
+      "0",
+      "000",
+      "-1",
+      "+1",
+      "1.0",
+      "1.5",
+      "10oops",
+      "1e2",
+      "0x10",
+      "Infinity",
+      "NaN",
+      String(Number.MAX_SAFE_INTEGER + 1),
+    ];
+
+    for (const keep of invalidValues) {
+      process.exitCode = 0;
+      errSpy.mockClear();
+
+      await clean({ dir: traceDir, keep, yes: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Invalid --keep"))).toBe(true);
+      expect(await readdir(traceDir)).toEqual(
+        expect.arrayContaining(["run_invalid_keep_old.jsonl", "run_invalid_keep_new.jsonl"]),
+      );
+    }
+
     errSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

- Reject malformed and unsafe `--keep` values before `clean` computes a deletion plan.

- Preserve existing leading-zero decimal compatibility, so values like `0010` continue to resolve to `10`.

- Add regression coverage for malformed numeric forms, safe-integer bounds, trimming, leading zeros, and fail-closed behavior without deleting traces.

**Linked issue (required):** #339 

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change, malformed `--keep` values could be partially parsed instead of rejected.

Using the same three synthetic traces, malformed `--keep 1.5` and valid `--keep 1` produced the exact same deletion plan:

```powershell
node packages/cli/dist/index.cjs clean --dir .tmp-clean-evidence --keep 1.5 --dry-run
```

Output:

```text
Would delete 2 run(s):

- .tmp-clean-evidence\run_2.jsonl
- .tmp-clean-evidence\run_1.jsonl
```

Control:

```powershell
node packages/cli/dist/index.cjs clean --dir .tmp-clean-evidence --keep 1 --dry-run
```

Output:

```text
Would delete 2 run(s):

- .tmp-clean-evidence\run_2.jsonl
- .tmp-clean-evidence\run_1.jsonl
```

This shows that malformed `--keep 1.5` was accepted and behaved the same as valid `--keep 1`, rather than failing validation.

### Before

Malformed `--keep 1.5` is accepted and produces the exact same deletion plan as valid `--keep 1`.

<img width="925" height="251" alt="2026-09-04-224313" src="https://github.com/user-attachments/assets/c9b35b61-bbe2-49f5-a966-6b7cc4b57d09" />

After this change, the same malformed value is rejected before any deletion plan is produced:

```powershell
node packages/cli/dist/index.cjs clean --dir .tmp-clean-evidence --keep 1.5 --dry-run
```

Output:

```text
[AgentInspect] clean failed: Invalid --keep value: 1.5. Provide a positive integer.
```

### After

The same malformed value now fails validation before deletion planning.

<img width="945" height="75" alt="2026-09-04-224503" src="https://github.com/user-attachments/assets/a6a7dfc6-b187-4855-93ab-88fc4013a060" />

Leading-zero decimal counts such as `0010` remain accepted intentionally to preserve the existing CLI behavior while rejecting malformed or ambiguous numeric forms.

The regression coverage also verifies that invalid `--keep` values do not delete traces.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

```text
pnpm exec vitest run packages/cli/test/clean.test.ts
15/15 passed

pnpm run typecheck
PASS

pnpm run build:cli
PASS

git diff --check
clean
```

Full repository suite:

```text
1934/1936 passed
```

The two remaining failures reproduce independently of this change:

```text
check.test.ts JavaScript config
public-truth-sync.test.ts demo-verify
```
No public API, export, CLI help, schema, dependency, or network behavior was changed.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [x] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`). No docs update was needed here because the existing CLI contract already requires a positive integer.
- [x] `git diff --check` clean