### PR TITLE
fix(cli): strictly validate clean --keep counts (#340)

### DIFF
--- a/.changeset/fix-clean-keep-strict-6178.md
+++ b/.changeset/fix-clean-keep-strict-6178.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": patch
+"@agent-inspect/adapter-sdk": patch
+"@agent-inspect/ai-sdk": patch
+"@agent-inspect/circuit": patch
+"@agent-inspect/eval": patch
+"@agent-inspect/guardrails": patch
+"@agent-inspect/harness": patch
+"@agent-inspect/index-sqlite": patch
+"@agent-inspect/jest": patch
+"@agent-inspect/langchain": patch
+"@agent-inspect/mcp": patch
+"@agent-inspect/mcp-server": patch
+"@agent-inspect/openai-agents": patch
+"@agent-inspect/redact": patch
+"@agent-inspect/studio": patch
+"@agent-inspect/tui": patch
+"@agent-inspect/viewer": patch
+"@agent-inspect/vitest": patch
+---
+
+Strictly validate `clean --keep` as a complete positive decimal integer token before planning deletions, so malformed values like `1.5`, `1e2`, or `10oops` fail closed instead of partial-parsing (#339, #340).

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -18,13 +18,15 @@ export interface CleanOptions {
   yes?: boolean;
 }
 
+const DECIMAL_INTEGER_PATTERN = /^\d+$/;
+
 function parseKeep(raw?: string): number {
   const trimmed = typeof raw === "string" ? raw.trim() : "";
-  if (trimmed === "") {
+  if (!DECIMAL_INTEGER_PATTERN.test(trimmed)) {
     throw new Error(`Invalid --keep value: ${raw}. Provide a positive integer.`);
   }
-  const n = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(n) || n <= 0) {
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n <= 0) {
     throw new Error(`Invalid --keep value: ${raw}. Provide a positive integer.`);
   }
   return n;

--- a/packages/cli/test/clean.test.ts
+++ b/packages/cli/test/clean.test.ts
@@ -129,6 +129,20 @@ describe("clean", () => {
     logSpy.mockRestore();
   });
 
+  it("--keep accepts trimmed decimal counts with leading zeros", async () => {
+    const now = Date.now();
+    await writeTrace(traceDir, "run_leading_zero_old", "old", now - 20_000);
+    await writeTrace(traceDir, "run_leading_zero_new", "new", now - 10_000);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await clean({ dir: traceDir, keep: " 001 ", dryRun: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(process.exitCode).not.toBe(1);
+    expect(out).toContain("run_leading_zero_old.jsonl");
+    expect(out).not.toContain("run_leading_zero_new.jsonl");
+    logSpy.mockRestore();
+  });
+
   it("dry-run deletes nothing", async () => {
     const now = Date.now();
     await writeTrace(traceDir, "run_a", "a", now - 3_600_000);
@@ -176,11 +190,40 @@ describe("clean", () => {
     errSpy.mockRestore();
   });
 
-  it("invalid --keep fails clearly", async () => {
+  it("invalid --keep fails clearly without deleting traces", async () => {
+    const now = Date.now();
+    await writeTrace(traceDir, "run_invalid_keep_old", "old", now - 20_000);
+    await writeTrace(traceDir, "run_invalid_keep_new", "new", now - 10_000);
+
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await clean({ dir: traceDir, keep: "0", dryRun: true });
-    expect(process.exitCode).toBe(1);
-    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Invalid --keep"))).toBe(true);
+    const invalidValues = [
+      "0",
+      "000",
+      "-1",
+      "+1",
+      "1.0",
+      "1.5",
+      "10oops",
+      "1e2",
+      "0x10",
+      "Infinity",
+      "NaN",
+      String(Number.MAX_SAFE_INTEGER + 1),
+    ];
+
+    for (const keep of invalidValues) {
+      process.exitCode = 0;
+      errSpy.mockClear();
+
+      await clean({ dir: traceDir, keep, yes: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Invalid --keep"))).toBe(true);
+      expect(await readdir(traceDir)).toEqual(
+        expect.arrayContaining(["run_invalid_keep_old.jsonl", "run_invalid_keep_new.jsonl"]),
+      );
+    }
+
     errSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- Lands contributor fix from #340 / #339: `clean --keep` requires a complete positive decimal integer token
- Rejects `+1`, floats, exponents, hex, suffix garbage, and unsafe integers before any deletion plan
- Invalid values leave files untouched even with `--yes`
- Dedicated patch Changeset for 6.17.8 (not buried under queue-health)

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/clean.test.ts`
- [ ] CI green

Closes #339
Supersedes merge of fork PR #340 (same change, rebased on current main + changeset)