### PR TITLE
feat(examples): prove same final answer with wrong trajectory

### DIFF
--- a/.changeset/618-same-output-wrong-path.md
+++ b/.changeset/618-same-output-wrong-path.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": minor
+"@agent-inspect/adapter-sdk": minor
+"@agent-inspect/ai-sdk": minor
+"@agent-inspect/circuit": minor
+"@agent-inspect/eval": minor
+"@agent-inspect/guardrails": minor
+"@agent-inspect/harness": minor
+"@agent-inspect/index-sqlite": minor
+"@agent-inspect/jest": minor
+"@agent-inspect/langchain": minor
+"@agent-inspect/mcp": minor
+"@agent-inspect/mcp-server": minor
+"@agent-inspect/openai-agents": minor
+"@agent-inspect/redact": minor
+"@agent-inspect/studio": minor
+"@agent-inspect/tui": minor
+"@agent-inspect/viewer": minor
+"@agent-inspect/vitest": minor
+---
+
+Improve the broken-agent starter so good and regression paths return the same final answer while TraceContract trajectory checks PASS vs FAIL (`prove-same-output-wrong-path.mjs`).

--- a/docs/COMPARE.md
+++ b/docs/COMPARE.md
@@ -11,11 +11,17 @@ AgentInspect is a local-first trace workbench for TypeScript AI agents: capture 
 Position AgentInspect as the **inner-loop local evidence** layer:
 
 ```text
+Observability collects, searches, and monitors traces.
+AgentInspect lets a local TypeScript test or CI job fail when the agent
+takes an unacceptable path, then packages bounded reviewable evidence.
+
 local evidence and inner-loop debugging → AgentInspect
 production observability → LangSmith / Langfuse / MLflow / Phoenix / APM
 prompt/output and red-team eval → Promptfoo / Evalite / other eval tools
 generic OTel trace access via MCP → OTel MCP servers
 ```
+
+Proof: `examples/starters/broken-agent-debugging` — good and regression variants return the **same** final answer; trajectory checks PASS vs FAIL (`node prove-same-output-wrong-path.mjs`).
 
 Handoff story:
 

--- a/docs/FIRST-TRACE-IN-5-MINUTES.md
+++ b/docs/FIRST-TRACE-IN-5-MINUTES.md
@@ -73,7 +73,7 @@ npx agent-inspect redact <run-id> --dir .agent-inspect --profile share -o redact
 
 | If you use… | Go to |
 | ----------- | ----- |
-| Broken agent demo | [broken-agent-debugging starter](../examples/starters/broken-agent-debugging/README.md) |
+| Broken agent demo (same answer, wrong path) | [broken-agent-debugging starter](../examples/starters/broken-agent-debugging/README.md) (`node prove-same-output-wrong-path.mjs`) |
 | Coding-agent MCP loop | [CODING-AGENT-LOOP.md](./CODING-AGENT-LOOP.md) · [coding-agent-debug-loop](../examples/starters/coding-agent-debug-loop/README.md) |
 | Contracts / CI gates | [TRACE-CONTRACTS.md](./TRACE-CONTRACTS.md) · [SUITES-COHORTS-GATES.md](./SUITES-COHORTS-GATES.md) |
 | AI SDK | [AI SDK adoption](./AI-SDK-ADOPTION.md) |

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -24,7 +24,7 @@ npx agent-inspect redact <run-id> --dir .agent-inspect --profile share -o safe.j
 npx agent-inspect verify-safe <run-id> --dir .agent-inspect
 ```
 
-**Starter:** [broken-agent-debugging](../examples/starters/broken-agent-debugging/README.md) (intentional failure) or [custom-observe](../examples/starters/custom-observe/README.md)
+**Starter:** [broken-agent-debugging](../examples/starters/broken-agent-debugging/README.md) (same final answer, wrong trajectory — `node prove-same-output-wrong-path.mjs`) or [custom-observe](../examples/starters/custom-observe/README.md)
 
 **Not:** Live model replay or hosted trace UI.
 

--- a/examples/starters/broken-agent-debugging/README.md
+++ b/examples/starters/broken-agent-debugging/README.md
@@ -2,13 +2,39 @@
 
 Canonical keyless **Debug / Prevent / Share** showcase. Three synthetic variants, no API keys, no network.
 
+**Positioning:** Observability collects, searches, and monitors traces. AgentInspect lets a local TypeScript test or CI job fail when the agent takes an unacceptable path, then packages bounded reviewable evidence.
+
 | Variant | Run id | What it shows |
 | --- | --- | --- |
 | `good` | `demo-good` | plan → retrieve_policy → rank → generate → observed outcome passes |
-| `regression` | `demo-regression` | generate-before-retrieve, duplicate retrieve, failed tool, observed outcome fails |
+| `regression` | `demo-regression` | **same final answer**, but generate-before-retrieve, duplicate retrieve, forbidden `search_docs`, observed outcome fails |
 | `pii` | `demo-pii` | synthetic demo PII with `redact: false`; `verify-safe` reports source risk |
 
 Inbound scripts `pnpm start` / `pnpm run fixed` still work: start is the regression, fixed is the good path.
+
+## Same output, wrong path
+
+Both good and regression return:
+
+```text
+Per policy P-204: refunds are available within 30 days of purchase.
+```
+
+Prove divergence with shipped TraceContract APIs (`generate_answer` is an LLM step — it is not placed in `tools.requiredOrder`):
+
+```bash
+node prove-same-output-wrong-path.mjs
+```
+
+Expect:
+
+```text
+Final output equal: yes
+demo-good: PASS
+demo-regression: FAIL
+Failed invariants:
+- ...
+```
 
 ## Run
 

--- a/examples/starters/broken-agent-debugging/demo-agent.mjs
+++ b/examples/starters/broken-agent-debugging/demo-agent.mjs
@@ -3,6 +3,7 @@
  * Canonical keyless Debug / Prevent / Share showcase.
  * Variants: good | regression | pii
  *
+ * Good and regression return the same FINAL_ANSWER; trajectory checks diverge.
  * Stable run ids (createInspector) so walkthrough commands are copyable.
  * No API keys. No network.
  */
@@ -13,6 +14,8 @@ import { fileURLToPath } from "node:url";
 import { createInspector } from "agent-inspect";
 import { resolveTraceSafetyOptions } from "agent-inspect/advanced";
 import { fileWriter } from "agent-inspect/writers";
+
+import { FINAL_ANSWER } from "./final-answer.mjs";
 
 const starterDir = path.dirname(fileURLToPath(import.meta.url));
 const variant = (process.argv[2] ?? "regression").trim().toLowerCase();
@@ -66,14 +69,14 @@ async function runGood() {
       });
       await inspector.llm("generate_answer", async () => {
         await pause(20);
-        return "Per policy P-204: Refunds are available within 30 days of purchase.";
+        return FINAL_ANSWER;
       });
       await inspector.observeOutcome("policyShown", {
         expectation: "Refund policy visible to the customer",
         status: "passed",
         method: "custom",
       });
-      return "ok";
+      return FINAL_ANSWER;
     },
     { runId },
   );
@@ -83,9 +86,11 @@ async function runRegression() {
   return inspector.run(
     "demo-support-agent",
     async () => {
+      // Same customer-visible answer, unacceptable trajectory:
+      // generate before retrieve, duplicate retrieve, forbidden search_docs, failed outcome.
       await inspector.llm("generate_answer", async () => {
         await pause(20);
-        return "Guessing a refund policy without retrieval.";
+        return FINAL_ANSWER;
       });
       await inspector.tool("retrieve_policy", async () => {
         await pause(10);
@@ -107,7 +112,7 @@ async function runRegression() {
         status: "failed",
         method: "custom",
       });
-      return "regression";
+      return FINAL_ANSWER;
     },
     { runId },
   );
@@ -129,21 +134,22 @@ async function runPii() {
         },
       );
       await inspector.tool("retrieve_policy", async () => ({ policy: "P-204" }));
-      await inspector.llm("generate_answer", async () => "Policy P-204 applies.");
+      await inspector.llm("generate_answer", async () => FINAL_ANSWER);
       await inspector.observeOutcome("policyShown", {
         expectation: "Refund policy visible to the customer",
         status: "passed",
         method: "custom",
       });
-      return "pii";
+      return FINAL_ANSWER;
     },
     { runId },
   );
 }
 
-if (variant === "good") await runGood();
-else if (variant === "pii") await runPii();
-else await runRegression();
+let answer;
+if (variant === "good") answer = await runGood();
+else if (variant === "pii") answer = await runPii();
+else answer = await runRegression();
 
 await inspector.flush();
 await inspector.close();
@@ -151,6 +157,7 @@ await inspector.close();
 const relDir = path.relative(process.cwd(), traceDir) || ".";
 console.log(`Variant: ${variant}`);
 console.log(`Run ID: ${runId}`);
+console.log(`Final answer: ${answer}`);
 console.log(`Trace directory: ${relDir}`);
 console.log("");
 console.log("Copy the run id, then:");

--- a/examples/starters/broken-agent-debugging/final-answer.mjs
+++ b/examples/starters/broken-agent-debugging/final-answer.mjs
@@ -1,0 +1,3 @@
+/** Externally visible answer — identical for good and regression paths. */
+export const FINAL_ANSWER =
+  "Per policy P-204: refunds are available within 30 days of purchase.";

--- a/examples/starters/broken-agent-debugging/package.json
+++ b/examples/starters/broken-agent-debugging/package.json
@@ -7,7 +7,8 @@
     "good": "node demo-agent.mjs good",
     "regression": "node demo-agent.mjs regression",
     "pii": "node demo-agent.mjs pii",
-    "fixed": "node demo-agent.mjs good"
+    "fixed": "node demo-agent.mjs good",
+    "prove": "node prove-same-output-wrong-path.mjs"
   },
   "dependencies": {
     "agent-inspect": "workspace:*"

--- a/examples/starters/broken-agent-debugging/prove-same-output-wrong-path.mjs
+++ b/examples/starters/broken-agent-debugging/prove-same-output-wrong-path.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Prove same customer-visible answer with divergent trajectory checks.
+ * Usage (from this directory): node prove-same-output-wrong-path.mjs
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineTraceContract, evaluateTraceContract } from "agent-inspect/checks";
+import { openTrace } from "agent-inspect/readers";
+
+import { FINAL_ANSWER } from "./final-answer.mjs";
+
+const starterDir = path.dirname(fileURLToPath(import.meta.url));
+const demoAgent = path.join(starterDir, "demo-agent.mjs");
+const traceDir = path.join(starterDir, ".agent-inspect");
+
+function runVariant(variant) {
+  const result = spawnSync(process.execPath, [demoAgent, variant], {
+    cwd: starterDir,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`demo-agent ${variant} failed:\n${result.stderr || result.stdout}`);
+  }
+  const match = /Final answer: (.+)\n/.exec(result.stdout);
+  if (!match) {
+    throw new Error(`demo-agent ${variant} did not print Final answer`);
+  }
+  return match[1].trim();
+}
+
+/**
+ * Trajectory gate using shipped TraceContract APIs only.
+ * generate_answer is an LLM step — do not place it in tools.requiredOrder
+ * (that would misrepresent first-occurrence tool order as cross-kind causality).
+ */
+const contract = defineTraceContract({
+  run: {
+    requireCompleted: true,
+    allowedStatuses: ["success"],
+  },
+  tools: {
+    required: ["retrieve_policy"],
+    requiredOrder: ["retrieve_policy"],
+    forbidden: ["search_docs"],
+  },
+  observations: {
+    required: ["policyShown"],
+    failOn: ["failed", "unknown", "skipped"],
+  },
+});
+
+async function evaluate(runId) {
+  const read = await openTrace(
+    { type: "file", path: path.join(traceDir, `${runId}.jsonl`) },
+    { format: "agent-inspect-jsonl" },
+  );
+  return evaluateTraceContract({ read }, contract);
+}
+
+const goodAnswer = runVariant("good");
+const regressionAnswer = runVariant("regression");
+
+const good = await evaluate("demo-good");
+const regression = await evaluate("demo-regression");
+
+const outputEqual = goodAnswer === regressionAnswer && goodAnswer === FINAL_ANSWER;
+const goodPass = good.status === "pass";
+const regressionFail = regression.status === "fail";
+
+console.log(`Final output equal: ${outputEqual ? "yes" : "no"}`);
+console.log(`demo-good: ${goodPass ? "PASS" : "FAIL"}`);
+console.log(`demo-regression: ${regressionFail ? "FAIL" : "PASS"}`);
+if (regression.status === "fail") {
+  console.log("Failed invariants:");
+  for (const finding of regression.findings.filter((f) => f.status === "fail")) {
+    console.log(`- ${finding.ruleId}: ${finding.message}`);
+  }
+}
+
+if (!outputEqual || !goodPass || !regressionFail) {
+  process.exitCode = 1;
+}

--- a/packages/core/test/starters/broken-agent-same-output-wrong-path.test.ts
+++ b/packages/core/test/starters/broken-agent-same-output-wrong-path.test.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const starterDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../examples/starters/broken-agent-debugging",
+);
+
+describe("broken-agent-debugging same-output wrong-path", () => {
+  it("proves equal final answers with divergent TraceContract results", () => {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(starterDir, "prove-same-output-wrong-path.mjs")],
+      { cwd: starterDir, encoding: "utf8" },
+    );
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain("Final output equal: yes");
+    expect(result.stdout).toContain("demo-good: PASS");
+    expect(result.stdout).toContain("demo-regression: FAIL");
+  });
+});


### PR DESCRIPTION
## Summary
- 6.18.0-A: good and regression variants share `FINAL_ANSWER`; trajectory diverges
- `prove-same-output-wrong-path.mjs` + Vitest coverage
- Positioning updates in COMPARE / FIRST-TRACE / USE-CASES / starter README

## Test plan
- [x] `node examples/starters/broken-agent-debugging/prove-same-output-wrong-path.mjs`
- [x] `pnpm exec vitest run packages/core/test/starters/broken-agent-same-output-wrong-path.test.ts`