### PR TITLE
feat(cli): prune human view --errors-only into an error tree

### DIFF
--- a/.changeset/618-errors-only-tree.md
+++ b/.changeset/618-errors-only-tree.md
@@ -1,0 +1,22 @@
+---
+"agent-inspect": minor
+"@agent-inspect/adapter-sdk": minor
+"@agent-inspect/ai-sdk": minor
+"@agent-inspect/circuit": minor
+"@agent-inspect/eval": minor
+"@agent-inspect/guardrails": minor
+"@agent-inspect/harness": minor
+"@agent-inspect/index-sqlite": minor
+"@agent-inspect/jest": minor
+"@agent-inspect/langchain": minor
+"@agent-inspect/mcp": minor
+"@agent-inspect/mcp-server": minor
+"@agent-inspect/openai-agents": minor
+"@agent-inspect/redact": minor
+"@agent-inspect/studio": minor
+"@agent-inspect/tui": minor
+"@agent-inspect/viewer": minor
+"@agent-inspect/vitest": minor
+---
+
+Render `view --errors-only` as a pruned human error tree (ancestors + failed nodes) while keeping `--errors-only --json` as the filtered event list (#330).

--- a/packages/cli/src/view.ts
+++ b/packages/cli/src/view.ts
@@ -214,6 +214,18 @@ function filterErrorEvents(events: TraceEvent[]): TraceEvent[] {
   });
 }
 
+/** Keep failed nodes and ancestors needed to situate them; drop successful siblings. */
+function pruneErrorTree(nodes: StepNode[]): StepNode[] {
+  const pruned: StepNode[] = [];
+  for (const node of nodes) {
+    const children = pruneErrorTree(node.children);
+    if (node.status === "error" || children.length > 0) {
+      pruned.push({ ...node, children });
+    }
+  }
+  return pruned;
+}
+
 /**
  * Prints a single run as a tree (or JSON). Missing runs and invalid traces set `process.exitCode`
  * without throwing from normal paths.
@@ -306,12 +318,57 @@ export async function view(
     if (mode === "errors-only") {
       const errEvents = filterErrorEvents(events);
       if (options.json) {
+        // Machine-readable representation stays the filtered event list.
         console.log(JSON.stringify(errEvents, null, 2));
-      } else if (errEvents.length === 0) {
+        return;
+      }
+      if (errEvents.length === 0) {
         console.log("No errors found in trace");
+        return;
+      }
+
+      const started = events.find(
+        (e): e is RunStartedEvent => e.event === "run_started",
+      );
+      const completed = events.filter(
+        (e): e is RunCompletedEvent => e.event === "run_completed",
+      );
+      const last = completed[completed.length - 1];
+      const status: RunStatus = last ? last.status : "running";
+      const durationLine =
+        last !== undefined && Number.isFinite(last.durationMs)
+          ? formatDuration(last.durationMs)
+          : "-";
+      const startedTs =
+        started !== undefined && Number.isFinite(started.startTime)
+          ? started.startTime
+          : started?.timestamp;
+      const startedLabel =
+        startedTs !== undefined ? formatTimestamp(startedTs) : "-";
+
+      console.log(`AgentInspect Run: ${started?.name ?? id}`);
+      console.log(`ID: ${id}`);
+      console.log(`Status: ${status}`);
+      console.log(`Duration: ${durationLine}`);
+      console.log(`Started: ${startedLabel}`);
+      console.log("");
+      console.log("Error Tree:");
+
+      const pruned = pruneErrorTree(buildStepTree(events));
+      if (pruned.length === 0) {
+        // Run-level failure without step nodes (or unmatched lifecycle).
+        if (last?.status === "error") {
+          console.log(
+            renderErrorLine(
+              last.error ?? { message: "Run completed with error status" },
+              0,
+            ),
+          );
+        } else {
+          console.log("No error steps recorded");
+        }
       } else {
-        console.log("Error events");
-        console.log(JSON.stringify(errEvents, null, 2));
+        printStepTree(pruned, 0, options.verbose === true);
       }
       return;
     }

--- a/packages/cli/test/view.test.ts
+++ b/packages/cli/test/view.test.ts
@@ -256,8 +256,32 @@ describe("view", () => {
     logSpy.mockRestore();
   });
 
-  it("--errors-only shows only error events", async () => {
+  it("--errors-only shows a pruned human error tree", async () => {
     const runId = "run_errors_only";
+    const body = jsonl(
+      runStarted(runId, "e", 1, 1),
+      stepStarted(runId, "step_ok", "ok", 10),
+      stepCompleted(runId, "step_ok", "success", 20, 10),
+      stepStarted(runId, "step_parent", "parent", 25),
+      stepStarted(runId, "step_bad", "bad", 30, "step_parent"),
+      stepCompleted(runId, "step_bad", "error", 40, 10, { message: "oops" }),
+      stepCompleted(runId, "step_parent", "error", 41, 16),
+      runCompleted(runId, "error", 50, 49, { message: "run failed" }),
+    );
+    await writeFile(path.join(traceDir, `${runId}.jsonl`), body, "utf-8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await view(runId, { dir: traceDir, errorsOnly: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Error Tree:");
+    expect(out).toContain("parent");
+    expect(out).toContain("bad");
+    expect(out).toContain("oops");
+    expect(out).not.toContain("ok");
+    logSpy.mockRestore();
+  });
+
+  it("--errors-only --json keeps filtered event list compatibility", async () => {
+    const runId = "run_errors_only_json";
     const body = jsonl(
       runStarted(runId, "e", 1, 1),
       stepStarted(runId, "step_ok", "ok", 10),
@@ -268,10 +292,10 @@ describe("view", () => {
     );
     await writeFile(path.join(traceDir, `${runId}.jsonl`), body, "utf-8");
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await view(runId, { dir: traceDir, errorsOnly: true });
+    await view(runId, { dir: traceDir, errorsOnly: true, json: true });
     const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    expect(out).toContain("Error events");
-    expect(out).toContain("step_completed");
+    const parsed = JSON.parse(out) as Array<{ event: string; name?: string }>;
+    expect(parsed.some((e) => e.event === "step_completed")).toBe(true);
     expect(out).not.toContain("step_ok");
     logSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- 6.18.0-F / #330: human `--errors-only` prints a pruned Error Tree
- `--errors-only --json` unchanged (filtered event array)

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/view.test.ts`