### PR TITLE
docs: capture-path guide and VS Code deferral for 6.18

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -18,7 +18,7 @@ Reporters (`@agent-inspect/vitest` and `@agent-inspect/jest`) are public package
 
 ## Vercel AI SDK (`@agent-inspect/ai-sdk`)
 
-**Full guide:** [AI-SDK-ADOPTION.md](./AI-SDK-ADOPTION.md)
+**Full guide:** [AI-SDK-ADOPTION.md](./AI-SDK-ADOPTION.md) · **Capture path:** [CHOOSE-YOUR-CAPTURE-PATH.md](./CHOOSE-YOUR-CAPTURE-PATH.md)
 
 **Status:** experimental adapter — optional package published in the aligned v2.2.0 package set and hardened in the v2.3 adapter train.
 

--- a/docs/CHOOSE-YOUR-CAPTURE-PATH.md
+++ b/docs/CHOOSE-YOUR-CAPTURE-PATH.md
@@ -1,0 +1,47 @@
+# Choose your capture path
+
+Canonical guide for picking how AgentInspect records TypeScript agent evidence. Prefer this page before manually wrapping every step.
+
+**Positioning:** Observability collects, searches, and monitors traces. AgentInspect lets a local TypeScript test or CI job fail when the agent takes an unacceptable path, then packages bounded reviewable evidence.
+
+## Decision table
+
+| Workflow | Correct path |
+| --- | --- |
+| Custom TypeScript function/class | `inspectRun`, `createInspector`, `step` / `tool` / `llm` |
+| AI SDK (`generateText` / `streamText`) | `@agent-inspect/ai-sdk` |
+| LangChain / LangGraph | `@agent-inspect/langchain` |
+| OpenAI Agents JS | `@agent-inspect/openai-agents` |
+| MCP **client** calls inside an agent | `@agent-inspect/mcp` |
+| MCP **server** internals | Ordinary manual/framework tracing inside the server (no special package) |
+| Existing JSON logs | Log-to-tree ingest ([LOGGING-PLAYBOOK.md](./LOGGING-PLAYBOOK.md)) |
+| OTLP / OpenInference | Reader / `open` path ([STANDARDS.md](./STANDARDS.md)) |
+| Foreign persisted session JSON | Custom `TraceReader` (scheduled 6.19) |
+| Unsupported framework | Manual tracing or `@agent-inspect/adapter-sdk`; **no automatic-support claim** |
+
+There is **no** official Mastra adapter. Do not invent one from interest alone.
+
+## Boundary rule for `observe()`
+
+```text
+observe() captures a top-level boundary.
+It does not discover internal work.
+Use explicit steps or a supported adapter for internal detail.
+```
+
+## Official adapter no-key packed lifecycle (#213)
+
+Default CI paths must not require provider secrets:
+
+| Adapter | Lifecycle proof |
+| --- | --- |
+| `@agent-inspect/ai-sdk` | `scripts/packed-ai-sdk-e2e.mjs` (in `pnpm pack:smoke`) |
+| `@agent-inspect/openai-agents` | `scripts/packed-openai-agents-e2e.mjs` (in `pnpm pack:smoke`) |
+| `@agent-inspect/langchain` | Packed install + API smoke via `scripts/package-smoke.mjs` with `@langchain/core` peer; full agent-loop recipes remain keyless fixtures under `examples/` / LangGraph synthetic fixtures. A separate FakeLLM packed agent loop is not required for CI when the host SDK’s agent runtime is peer-heavy — the smoke + recipes path is the documented exception for full multi-package LangChain graphs. |
+
+## Related
+
+- [ADAPTERS.md](./ADAPTERS.md) — adapter scorecard and install snippets
+- [MCP-ROLES.md](./MCP-ROLES.md) — client tracing vs read-only MCP evidence server
+- [FIRST-TRACE-IN-5-MINUTES.md](./FIRST-TRACE-IN-5-MINUTES.md) — install → check → share
+- [COMPARE.md](./COMPARE.md) — where AgentInspect sits beside observability

--- a/docs/FIRST-TRACE-IN-5-MINUTES.md
+++ b/docs/FIRST-TRACE-IN-5-MINUTES.md
@@ -31,6 +31,8 @@ npx agent-inspect init --yes
 Creates `agent-inspect.config.ts`, `.agent-inspect/`, and `examples/agent-inspect-demo.mjs`.  
 `init` scaffolds files; it does **not** write a trace by itself.
 
+Framework users: pick the correct capture path first — [CHOOSE-YOUR-CAPTURE-PATH.md](./CHOOSE-YOUR-CAPTURE-PATH.md).
+
 ## Minutes 1–2: Run
 
 ```bash

--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -2,6 +2,14 @@
 
 Read-only sidebar for local trace directories. The extension shells out to the published `agent-inspect` CLI (`list`, `view`, `timeline`, `report`, `check`, `doctor`, `verify-safe`).
 
+**Support level:** Experimental (unpublished). Ignored by Changesets; not part of the fixed npm release group.
+
+## Product scope decision (6.18.0-H)
+
+**Disposition: defer (Option A).** Keep the in-repo extension unpublished. Core, official adapters, CLI, and Evidence take precedence over Marketplace packaging. Open PR #295 (sample trace command) and related issues (#66, #65) stay out of the active 6.18 implementation train until a later capacity window revisits VS Code.
+
+Do not merge #295 merely to clear the contributor queue.
+
 ## Develop
 
 ```bash


### PR DESCRIPTION
## Summary
- 6.18.0-G: `docs/CHOOSE-YOUR-CAPTURE-PATH.md` + onboarding links
- 6.18.0-B/#213: document official adapter no-key packed lifecycle matrix
- 6.18.0-H: VS Code Option A — defer unpublished Experimental; do not merge #295 to clear queue

## Test plan
- [x] Docs-only