### PR TITLE
feat(cli): residual safety after redact and bounded --policy (#328, #329)

### DIFF
--- a/.changeset/618-redact-residual-policy.md
+++ b/.changeset/618-redact-residual-policy.md
@@ -1,0 +1,5 @@
+---
+"agent-inspect": minor
+---
+
+Surface residual safety assessment after CLI `redact` (#328) and add a bounded local `--policy` JSON for redact/verify-safe (#329).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -445,12 +445,17 @@ Options:
 - `--profile <local|share|strict>`: redaction profile (default `share`)
 - `-o, --output <path>`: write redacted content to a file
 - `--json`: print deterministic JSON wrapper with findings
+- `--policy <path>`: local JSON redaction policy (`extraKeys` + bounded `literal` / `prefix` / `typed` patterns). No remote fetch; no secrets on argv. See [SAFETY-POLICY.md](SAFETY-POLICY.md).
+- `--fail-on-residual`: opt-in non-zero exit when residual safety is `UNSAFE` or `UNKNOWN` (default exit codes unchanged)
+
+After redaction, the command surfaces a **residual safety assessment** using the same local detector pipeline as `verify-safe`. Human mode prints a concise stderr warning when residual status is not `SAFE`. JSON mode adds an additive `residualAssessment` field (`status`, finding counts, codes only — never matched secret values). Residual status uses `SAFE` | `SAFE_WITH_WARNINGS` | `UNSAFE` | `UNKNOWN`. Supported AgentInspect traces get a full assessment; arbitrary JSON that is not a supported trace yields `UNKNOWN`. Redact never certifies safe sharing — finish with `verify-safe` before publishing.
 
 Examples:
 
 ```bash
 npx agent-inspect redact trace.jsonl --profile share --json
 npx agent-inspect redact trace.jsonl --profile strict -o trace.share.jsonl
+npx agent-inspect redact trace.jsonl --policy ./redact-policy.json --fail-on-residual
 ```
 
 Recipe: [redact-share-safe-file](../examples/recipes/redact-share-safe-file/README.md).
@@ -486,6 +491,7 @@ Options:
 - `--max-array-length <number>`: unsafe threshold for array values
 - `--max-object-keys <number>`: unsafe threshold for object key counts
 - `--max-serialized-bytes <number>`: unsafe threshold for serialized values
+- `--policy <path>`: local JSON redaction policy shared with `redact` (`extraKeys` + bounded patterns)
 
 The scan looks for raw prompt/output-like capture paths, unredacted sensitive-looking keys, secret-like string patterns, and oversized values. It reports evidence paths rather than raw prompt, output, request/response, header, API key, secret, or full tool payload values. Secret detection is best-effort and should not be treated as exhaustive.
 

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -6,7 +6,7 @@ AgentInspect traces, log-ingest outputs, and exports are local files. They may s
 
 This guide is practical sharing guidance, not a guarantee that any artifact is safe to publish. Redaction profiles are **best-effort transformation**, not compliance-grade DLP or a safety certification. Always finish with `verify-safe` before sharing.
 
-Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and require human review. Org-specific patterns need programmatic custom detectors today; a bounded local CLI policy is proposed separately and is not yet supported.
+Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and as residual status after `redact`. Org-specific patterns can use a local CLI `--policy` JSON file (`extraKeys` plus bounded literal/prefix/typed patterns) or programmatic custom detectors.
 
 `strict` is a stricter **rule set** (more keys), not a promise that every input produces bytes different from `share`.
 

--- a/docs/SAFETY-POLICY.md
+++ b/docs/SAFETY-POLICY.md
@@ -115,9 +115,22 @@ redact(
 );
 ```
 
-CLI custom policy files are **not** supported yet. Do not put secrets on the command line.
-3. **CLI size thresholds** on `scan` / `verify-safe` (`--max-string-length`, etc.) when oversized findings are false positives for your workload.
-4. **Bundle write override** with explicit `--allow-unsafe` after reviewing `verify-safe --explain` (records that the artifact was not share-gated).
+3. **CLI local policy file** (`--policy <path>` on `redact` / `verify-safe` / `scan`): JSON only, no remote fetch, no secrets on argv. Supports `extraKeys` plus bounded `literal` / `prefix` / `typed` patterns with max count/length and ReDoS protections. The same compiled policy drives redaction and residual/verify-safe detection.
+
+```json
+{
+  "version": 1,
+  "extraKeys": ["houseToken"],
+  "patterns": [
+    { "id": "houseLiteral", "type": "literal", "value": "HOUSE_MARK" },
+    { "id": "housePrefix", "type": "prefix", "value": "hsec_" },
+    { "id": "houseTyped", "type": "typed", "pattern": "hsec_[A-Za-z0-9]{8,24}" }
+  ]
+}
+```
+
+4. **CLI size thresholds** on `scan` / `verify-safe` (`--max-string-length`, etc.) when oversized findings are false positives for your workload.
+5. **Bundle write override** with explicit `--allow-unsafe` after reviewing `verify-safe --explain` (records that the artifact was not share-gated).
 
 High-confidence built-in credentials (including bounded `token=` / `api_key=` / `internal_token=` forms) are covered by built-in redaction profiles. Context-sensitive findings such as private filesystem paths may remain verification-only when automatic erasure would create excessive false positives or destroy legitimate debugging context. `redact` remains best-effort; `verify-safe` remains the final automated local assessment before sharing.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -612,6 +612,7 @@ export function createCliProgram(): Command {
     .option("--max-array-length <number>", "unsafe threshold for array values")
     .option("--max-object-keys <number>", "unsafe threshold for object key counts")
     .option("--max-serialized-bytes <number>", "unsafe threshold for serialized values")
+    .option("--policy <path>", "local JSON redaction policy (extraKeys + bounded patterns)")
     .action((target: string, opts: SafetyCommandOptions) => {
       runCommand(() => scanCommand(target, opts));
     });
@@ -635,6 +636,7 @@ export function createCliProgram(): Command {
     .option("--max-array-length <number>", "unsafe threshold for array values")
     .option("--max-object-keys <number>", "unsafe threshold for object key counts")
     .option("--max-serialized-bytes <number>", "unsafe threshold for serialized values")
+    .option("--policy <path>", "local JSON redaction policy (extraKeys + bounded patterns)")
     .action((target: string, opts: SafetyCommandOptions) => {
       runCommand(() => verifySafeCommand(target, opts));
     });
@@ -1002,6 +1004,11 @@ export function createCliProgram(): Command {
     .option("-o, --output <path>", "write redacted content to a file")
     .option("--out <path>", "alias for --output")
     .option("--json", "print deterministic JSON wrapper with findings")
+    .option("--policy <path>", "local JSON redaction policy (extraKeys + bounded patterns)")
+    .option(
+      "--fail-on-residual",
+      "exit non-zero when residual safety is UNSAFE or UNKNOWN (opt-in)",
+    )
     .action((target: string, opts: RedactCommandOptions) => {
       runCommand(() => redactCommand(target, opts));
     });

--- a/packages/cli/src/redact.ts
+++ b/packages/cli/src/redact.ts
@@ -101,8 +101,8 @@ function applyRedact(
 ): { value: unknown; findings: RedactionFinding[] } {
   const result = createRedactor({
     profile,
-    ...(policy?.extraKeys.length ? { extraKeys: policy.extraKeys } : {}),
-    ...(policy?.detectors.length ? { detectors: policy.detectors } : {}),
+    ...(policy?.extraKeys.length ? { extraKeys: [...policy.extraKeys] } : {}),
+    ...(policy?.detectors.length ? { detectors: [...policy.detectors] } : {}),
   }).redact(value);
   return { value: result.value, findings: result.findings };
 }

--- a/packages/cli/src/redact.ts
+++ b/packages/cli/src/redact.ts
@@ -5,7 +5,7 @@ import {
   resolveTraceDir,
 } from "@agent-inspect/core/advanced";
 import {
-  redact,
+  createRedactor,
   type RedactionFinding,
   type RedactionProfile,
 } from "@agent-inspect/redact";
@@ -14,6 +14,12 @@ import {
   resolveOutputOption,
   resolveRedactionProfileOption,
 } from "./cli-option-aliases.js";
+import type { CompiledRedactionPolicy } from "./redaction-policy.js";
+import { loadRedactionPolicy } from "./redaction-policy.js";
+import {
+  assessResidualFromContent,
+  type ResidualSafetyAssessment,
+} from "./safety.js";
 import { readStdin } from "./trace-input.js";
 
 export interface RedactCommandOptions {
@@ -23,6 +29,10 @@ export interface RedactCommandOptions {
   output?: string;
   out?: string;
   json?: boolean;
+  /** Local JSON path for bounded custom redaction policy (#329). */
+  policy?: string;
+  /** Opt-in: non-zero exit when residual assessment is UNSAFE or UNKNOWN (#328). */
+  failOnResidual?: boolean;
 }
 
 interface RedactedDocument {
@@ -84,16 +94,37 @@ async function contentFromTarget(
   return { content: await readFile(runPath, "utf-8"), source: runPath };
 }
 
-function redactJsonText(content: string, profile: RedactionProfile): RedactedDocument {
+function applyRedact(
+  value: unknown,
+  profile: RedactionProfile,
+  policy: CompiledRedactionPolicy | undefined,
+): { value: unknown; findings: RedactionFinding[] } {
+  const result = createRedactor({
+    profile,
+    ...(policy?.extraKeys.length ? { extraKeys: policy.extraKeys } : {}),
+    ...(policy?.detectors.length ? { detectors: policy.detectors } : {}),
+  }).redact(value);
+  return { value: result.value, findings: result.findings };
+}
+
+function redactJsonText(
+  content: string,
+  profile: RedactionProfile,
+  policy: CompiledRedactionPolicy | undefined,
+): RedactedDocument {
   const parsed = JSON.parse(content) as unknown;
-  const result = redact(parsed, { profile });
+  const result = applyRedact(parsed, profile, policy);
   return {
     content: `${JSON.stringify(result.value, null, 2)}\n`,
     findings: result.findings,
   };
 }
 
-function redactJsonlText(content: string, profile: RedactionProfile): RedactedDocument {
+function redactJsonlText(
+  content: string,
+  profile: RedactionProfile,
+  policy: CompiledRedactionPolicy | undefined,
+): RedactedDocument {
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
   const findings: RedactionFinding[] = [];
@@ -109,7 +140,7 @@ function redactJsonlText(content: string, profile: RedactionProfile): RedactedDo
       throw new Error(`Input is not valid JSON or JSONL at line ${index + 1}.`);
     }
 
-    const result = redact(parsed, { profile });
+    const result = applyRedact(parsed, profile, policy);
     out.push(JSON.stringify(result.value));
     findings.push(
       ...result.findings.map((finding) => ({
@@ -125,7 +156,11 @@ function redactJsonlText(content: string, profile: RedactionProfile): RedactedDo
   };
 }
 
-function redactDocument(content: string, profile: RedactionProfile): RedactedDocument {
+function redactDocument(
+  content: string,
+  profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
+): RedactedDocument {
   const trimmed = content.trim();
   // Single-line AgentInspect events parse as JSON but must stay JSONL for re-read.
   if (trimmed.startsWith("{")) {
@@ -137,16 +172,16 @@ function redactDocument(content: string, profile: RedactionProfile): RedactedDoc
         !Array.isArray(parsed) &&
         ("schemaVersion" in parsed || "eventId" in parsed || "runId" in parsed)
       ) {
-        return redactJsonlText(content, profile);
+        return redactJsonlText(content, profile, policy);
       }
     } catch {
       // fall through
     }
   }
   try {
-    return redactJsonText(content, profile);
+    return redactJsonText(content, profile, policy);
   } catch {
-    return redactJsonlText(content, profile);
+    return redactJsonlText(content, profile, policy);
   }
 }
 
@@ -154,8 +189,46 @@ function redactDocument(content: string, profile: RedactionProfile): RedactedDoc
 export function redactTraceContent(
   content: string,
   profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
 ): RedactedDocument {
-  return redactDocument(content, profile);
+  return redactDocument(content, profile, policy);
+}
+
+function looksLikeAgentInspectTrace(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{")) return false;
+  try {
+    const firstLine = trimmed.split(/\r?\n/).find((line) => line.trim() !== "") ?? trimmed;
+    const parsed = JSON.parse(firstLine) as unknown;
+    return (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      ("schemaVersion" in parsed || "eventId" in parsed || "runId" in parsed)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function printResidualWarning(
+  assessment: ResidualSafetyAssessment,
+  sourceLooksLikeTrace: boolean,
+): void {
+  if (assessment.status === "SAFE") return;
+  // Arbitrary JSON that is not a supported trace yields UNKNOWN; keep human stdout quiet.
+  if (assessment.status === "UNKNOWN" && !sourceLooksLikeTrace) return;
+  const codes =
+    assessment.codes.length > 0 ? ` codes=${assessment.codes.join(",")}` : "";
+  console.error(
+    `Residual safety: ${assessment.status} (findings=${assessment.findings}, warnings=${assessment.warnings}, errors=${assessment.errors})${codes}. Redact does not certify safe sharing; run verify-safe before publishing.`,
+  );
+}
+
+function residualExitCode(assessment: ResidualSafetyAssessment): number {
+  if (assessment.status === "UNSAFE") return 1;
+  if (assessment.status === "UNKNOWN") return 2;
+  return 0;
 }
 
 export async function redactCommand(
@@ -164,12 +237,21 @@ export async function redactCommand(
   stdin: NodeJS.ReadableStream = process.stdin,
 ): Promise<void> {
   const profile = parseRedactionProfile(resolveRedactionProfileOption(options));
+  const policy =
+    options.policy !== undefined ? await loadRedactionPolicy(options.policy) : undefined;
   const source = await contentFromTarget(target, options, stdin);
-  const redacted = redactDocument(source.content, profile);
+  const redacted = redactDocument(source.content, profile, policy);
   const outputPath = resolveOutputOption(options);
+  const residualAssessment = await assessResidualFromContent(redacted.content, {
+    compiledPolicy: policy,
+  });
 
   if (outputPath !== undefined) {
     await writeFile(outputPath, redacted.content, "utf-8");
+  }
+
+  if (options.failOnResidual === true) {
+    process.exitCode = residualExitCode(residualAssessment);
   }
 
   if (options.json) {
@@ -181,6 +263,17 @@ export async function redactCommand(
           source: source.source,
           output: outputPath,
           findings: redacted.findings,
+          residualAssessment,
+          ...(policy !== undefined
+            ? {
+                policy: {
+                  path: policy.path,
+                  extraKeys: policy.extraKeys.length,
+                  patterns: policy.detectors.length,
+                  diagnostics: policy.diagnostics,
+                },
+              }
+            : {}),
           content: outputPath === undefined ? redacted.content : undefined,
         }),
         null,
@@ -189,6 +282,8 @@ export async function redactCommand(
     );
     return;
   }
+
+  printResidualWarning(residualAssessment, looksLikeAgentInspectTrace(redacted.content));
 
   if (outputPath === undefined) {
     process.stdout.write(redacted.content);

--- a/packages/cli/src/redaction-policy.ts
+++ b/packages/cli/src/redaction-policy.ts
@@ -1,0 +1,305 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { RedactionDetector, RedactionSeverity } from "@agent-inspect/redact";
+
+/** Hard bounds for local CLI redaction policies (#329). */
+export const REDACTION_POLICY_LIMITS = {
+  maxExtraKeys: 64,
+  maxKeyLength: 64,
+  maxPatterns: 32,
+  maxPatternLength: 128,
+  maxPatternIdLength: 64,
+  maxTypedQuantifier: 64,
+} as const;
+
+export type RedactionPolicyPatternType = "literal" | "prefix" | "typed";
+
+export interface RedactionPolicyPatternInput {
+  id?: unknown;
+  type?: unknown;
+  value?: unknown;
+  pattern?: unknown;
+  severity?: unknown;
+}
+
+export interface RedactionPolicyFile {
+  version?: unknown;
+  extraKeys?: unknown;
+  patterns?: unknown;
+}
+
+export interface PolicyDiagnostic {
+  code: string;
+  message: string;
+}
+
+export interface CompiledRedactionPolicy {
+  path: string;
+  extraKeys: readonly string[];
+  detectors: readonly RedactionDetector[];
+  diagnostics: readonly PolicyDiagnostic[];
+}
+
+const SAFE_TYPED_PATTERN =
+  /^[A-Za-z0-9_@./:=<>\-[\]()|+*?{},\\\s^$]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function rejectRemotePolicyPath(policyPath: string): void {
+  const trimmed = policyPath.trim();
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    throw new Error(
+      `--policy must be a local JSON file path (got a URL-like value). Remote policy fetch is not supported.`,
+    );
+  }
+}
+
+function parseSeverity(value: unknown, label: string): RedactionSeverity {
+  if (value === undefined) return "error";
+  if (value === "info" || value === "warning" || value === "error") return value;
+  throw new Error(`${label} severity must be info, warning, or error.`);
+}
+
+function validateExtraKey(key: string, index: number): string {
+  const label = `extraKeys[${index}]`;
+  if (key.length === 0) throw new Error(`${label} must be a non-empty string.`);
+  if (key.length > REDACTION_POLICY_LIMITS.maxKeyLength) {
+    throw new Error(
+      `${label} exceeds max length ${REDACTION_POLICY_LIMITS.maxKeyLength}.`,
+    );
+  }
+  if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(key)) {
+    throw new Error(
+      `${label} must be an identifier-like key (letters, digits, _, ., -).`,
+    );
+  }
+  return key;
+}
+
+function assertBoundedTypedPattern(pattern: string, label: string): void {
+  if (pattern.length === 0) throw new Error(`${label} must be non-empty.`);
+  if (pattern.length > REDACTION_POLICY_LIMITS.maxPatternLength) {
+    throw new Error(
+      `${label} exceeds max length ${REDACTION_POLICY_LIMITS.maxPatternLength}.`,
+    );
+  }
+  if (!SAFE_TYPED_PATTERN.test(pattern)) {
+    throw new Error(
+      `${label} contains unsupported characters for bounded typed patterns.`,
+    );
+  }
+  // Reject constructs that commonly enable ReDoS or unbounded matching.
+  if (/\(\?/.test(pattern) || /\\[1-9]/.test(pattern)) {
+    throw new Error(
+      `${label} rejects lookaround, backreferences, and nested quantifiers.`,
+    );
+  }
+  // Nested quantifiers: a quantified group that is itself quantified, e.g. (a+)+
+  if (/\([^)]*[+*{][^)]*\)[+*{]/.test(pattern) || /\[[^\]]*[+*{][^\]]*\][+*{]/.test(pattern)) {
+    throw new Error(`${label} rejects nested quantifiers.`);
+  }
+  if (/\.[*+]/.test(pattern) || /[*+]\{/.test(pattern)) {
+    throw new Error(`${label} rejects unbounded .* / .+ style quantifiers.`);
+  }
+  for (const match of pattern.matchAll(/\{(\d+)(?:,(\d*))?\}/g)) {
+    const min = Number(match[1]);
+    const maxRaw = match[2];
+    const max = maxRaw === undefined || maxRaw === "" ? min : Number(maxRaw);
+    if (
+      !Number.isFinite(min) ||
+      !Number.isFinite(max) ||
+      min > REDACTION_POLICY_LIMITS.maxTypedQuantifier ||
+      max > REDACTION_POLICY_LIMITS.maxTypedQuantifier
+    ) {
+      throw new Error(
+        `${label} quantifiers must be <= ${REDACTION_POLICY_LIMITS.maxTypedQuantifier}.`,
+      );
+    }
+  }
+}
+
+function compilePatternDetector(
+  input: RedactionPolicyPatternInput,
+  index: number,
+): RedactionDetector {
+  const label = `patterns[${index}]`;
+  if (!isRecord(input)) throw new Error(`${label} must be an object.`);
+
+  const idRaw = input.id;
+  if (typeof idRaw !== "string" || idRaw.trim() === "") {
+    throw new Error(`${label}.id must be a non-empty string.`);
+  }
+  const id = idRaw.trim();
+  if (id.length > REDACTION_POLICY_LIMITS.maxPatternIdLength) {
+    throw new Error(
+      `${label}.id exceeds max length ${REDACTION_POLICY_LIMITS.maxPatternIdLength}.`,
+    );
+  }
+  if (!/^[A-Za-z][A-Za-z0-9._-]*$/.test(id)) {
+    throw new Error(`${label}.id must be an identifier-like detector id.`);
+  }
+
+  const type = input.type;
+  if (type !== "literal" && type !== "prefix" && type !== "typed") {
+    throw new Error(`${label}.type must be literal, prefix, or typed.`);
+  }
+
+  const severity = parseSeverity(input.severity, label);
+  let source: string;
+  if (type === "typed") {
+    if (typeof input.pattern !== "string") {
+      throw new Error(`${label}.pattern must be a string for typed patterns.`);
+    }
+    assertBoundedTypedPattern(input.pattern, `${label}.pattern`);
+    source = input.pattern;
+  } else {
+    if (typeof input.value !== "string") {
+      throw new Error(`${label}.value must be a string for ${type} patterns.`);
+    }
+    if (input.value.length === 0) {
+      throw new Error(`${label}.value must be non-empty.`);
+    }
+    if (input.value.length > REDACTION_POLICY_LIMITS.maxPatternLength) {
+      throw new Error(
+        `${label}.value exceeds max length ${REDACTION_POLICY_LIMITS.maxPatternLength}.`,
+      );
+    }
+    const escaped = escapeRegExp(input.value);
+    source = type === "prefix" ? `^${escaped}` : escaped;
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(source);
+  } catch (error) {
+    throw new Error(
+      `${label} failed to compile: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return {
+    id: `policy.${id}`,
+    severity,
+    matchKind: "custom",
+    detect({ value }) {
+      if (typeof value !== "string") return [];
+      regex.lastIndex = 0;
+      return regex.test(value) ? [{ action: "replace", severity, matchKind: "custom" }] : [];
+    },
+  };
+}
+
+/**
+ * Compile a local redaction policy object into extraKeys + detectors.
+ * Throws deterministic errors for invalid or unbounded input.
+ */
+export function compileRedactionPolicy(
+  raw: unknown,
+  policyPath: string,
+): CompiledRedactionPolicy {
+  if (!isRecord(raw)) {
+    throw new Error(`Redaction policy must be a JSON object (${policyPath}).`);
+  }
+
+  const diagnostics: PolicyDiagnostic[] = [];
+  if (raw.version !== undefined && raw.version !== 1) {
+    throw new Error(`Unsupported redaction policy version (supported: 1).`);
+  }
+
+  const extraKeysRaw = raw.extraKeys;
+  const extraKeys: string[] = [];
+  if (extraKeysRaw !== undefined) {
+    if (!Array.isArray(extraKeysRaw)) {
+      throw new Error(`extraKeys must be an array of strings.`);
+    }
+    if (extraKeysRaw.length > REDACTION_POLICY_LIMITS.maxExtraKeys) {
+      throw new Error(
+        `extraKeys exceeds max count ${REDACTION_POLICY_LIMITS.maxExtraKeys}.`,
+      );
+    }
+    for (let i = 0; i < extraKeysRaw.length; i += 1) {
+      const key = extraKeysRaw[i];
+      if (typeof key !== "string") {
+        throw new Error(`extraKeys[${i}] must be a string.`);
+      }
+      extraKeys.push(validateExtraKey(key, i));
+    }
+  }
+
+  const patternsRaw = raw.patterns;
+  const detectors: RedactionDetector[] = [];
+  if (patternsRaw !== undefined) {
+    if (!Array.isArray(patternsRaw)) {
+      throw new Error(`patterns must be an array.`);
+    }
+    if (patternsRaw.length > REDACTION_POLICY_LIMITS.maxPatterns) {
+      throw new Error(
+        `patterns exceeds max count ${REDACTION_POLICY_LIMITS.maxPatterns}.`,
+      );
+    }
+    const seenIds = new Set<string>();
+    for (let i = 0; i < patternsRaw.length; i += 1) {
+      const detector = compilePatternDetector(
+        patternsRaw[i] as RedactionPolicyPatternInput,
+        i,
+      );
+      if (seenIds.has(detector.id)) {
+        throw new Error(`Duplicate pattern id "${detector.id}".`);
+      }
+      seenIds.add(detector.id);
+      detectors.push(detector);
+    }
+  }
+
+  if (extraKeys.length === 0 && detectors.length === 0) {
+    diagnostics.push({
+      code: "AI_POLICY_EMPTY",
+      message: "Redaction policy contained no extraKeys or patterns.",
+    });
+  }
+
+  return {
+    path: policyPath,
+    extraKeys,
+    detectors,
+    diagnostics,
+  };
+}
+
+/** Load and compile a local JSON redaction policy file. Never fetches remotes. */
+export async function loadRedactionPolicy(
+  policyPath: string,
+): Promise<CompiledRedactionPolicy> {
+  rejectRemotePolicyPath(policyPath);
+  const resolved = path.resolve(policyPath);
+  let text: string;
+  try {
+    text = await readFile(resolved, "utf-8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read --policy file "${resolved}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in --policy file "${resolved}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  return compileRedactionPolicy(parsed, resolved);
+}

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -394,13 +394,13 @@ function classifyRedactionDetector(detector: string): {
 }
 
 function redactionOptionsFromPolicy(policy: CompiledRedactionPolicy | undefined): {
-  extraKeys?: readonly string[];
-  detectors?: readonly RedactionDetector[];
+  extraKeys?: string[];
+  detectors?: RedactionDetector[];
 } {
   if (policy === undefined) return {};
   return {
-    ...(policy.extraKeys.length > 0 ? { extraKeys: policy.extraKeys } : {}),
-    ...(policy.detectors.length > 0 ? { detectors: policy.detectors } : {}),
+    ...(policy.extraKeys.length > 0 ? { extraKeys: [...policy.extraKeys] } : {}),
+    ...(policy.detectors.length > 0 ? { detectors: [...policy.detectors] } : {}),
   };
 }
 

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -15,9 +15,16 @@ import {
   type TraceCheckFinding,
   type TraceCheckRule,
 } from "@agent-inspect/core/checks";
-import { redact, type RedactionFinding, type RedactionProfile } from "@agent-inspect/redact";
+import {
+  createRedactor,
+  type RedactionDetector,
+  type RedactionFinding,
+  type RedactionProfile,
+} from "@agent-inspect/redact";
 
 import { redactTraceContent } from "./redact.js";
+import type { CompiledRedactionPolicy } from "./redaction-policy.js";
+import { loadRedactionPolicy } from "./redaction-policy.js";
 import { inputFromTarget } from "./trace-input.js";
 
 export interface SafetyCommandOptions {
@@ -32,10 +39,31 @@ export interface SafetyCommandOptions {
   maxSerializedBytes?: string;
   /** Redaction profile used when deriving the artifact assessment (verify-safe). */
   redactionProfile?: RedactionProfile;
+  /** Local JSON path for bounded custom redaction policy (#329). */
+  policy?: string;
+  /** Pre-compiled policy (tests / shared redact+verify path). */
+  compiledPolicy?: CompiledRedactionPolicy;
 }
 
 type SafetyStatus = "SAFE" | "SAFE WITH WARNINGS" | "UNSAFE" | "UNKNOWN";
 type SafetyCommandName = "scan" | "verify-safe";
+
+/** Residual assessment status after redact (#328); underscore form for JSON stability. */
+export type ResidualSafetyStatus =
+  | "SAFE"
+  | "SAFE_WITH_WARNINGS"
+  | "UNSAFE"
+  | "UNKNOWN";
+
+/** Compact residual assessment: counts and codes only — never secret values. */
+export interface ResidualSafetyAssessment {
+  status: ResidualSafetyStatus;
+  findings: number;
+  warnings: number;
+  errors: number;
+  codes: string[];
+  note: string;
+}
 
 interface SafetyDiagnostic {
   code: string;
@@ -365,21 +393,37 @@ function classifyRedactionDetector(detector: string): {
   return { category: "credential", confidence: "medium" };
 }
 
+function redactionOptionsFromPolicy(policy: CompiledRedactionPolicy | undefined): {
+  extraKeys?: readonly string[];
+  detectors?: readonly RedactionDetector[];
+} {
+  if (policy === undefined) return {};
+  return {
+    ...(policy.extraKeys.length > 0 ? { extraKeys: policy.extraKeys } : {}),
+    ...(policy.detectors.length > 0 ? { detectors: policy.detectors } : {}),
+  };
+}
+
 function redactionDetectorFindings(
   read: Awaited<ReturnType<typeof openTrace>>,
   runId: string | undefined,
+  policy?: CompiledRedactionPolicy,
 ): TraceCheckFinding[] {
   const runs = runId === undefined
     ? read.runs
     : read.runs.filter((run) => run.runId === runId);
   const out: TraceCheckFinding[] = [];
+  const policyOptions = redactionOptionsFromPolicy(policy);
 
   for (const run of runs) {
     for (const node of flattenNodes(run.children)) {
       const attrs = node.event.attributes;
       if (attrs === undefined) continue;
 
-      const result = redact(attrs, { profile: "share" });
+      const result = createRedactor({
+        profile: "share",
+        ...policyOptions,
+      }).redact(attrs);
       for (const finding of result.findings) {
         if (finding.action === "keep") continue;
         const taxonomy = classifyRedactionDetector(finding.detector);
@@ -426,6 +470,72 @@ function exitCodeFor(result: SafetyResult): number {
   if (result.status === "SAFE" || result.status === "SAFE WITH WARNINGS") return 0;
   if (result.status === "UNSAFE") return 1;
   return 2;
+}
+
+function toResidualStatus(status: SafetyStatus): ResidualSafetyStatus {
+  if (status === "SAFE WITH WARNINGS") return "SAFE_WITH_WARNINGS";
+  return status;
+}
+
+/** Map a full safety result into a residual assessment (no secret values). */
+export function toResidualSafetyAssessment(result: {
+  status: SafetyStatus;
+  summary: SafetySummary;
+  diagnostics: readonly SafetyDiagnostic[];
+  findings: readonly TraceCheckFinding[];
+}): ResidualSafetyAssessment {
+  const codes = [
+    ...new Set([
+      ...result.diagnostics.map((item) => item.code),
+      ...result.findings.map((item) => item.ruleId),
+    ]),
+  ].sort((a, b) => a.localeCompare(b));
+  return {
+    status: toResidualStatus(result.status),
+    findings: result.summary.findings,
+    warnings: result.summary.warnings,
+    errors: result.summary.errors,
+    codes,
+    note: BEST_EFFORT_NOTE,
+  };
+}
+
+/**
+ * Assess residual safety on already-redacted content using the canonical
+ * verify-safe detector pipeline. Supported AgentInspect traces get full
+ * assessment; arbitrary JSON that cannot be opened as a trace yields UNKNOWN.
+ */
+export async function assessResidualFromContent(
+  content: string,
+  options: SafetyCommandOptions = {},
+): Promise<ResidualSafetyAssessment> {
+  try {
+    const policy =
+      options.compiledPolicy ??
+      (options.policy !== undefined ? await loadRedactionPolicy(options.policy) : undefined);
+    const read = await openTrace(
+      { type: "string", content },
+      { format: options.format ?? "agent-inspect-jsonl" },
+    );
+    const result = assessOpenedTrace(read, {
+      ...options,
+      ...(policy !== undefined ? { compiledPolicy: policy } : {}),
+    });
+    return toResidualSafetyAssessment(result);
+  } catch (error) {
+    if (error instanceof TraceReadError) {
+      return toResidualSafetyAssessment(readErrorResult("verify-safe", error));
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      status: "UNKNOWN",
+      findings: 0,
+      warnings: 0,
+      errors: 1,
+      codes: ["AI_SAFETY_TRACE_UNREADABLE"],
+      note: `${BEST_EFFORT_NOTE} Residual assessment requires a supported AgentInspect trace; ${message}`,
+    };
+  }
 }
 
 function explainFinding(finding: TraceCheckFinding, blocksBundle: boolean): string[] {
@@ -519,12 +629,19 @@ async function safetyCommand(
   let result: SafetyResult;
 
   try {
-    const input = await inputFromTarget(target, options, stdin);
+    const policy =
+      options.compiledPolicy ??
+      (options.policy !== undefined ? await loadRedactionPolicy(options.policy) : undefined);
+    const optionsWithPolicy: SafetyCommandOptions = {
+      ...options,
+      ...(policy !== undefined ? { compiledPolicy: policy } : {}),
+    };
+    const input = await inputFromTarget(target, optionsWithPolicy, stdin);
     const read = await openTrace(input, {
       ...(options.format !== undefined ? { format: options.format } : {}),
     });
     const source = assessOpenedTrace(read, {
-      ...options,
+      ...optionsWithPolicy,
       ...(options.run !== undefined ? { runId: options.run } : {}),
     });
     if (command === "scan") {
@@ -546,7 +663,7 @@ async function safetyCommand(
           sourceAssessment: layerFromResult(source),
         };
       } else {
-        const redacted = redactTraceContent(rawContent, profile);
+        const redacted = redactTraceContent(rawContent, profile, policy);
         // Reader labels (e.g. agent-inspect-v0.2-jsonl) are not registered format ids;
         // re-open redacted content with the canonical JSONL reader id.
         const artifactRead = await openTrace(
@@ -554,7 +671,7 @@ async function safetyCommand(
           { format: options.format ?? "agent-inspect-jsonl" },
         );
         const artifact = assessOpenedTrace(artifactRead, {
-          ...options,
+          ...optionsWithPolicy,
           ...(options.run !== undefined ? { runId: options.run } : {}),
         });
         const detectors = [
@@ -581,7 +698,7 @@ async function safetyCommand(
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    result = message.startsWith("--")
+    result = message.startsWith("--") || message.includes("--policy")
       ? invalidArgumentResult(command, error)
       : readErrorResult(command, error);
   }
@@ -624,7 +741,7 @@ export function assessOpenedTrace(
     );
     const detectorFindings =
       checkResult.diagnostics.length === 0
-        ? redactionDetectorFindings(read, checkResult.runId)
+        ? redactionDetectorFindings(read, checkResult.runId, options.compiledPolicy)
         : [];
     return resultFromParts({
       command: "verify-safe",

--- a/packages/cli/test/redact-residual-policy.test.ts
+++ b/packages/cli/test/redact-residual-policy.test.ts
@@ -1,0 +1,246 @@
+import { PassThrough } from "node:stream";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { redactCommand } from "../src/redact.js";
+import {
+  compileRedactionPolicy,
+  loadRedactionPolicy,
+  REDACTION_POLICY_LIMITS,
+} from "../src/redaction-policy.js";
+
+function stdinFrom(text: string): NodeJS.ReadableStream {
+  const stream = new PassThrough();
+  stream.end(text);
+  return stream;
+}
+
+function jsonl(row: unknown): string {
+  return `${JSON.stringify(row)}\n`;
+}
+
+function event(attributes: Record<string, unknown>): string {
+  return jsonl({
+    schemaVersion: "0.2",
+    eventId: "event-a",
+    runId: "run-residual-policy",
+    kind: "RUN",
+    name: "residual-policy",
+    status: "ok",
+    timestamp: "2026-06-26T00:00:00.000Z",
+    confidence: "explicit",
+    source: { type: "manual" },
+    attributes,
+  });
+}
+
+describe("redact residual assessment (#328)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-residual-"));
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("adds residualAssessment to JSON without changing default exit code", async () => {
+    const file = path.join(tmp, "safe.jsonl");
+    await writeFile(file, event({ note: "ok" }), "utf-8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, profile: "share" });
+
+    const result = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      residualAssessment?: { status?: string; codes?: string[]; note?: string };
+      findings?: unknown[];
+    };
+    expect(process.exitCode ?? 0).toBe(0);
+    expect(result.residualAssessment?.status).toBeDefined();
+    expect(result.residualAssessment?.note).toContain("Best-effort");
+    expect(JSON.stringify(result)).not.toMatch(/sk-|Bearer |password=/i);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns on stderr in human mode when residual is not SAFE", async () => {
+    const file = path.join(tmp, "paths.jsonl");
+    // Private filesystem paths often remain as residual context-sensitive findings.
+    await writeFile(
+      file,
+      event({
+        workspacePath: "/Users/private-user/secret-project/src/index.ts",
+        note: "review",
+      }),
+      "utf-8",
+    );
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await redactCommand(file, { profile: "share" });
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const stderr = errSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    if (stderr.includes("Residual safety:")) {
+      expect(stderr).toMatch(/Residual safety: (SAFE_WITH_WARNINGS|UNSAFE|UNKNOWN)/);
+      expect(stderr).not.toContain("/Users/private-user");
+    }
+    expect(writeSpy).toHaveBeenCalled();
+  });
+
+  it("supports --fail-on-residual opt-in exit codes", async () => {
+    const file = path.join(tmp, "plain.json");
+    await writeFile(file, JSON.stringify({ hello: "world" }), "utf-8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, failOnResidual: true, profile: "share" });
+
+    const result = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      residualAssessment?: { status?: string };
+    };
+    // Arbitrary JSON is not a supported AgentInspect trace → UNKNOWN residual.
+    expect(result.residualAssessment?.status).toBe("UNKNOWN");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("never prints matched secret values in residual output", async () => {
+    const secret = "sk-fixtureResidualSecretValue123456789";
+    const file = path.join(tmp, "secret.jsonl");
+    await writeFile(file, event({ apiKey: secret, note: "x" }), "utf-8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, profile: "share" });
+
+    const payload = String(logSpy.mock.calls[0]?.[0] ?? "");
+    const stderr = errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+    expect(payload).not.toContain(secret);
+    expect(stderr).not.toContain(secret);
+    expect(payload).toContain("[REDACTED]");
+  });
+});
+
+describe("bounded redaction policy (#329)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-policy-"));
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("compiles extraKeys and bounded patterns deterministically", () => {
+    const compiled = compileRedactionPolicy(
+      {
+        version: 1,
+        extraKeys: ["houseToken"],
+        patterns: [
+          { id: "houseLiteral", type: "literal", value: "HOUSE_MARK" },
+          { id: "housePrefix", type: "prefix", value: "hsec_" },
+          { id: "houseTyped", type: "typed", pattern: "hsec_[A-Za-z0-9]{8,24}" },
+        ],
+      },
+      "/tmp/policy.json",
+    );
+    expect(compiled.extraKeys).toEqual(["houseToken"]);
+    expect(compiled.detectors.map((d) => d.id)).toEqual([
+      "policy.houseLiteral",
+      "policy.housePrefix",
+      "policy.houseTyped",
+    ]);
+  });
+
+  it("rejects remote policy URLs and unbounded patterns", async () => {
+    await expect(loadRedactionPolicy("https://example.test/policy.json")).rejects.toThrow(
+      /local JSON file path/,
+    );
+
+    expect(() =>
+      compileRedactionPolicy(
+        {
+          patterns: [{ id: "bad", type: "typed", pattern: "(a+)+" }],
+        },
+        "policy.json",
+      ),
+    ).toThrow(/nested quantifiers|unbounded/);
+
+    expect(() =>
+      compileRedactionPolicy(
+        {
+          patterns: Array.from({ length: REDACTION_POLICY_LIMITS.maxPatterns + 1 }, (_, i) => ({
+            id: `p${i}`,
+            type: "literal",
+            value: "x",
+          })),
+        },
+        "policy.json",
+      ),
+    ).toThrow(/max count/);
+  });
+
+  it("applies the same policy to redact and residual detection", async () => {
+    const policyPath = path.join(tmp, "policy.json");
+    await writeFile(
+      policyPath,
+      JSON.stringify({
+        version: 1,
+        extraKeys: ["houseToken"],
+        patterns: [{ id: "houseCred", type: "literal", value: "HOUSE_CREDENTIAL_MARK" }],
+      }),
+      "utf-8",
+    );
+    const file = path.join(tmp, "custom.jsonl");
+    await writeFile(
+      file,
+      event({
+        houseToken: "should-redact-by-key",
+        note: "prefix HOUSE_CREDENTIAL_MARK suffix",
+        safe: "ok",
+      }),
+      "utf-8",
+    );
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, profile: "share", policy: policyPath });
+
+    const result = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      content?: string;
+      findings?: { detector?: string }[];
+      residualAssessment?: { status?: string };
+      policy?: { extraKeys?: number; patterns?: number };
+    };
+    expect(result.policy).toEqual({
+      path: path.resolve(policyPath),
+      extraKeys: 1,
+      patterns: 1,
+      diagnostics: [],
+    });
+    expect(result.content).toContain("[REDACTED]");
+    expect(result.content).not.toContain("should-redact-by-key");
+    expect(result.content).not.toContain("HOUSE_CREDENTIAL_MARK");
+    expect(result.findings?.some((f) => f.detector === "key.housetoken")).toBe(true);
+    expect(result.findings?.some((f) => f.detector === "policy.houseCred")).toBe(true);
+    expect(JSON.stringify(result.findings)).not.toContain("should-redact-by-key");
+    expect(result.residualAssessment?.status).toBeDefined();
+  });
+
+  it("does not accept secrets on argv (policy path only)", async () => {
+    // Ensure redact still works when policy is omitted and no secret flags exist.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await redactCommand("-", { json: true, profile: "share" }, stdinFrom(event({ safe: "ok" })));
+    expect(process.exitCode ?? 0).toBe(0);
+    expect(logSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/redact.test.ts
+++ b/packages/cli/test/redact.test.ts
@@ -26,6 +26,7 @@ describe("redact command", () => {
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-redact-cli-"));
     process.exitCode = 0;
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- After standalone `redact`, surface an additive residual safety assessment (`residualAssessment`) using the same local detector pipeline as `verify-safe` (#328). Default output/exit codes stay backward-compatible; human mode warns on stderr when residual is not `SAFE` (except quiet `UNKNOWN` for non-trace JSON); `--fail-on-residual` is opt-in only.
- Add local JSON `--policy` for `redact` / `verify-safe` / `scan` with `extraKeys` plus bounded `literal` / `prefix` / `typed` patterns, max count/length, and ReDoS protections (#329). Same compiled policy drives redaction and residual/verify-safe detection. No remote fetch; no secrets in argv.

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/redact-residual-policy.test.ts packages/cli/test/redact.test.ts packages/cli/test/safety.test.ts`
- [x] `pnpm --filter @agent-inspect/cli build`
- [x] `git diff --check`
- [ ] CI green on PR