### PR TITLE
feat(cli): residual safety after redact and bounded local redaction policy (#328, #329)

### DIFF
--- a/.changeset/618-redact-residual-policy.md
+++ b/.changeset/618-redact-residual-policy.md
@@ -1,0 +1,26 @@
+---
+"agent-inspect": minor
+"@agent-inspect/adapter-sdk": minor
+"@agent-inspect/ai-sdk": minor
+"@agent-inspect/circuit": minor
+"@agent-inspect/eval": minor
+"@agent-inspect/guardrails": minor
+"@agent-inspect/harness": minor
+"@agent-inspect/index-sqlite": minor
+"@agent-inspect/jest": minor
+"@agent-inspect/langchain": minor
+"@agent-inspect/mcp": minor
+"@agent-inspect/mcp-server": minor
+"@agent-inspect/openai-agents": minor
+"@agent-inspect/redact": minor
+"@agent-inspect/studio": minor
+"@agent-inspect/tui": minor
+"@agent-inspect/viewer": minor
+"@agent-inspect/vitest": minor
+---
+
+Surface residual safety after standalone `redact` and add a bounded local CLI redaction policy (#328, #329).
+
+`redact --json` now carries an additive `residualAssessment` (`status`, `basis`, `findingCount`, `highConfidenceFindingCount`, `codes`) derived from the same local safety pipeline `verify-safe` uses; human mode prints one concise stderr warning when the redacted copy is `UNSAFE` or `UNKNOWN`. Default output and exit codes are unchanged — the new `--fail-on-residual` flag is the only way to make residual risk non-zero. Matched secret values are never printed, and `redact` still writes a derived copy without mutating the source.
+
+`redact --policy ./agent-inspect.redaction.json` and `verify-safe --policy` accept a bounded local JSON policy that adds org-specific sensitive keys and `prefix` / `key-value` patterns. Policies are additive only and cannot disable built-in high-confidence protection. The loader enforces file-size, rule-count, and length bounds, rejects unknown fields, and supports no raw regex, no code execution, no remote URLs, and no environment interpolation.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -444,6 +444,8 @@ Options:
 - `--dir <path>`: trace directory for run-id lookup
 - `--profile <local|share|strict>`: redaction profile (default `share`)
 - `-o, --output <path>`: write redacted content to a file
+- `--policy <path>`: local bounded redaction policy JSON file (see [SAFETY-POLICY.md](SAFETY-POLICY.md))
+- `--fail-on-residual`: exit non-zero when the redacted copy still has residual safety findings
 - `--json`: print deterministic JSON wrapper with findings
 
 Examples:
@@ -451,7 +453,39 @@ Examples:
 ```bash
 npx agent-inspect redact trace.jsonl --profile share --json
 npx agent-inspect redact trace.jsonl --profile strict -o trace.share.jsonl
+npx agent-inspect redact trace.jsonl --policy ./agent-inspect.redaction.json --json
+npx agent-inspect redact trace.jsonl --profile share --fail-on-residual -o trace.share.jsonl
 ```
+
+#### Residual safety (6.18+)
+
+`redact` produces a derived copy; it never certifies that the copy is safe to share. Every run assesses what the local safety pipeline still finds in the redacted output:
+
+```json
+{
+  "residualAssessment": {
+    "status": "UNSAFE",
+    "basis": "supported-trace",
+    "findingCount": 2,
+    "highConfidenceFindingCount": 1,
+    "codes": ["safety.rawPrompt"],
+    "note": "Best-effort local residual assessment of the redacted copy; not a certification that sharing is safe."
+  }
+}
+```
+
+- `status`: `SAFE` · `SAFE_WITH_WARNINGS` · `UNSAFE` · `UNKNOWN`.
+- `basis`: `supported-trace` when the redacted output re-opens as a trace and the full `verify-safe` rule set runs; `detector-only` for arbitrary JSON/JSONL that is not a supported trace, where only redaction detectors run and context-sensitive rules (raw content, oversized attributes) are **not** evaluated; `unavailable` when nothing could be assessed.
+- `codes`: sorted rule/detector identifiers. Matched secret or PII values are never included.
+
+Behavior is backward compatible:
+
+- Default stdout/file output and the default exit code are unchanged.
+- `--json` adds the `residualAssessment` field (and `policy` when `--policy` is used); existing fields keep their meaning.
+- Human mode prints one concise stderr warning only when the redacted copy is `UNSAFE` or `UNKNOWN`. Warning-level residue (for example a sensitive key name whose value is now a placeholder) stays in JSON output.
+- `--fail-on-residual` is the only way to change the exit code: `1` for `UNSAFE`, `2` for `UNKNOWN`, `0` otherwise.
+
+`verify-safe` remains the final local assessment before sharing.
 
 Recipe: [redact-share-safe-file](../examples/recipes/redact-share-safe-file/README.md).
 
@@ -482,6 +516,7 @@ Options:
 - `--run <run-id>`: select a run when input contains multiple runs
 - `--json`: print deterministic JSON safety result
 - `--explain`: explain each finding (detector/path/category/confidence/redaction/override/bundle gate) without printing matched secret values
+- `--policy <path>` (`verify-safe` only): local bounded redaction policy JSON file, applied to the same detector pipeline `redact --policy` uses (see [SAFETY-POLICY.md](SAFETY-POLICY.md))
 - `--max-string-length <number>`: unsafe threshold for string values
 - `--max-array-length <number>`: unsafe threshold for array values
 - `--max-object-keys <number>`: unsafe threshold for object key counts

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -6,7 +6,7 @@ AgentInspect traces, log-ingest outputs, and exports are local files. They may s
 
 This guide is practical sharing guidance, not a guarantee that any artifact is safe to publish. Redaction profiles are **best-effort transformation**, not compliance-grade DLP or a safety certification. Always finish with `verify-safe` before sharing.
 
-Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and require human review. Org-specific patterns need programmatic custom detectors today; a bounded local CLI policy is proposed separately and is not yet supported.
+Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and require human review. Org-specific patterns can be added programmatically with custom detectors, or from the CLI with a bounded local policy file (`--policy`, 6.18+); see [SAFETY-POLICY.md](./SAFETY-POLICY.md#bounded-local-cli-policy-618).
 
 `strict` is a stricter **rule set** (more keys), not a promise that every input produces bytes different from `share`.
 
@@ -60,7 +60,7 @@ Replace sensitive data with clear placeholders such as `example.test`, `user@exa
 
 - Markdown / HTML exports: review rendered text and copied snippets, not only the source trace.
 - Eval JSON / Markdown: review failed-rule messages, expected/actual summaries, source IDs, and evidence paths before attaching them to PRs or issues.
-- Redacted copies from `agent-inspect redact`: review the output file itself; findings show detector/path/action evidence but do not certify full safety.
+- Redacted copies from `agent-inspect redact`: review the output file itself; findings show detector/path/action evidence but do not certify full safety. The `residualAssessment` field (6.18+) reports what `verify-safe` would still flag in the redacted copy; `--fail-on-residual` turns that into a non-zero exit in CI.
 - OpenInference / OTLP JSON exports: check attributes, span names, events, and resource metadata.
 - Structured log ingest configs: confirm mapped keys do not pull in full request bodies, headers, raw prompts, or unbounded output fields.
 - LangChain adapter traces: keep `capture: "metadata-only"` for shareable examples; review `capture: "preview"` traces carefully because previews can include prompt or output fragments.

--- a/docs/SAFETY-POLICY.md
+++ b/docs/SAFETY-POLICY.md
@@ -115,9 +115,9 @@ redact(
 );
 ```
 
-CLI custom policy files are **not** supported yet. Do not put secrets on the command line.
-3. **CLI size thresholds** on `scan` / `verify-safe` (`--max-string-length`, etc.) when oversized findings are false positives for your workload.
-4. **Bundle write override** with explicit `--allow-unsafe` after reviewing `verify-safe --explain` (records that the artifact was not share-gated).
+3. **Bounded local CLI policy** via `--policy ./agent-inspect.redaction.json` on `redact` and `verify-safe` (6.18+, experimental). See [Bounded local CLI policy](#bounded-local-cli-policy-618) below. Do not put secrets on the command line.
+4. **CLI size thresholds** on `scan` / `verify-safe` (`--max-string-length`, etc.) when oversized findings are false positives for your workload.
+5. **Bundle write override** with explicit `--allow-unsafe` after reviewing `verify-safe --explain` (records that the artifact was not share-gated).
 
 High-confidence built-in credentials (including bounded `token=` / `api_key=` / `internal_token=` forms) are covered by built-in redaction profiles. Context-sensitive findings such as private filesystem paths may remain verification-only when automatic erasure would create excessive false positives or destroy legitimate debugging context. `redact` remains best-effort; `verify-safe` remains the final automated local assessment before sharing.
 
@@ -127,6 +127,53 @@ High-confidence built-in credentials (including bounded `token=` / `api_key=` / 
 - Disabling detectors globally “to make CI green”
 - Printing matched secret/PII values in CI logs or MCP tool output
 - Claiming overrides produce certified / compliant / guaranteed-safe artifacts
+
+### Bounded local CLI policy (6.18+)
+
+**Status:** experimental, additive. Wired into `agent-inspect redact --policy` and `agent-inspect verify-safe --policy`.
+
+A policy is a **local JSON file**. It only **adds** sensitive keys and bounded value patterns on top of the built-in profiles. It can never remove or weaken built-in high-confidence protection.
+
+```json
+{
+  "policyVersion": 1,
+  "sensitiveKeys": ["houseSecret"],
+  "valuePatterns": [
+    { "id": "house-prefix", "type": "prefix", "prefix": "hsk_", "severity": "error" },
+    { "id": "house-kv", "type": "key-value", "key": "house_token", "minSecretLength": 12 }
+  ]
+}
+```
+
+Pattern types (no raw regex is accepted):
+
+| Type | Matches |
+|------|---------|
+| `prefix` | a token starting with `prefix` at a word boundary, followed by at least `minSecretLength` secret-like characters |
+| `key-value` | `key=value` or `key: value` inside a string, where the value has at least `minSecretLength` secret-like characters |
+
+Per-rule fields: `id` (required, `[A-Za-z0-9._-]`), `type`, `prefix` or `key`, optional `minSecretLength` (default `8`), optional `severity` (`warning` default, or `error`).
+
+Bounds and rejections:
+
+| Bound | Limit |
+|-------|-------|
+| policy file size | 64 KiB |
+| total rules (`sensitiveKeys` + `valuePatterns`) | 200 |
+| `sensitiveKeys` / `key` length | 128 |
+| `prefix` length | 3–64 |
+| `id` length | 64 |
+| `minSecretLength` | 1–256 |
+
+The loader rejects unknown top-level and per-rule fields, a `policyVersion` other than `1`, duplicate rule ids, non-ASCII identifier characters, malformed JSON, directories, and oversized files. There is **no** JavaScript execution, **no** remote policy URL, and **no** environment interpolation — `${HOME}`-style text is literal and fails identifier validation. Matching is a bounded linear scan with no user-supplied regex, so a policy cannot introduce catastrophic backtracking.
+
+Policy detectors appear as `policy.<id>` in `redact --json` findings and in `verify-safe` `redactionSummary.detectors`. Both commands compile the same policy and apply it to the same detector pipeline. Matched values are never printed.
+
+Invalid policies fail loudly: `redact` exits `1` with a `--policy …` message; `verify-safe` reports `AI_SAFETY_INVALID_ARGUMENTS` with status `UNKNOWN`.
+
+### Residual safety after `redact` (6.18+)
+
+`redact` writes a derived copy and never mutates the source. It does **not** certify that the copy is safe to share. Each run reports a `residualAssessment` describing what the local safety pipeline still finds in the redacted output, so operators know whether `verify-safe` will still flag it. Default output and exit codes are unchanged; `--fail-on-residual` is the explicit opt-in that turns residual risk into a non-zero exit. See [CLI.md](CLI.md#611-redact) for the field contract.
 
 ### Explain + review loop
 

--- a/packages/cli/src/artifacts.ts
+++ b/packages/cli/src/artifacts.ts
@@ -26,7 +26,7 @@ import {
 import { createEvidenceCiArtifacts } from "@agent-inspect/core/reporters";
 
 import { version as packageVersion } from "../../../package.json";
-import { redactTraceContent } from "./redact.js";
+import { redactTraceContent } from "./redact-content.js";
 import { inputFromTarget } from "./trace-input.js";
 
 export interface ArtifactsCommandOptions {

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -58,7 +58,7 @@ import {
   resolveOutputOption,
   resolveRedactionProfileOption,
 } from "./cli-option-aliases.js";
-import { redactTraceContent } from "./redact.js";
+import { redactTraceContent } from "./redact-content.js";
 import { assessOpenedTrace } from "./safety.js";
 import { loadSessionRuns } from "./sessions-load.js";
 

--- a/packages/cli/src/evidence-on.ts
+++ b/packages/cli/src/evidence-on.ts
@@ -13,7 +13,7 @@ import type { TraceCheckResult } from "@agent-inspect/core/checks";
 import type { RedactionProfile } from "@agent-inspect/redact";
 
 import { version as packageVersion } from "../../../package.json";
-import { redactTraceContent } from "./redact.js";
+import { redactTraceContent } from "./redact-content.js";
 
 export type EvidenceOnMode = "fail" | "always" | "never";
 export type EvidenceEmitFormat = "directory" | "html" | "zip";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -631,12 +631,19 @@ export function createCliProgram(): Command {
     .option("--run <run-id>", "select a run when the trace contains multiple runs")
     .option("--json", "print deterministic JSON safety result")
     .option("--explain", "explain each finding (path, confidence, redaction, override, bundle gate)")
+    .option("--policy <path>", "local bounded redaction policy JSON file")
     .option("--max-string-length <number>", "unsafe threshold for string values")
     .option("--max-array-length <number>", "unsafe threshold for array values")
     .option("--max-object-keys <number>", "unsafe threshold for object key counts")
     .option("--max-serialized-bytes <number>", "unsafe threshold for serialized values")
-    .action((target: string, opts: SafetyCommandOptions) => {
-      runCommand(() => verifySafeCommand(target, opts));
+    .action((target: string, opts: Omit<SafetyCommandOptions, "policy"> & { policy?: string }) => {
+      const { policy, ...rest } = opts;
+      runCommand(() =>
+        verifySafeCommand(target, {
+          ...rest,
+          ...(policy !== undefined ? { policyPath: policy } : {}),
+        }),
+      );
     });
 
   program
@@ -1001,6 +1008,11 @@ export function createCliProgram(): Command {
     )
     .option("-o, --output <path>", "write redacted content to a file")
     .option("--out <path>", "alias for --output")
+    .option("--policy <path>", "local bounded redaction policy JSON file")
+    .option(
+      "--fail-on-residual",
+      "exit non-zero when the redacted copy still has residual safety findings",
+    )
     .option("--json", "print deterministic JSON wrapper with findings")
     .action((target: string, opts: RedactCommandOptions) => {
       runCommand(() => redactCommand(target, opts));

--- a/packages/cli/src/redact-content.ts
+++ b/packages/cli/src/redact-content.ts
@@ -1,0 +1,106 @@
+import {
+  createRedactor,
+  type RedactionFinding,
+  type RedactionProfile,
+} from "@agent-inspect/redact";
+
+import type { CompiledRedactionPolicy } from "./redaction-policy.js";
+
+export interface RedactedDocument {
+  content: string;
+  findings: RedactionFinding[];
+}
+
+/** Applies the built-in profile plus any additive local policy. Built-ins are never removed. */
+export function redactValueWithPolicy(
+  value: unknown,
+  profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
+): { value: unknown; findings: RedactionFinding[] } {
+  const redactor = createRedactor({
+    profile,
+    ...(policy !== undefined ? { detectors: [...policy.detectors] } : {}),
+    ...(policy !== undefined ? { extraKeys: policy.sensitiveKeys } : {}),
+  });
+  const result = redactor.redact(value);
+  return { value: result.value, findings: result.findings };
+}
+
+function redactJsonText(
+  content: string,
+  profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
+): RedactedDocument {
+  const parsed = JSON.parse(content) as unknown;
+  const result = redactValueWithPolicy(parsed, profile, policy);
+  return {
+    content: `${JSON.stringify(result.value, null, 2)}\n`,
+    findings: result.findings,
+  };
+}
+
+function redactJsonlText(
+  content: string,
+  profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
+): RedactedDocument {
+  const lines = content.split(/\r?\n/);
+  const out: string[] = [];
+  const findings: RedactionFinding[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (line.trim() === "") continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error(`Input is not valid JSON or JSONL at line ${index + 1}.`);
+    }
+
+    const result = redactValueWithPolicy(parsed, profile, policy);
+    out.push(JSON.stringify(result.value));
+    findings.push(
+      ...result.findings.map((finding) => ({
+        ...finding,
+        path: `line:${index + 1}:${finding.path}`,
+      })),
+    );
+  }
+
+  return {
+    content: out.length === 0 ? "" : `${out.join("\n")}\n`,
+    findings,
+  };
+}
+
+/** Redacts JSON or JSONL trace text with the given profile (used by bundle and redact commands). */
+export function redactTraceContent(
+  content: string,
+  profile: RedactionProfile,
+  policy?: CompiledRedactionPolicy,
+): RedactedDocument {
+  const trimmed = content.trim();
+  // Single-line AgentInspect events parse as JSON but must stay JSONL for re-read.
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed) &&
+        ("schemaVersion" in parsed || "eventId" in parsed || "runId" in parsed)
+      ) {
+        return redactJsonlText(content, profile, policy);
+      }
+    } catch {
+      // fall through
+    }
+  }
+  try {
+    return redactJsonText(content, profile, policy);
+  } catch {
+    return redactJsonlText(content, profile, policy);
+  }
+}

--- a/packages/cli/src/redact.ts
+++ b/packages/cli/src/redact.ts
@@ -4,16 +4,23 @@ import {
   getTraceFilePath,
   resolveTraceDir,
 } from "@agent-inspect/core/advanced";
-import {
-  redact,
-  type RedactionFinding,
-  type RedactionProfile,
-} from "@agent-inspect/redact";
+import type { RedactionProfile } from "@agent-inspect/redact";
 
 import {
   resolveOutputOption,
   resolveRedactionProfileOption,
 } from "./cli-option-aliases.js";
+import { redactTraceContent } from "./redact-content.js";
+import {
+  loadRedactionPolicy,
+  summarizeRedactionPolicy,
+  type CompiledRedactionPolicy,
+} from "./redaction-policy.js";
+import {
+  assessResidualSafety,
+  residualExitCode,
+  residualWarningLine,
+} from "./residual-safety.js";
 import { readStdin } from "./trace-input.js";
 
 export interface RedactCommandOptions {
@@ -23,11 +30,10 @@ export interface RedactCommandOptions {
   output?: string;
   out?: string;
   json?: boolean;
-}
-
-interface RedactedDocument {
-  content: string;
-  findings: RedactionFinding[];
+  /** Local bounded redaction policy file (see docs/SAFETY-POLICY.md). */
+  policy?: string;
+  /** Opt-in non-zero exit when the redacted copy still has residual findings. */
+  failOnResidual?: boolean;
 }
 
 function parseRedactionProfile(value: string | undefined): RedactionProfile {
@@ -84,93 +90,27 @@ async function contentFromTarget(
   return { content: await readFile(runPath, "utf-8"), source: runPath };
 }
 
-function redactJsonText(content: string, profile: RedactionProfile): RedactedDocument {
-  const parsed = JSON.parse(content) as unknown;
-  const result = redact(parsed, { profile });
-  return {
-    content: `${JSON.stringify(result.value, null, 2)}\n`,
-    findings: result.findings,
-  };
-}
-
-function redactJsonlText(content: string, profile: RedactionProfile): RedactedDocument {
-  const lines = content.split(/\r?\n/);
-  const out: string[] = [];
-  const findings: RedactionFinding[] = [];
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    if (line.trim() === "") continue;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      throw new Error(`Input is not valid JSON or JSONL at line ${index + 1}.`);
-    }
-
-    const result = redact(parsed, { profile });
-    out.push(JSON.stringify(result.value));
-    findings.push(
-      ...result.findings.map((finding) => ({
-        ...finding,
-        path: `line:${index + 1}:${finding.path}`,
-      })),
-    );
-  }
-
-  return {
-    content: out.length === 0 ? "" : `${out.join("\n")}\n`,
-    findings,
-  };
-}
-
-function redactDocument(content: string, profile: RedactionProfile): RedactedDocument {
-  const trimmed = content.trim();
-  // Single-line AgentInspect events parse as JSON but must stay JSONL for re-read.
-  if (trimmed.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(trimmed) as unknown;
-      if (
-        parsed !== null &&
-        typeof parsed === "object" &&
-        !Array.isArray(parsed) &&
-        ("schemaVersion" in parsed || "eventId" in parsed || "runId" in parsed)
-      ) {
-        return redactJsonlText(content, profile);
-      }
-    } catch {
-      // fall through
-    }
-  }
-  try {
-    return redactJsonText(content, profile);
-  } catch {
-    return redactJsonlText(content, profile);
-  }
-}
-
-/** Redacts JSON or JSONL trace text with the given profile (used by bundle and redact commands). */
-export function redactTraceContent(
-  content: string,
-  profile: RedactionProfile,
-): RedactedDocument {
-  return redactDocument(content, profile);
-}
-
 export async function redactCommand(
   target: string,
   options: RedactCommandOptions = {},
   stdin: NodeJS.ReadableStream = process.stdin,
 ): Promise<void> {
   const profile = parseRedactionProfile(resolveRedactionProfileOption(options));
+  const policy: CompiledRedactionPolicy | undefined =
+    options.policy === undefined ? undefined : await loadRedactionPolicy(options.policy);
   const source = await contentFromTarget(target, options, stdin);
-  const redacted = redactDocument(source.content, profile);
+  // Always a derived copy; the source file is never mutated.
+  const redacted = redactTraceContent(source.content, profile, policy);
   const outputPath = resolveOutputOption(options);
 
   if (outputPath !== undefined) {
     await writeFile(outputPath, redacted.content, "utf-8");
   }
+
+  const residual = await assessResidualSafety(redacted.content, {
+    profile,
+    ...(policy !== undefined ? { policy } : {}),
+  });
 
   if (options.json) {
     console.log(
@@ -181,16 +121,24 @@ export async function redactCommand(
           source: source.source,
           output: outputPath,
           findings: redacted.findings,
+          residualAssessment: residual,
+          policy: policy === undefined ? undefined : summarizeRedactionPolicy(policy),
           content: outputPath === undefined ? redacted.content : undefined,
         }),
         null,
         2,
       ),
     );
-    return;
+  } else {
+    if (outputPath === undefined) {
+      process.stdout.write(redacted.content);
+    }
+    const warning = residualWarningLine(residual);
+    if (warning !== undefined) console.error(`[AgentInspect] ${warning}`);
   }
 
-  if (outputPath === undefined) {
-    process.stdout.write(redacted.content);
+  if (options.failOnResidual === true) {
+    const code = residualExitCode(residual);
+    if (code !== 0) process.exitCode = code;
   }
 }

--- a/packages/cli/src/redaction-policy.ts
+++ b/packages/cli/src/redaction-policy.ts
@@ -1,0 +1,361 @@
+import { readFile, stat } from "node:fs/promises";
+
+import type { RedactionDetector, RedactionSeverity } from "@agent-inspect/redact";
+
+/**
+ * Bounded local redaction policy (experimental, 6.18+).
+ *
+ * A policy file only *adds* sensitive keys and bounded value patterns on top of the
+ * built-in profiles. It can never disable built-in high-confidence protection, execute
+ * code, fetch a remote document, interpolate environment variables, or supply raw regex.
+ */
+
+/** Maximum accepted policy file size on disk. */
+export const MAX_POLICY_FILE_BYTES = 64 * 1024;
+/** Maximum combined `sensitiveKeys` + `valuePatterns` entries. */
+export const MAX_POLICY_RULES = 200;
+/** Maximum accepted `sensitiveKeys` entry length. */
+export const MAX_POLICY_KEY_LENGTH = 128;
+/** Minimum accepted `prefix` length (shorter prefixes match too much). */
+export const MIN_POLICY_PREFIX_LENGTH = 3;
+/** Maximum accepted `prefix` length. */
+export const MAX_POLICY_PREFIX_LENGTH = 64;
+/** Maximum accepted rule `id` length. */
+export const MAX_POLICY_ID_LENGTH = 64;
+/** Default number of trailing secret characters a bounded pattern requires. */
+export const DEFAULT_MIN_SECRET_LENGTH = 8;
+/** Maximum accepted `minSecretLength`. */
+export const MAX_MIN_SECRET_LENGTH = 256;
+
+/** Longest string prefix scanned by a policy detector (bounds worst-case work). */
+const MAX_SCAN_LENGTH = 64 * 1024;
+/** Maximum candidate positions examined per string per rule. */
+const MAX_SCAN_OCCURRENCES = 64;
+
+const POLICY_VERSION = 1;
+const TOP_LEVEL_KEYS = new Set(["policyVersion", "sensitiveKeys", "valuePatterns"]);
+const PREFIX_RULE_KEYS = new Set(["id", "type", "prefix", "minSecretLength", "severity"]);
+const KEY_VALUE_RULE_KEYS = new Set(["id", "type", "key", "minSecretLength", "severity"]);
+const SEVERITIES = new Set<RedactionSeverity>(["warning", "error"]);
+
+/** Compiled, validated policy safe to hand to `@agent-inspect/redact`. */
+export interface CompiledRedactionPolicy {
+  readonly policyVersion: number;
+  readonly source: string;
+  readonly sensitiveKeys: readonly string[];
+  readonly detectors: readonly RedactionDetector[];
+  readonly ruleCount: number;
+}
+
+function policyError(message: string): Error {
+  return new Error(`--policy ${message}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rejectUnknownKeys(
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  where: string,
+): void {
+  const unknown = Object.keys(record)
+    .filter((key) => !allowed.has(key))
+    .sort((a, b) => a.localeCompare(b));
+  if (unknown.length > 0) {
+    throw policyError(`${where} has unsupported field(s): ${unknown.join(", ")}.`);
+  }
+}
+
+function isIdentifierChar(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 46 ||
+    code === 45 ||
+    code === 95
+  );
+}
+
+/** Word-boundary alphabet used to reject matches glued inside a longer token. */
+function isTokenChar(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 45 ||
+    code === 95
+  );
+}
+
+/** Character class accepted inside a bounded secret value. */
+function isSecretChar(code: number): boolean {
+  return (
+    isTokenChar(code) ||
+    code === 46 ||
+    code === 43 ||
+    code === 47 ||
+    code === 61 ||
+    code === 126
+  );
+}
+
+function assertIdentifier(value: unknown, where: string, maxLength: number): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw policyError(`${where} must be a non-empty string.`);
+  }
+  if (value.length > maxLength) {
+    throw policyError(`${where} must be at most ${maxLength} characters.`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!isIdentifierChar(value.charCodeAt(index))) {
+      throw policyError(`${where} may only contain letters, digits, '.', '-', and '_'.`);
+    }
+  }
+  return value;
+}
+
+function assertSeverity(value: unknown, where: string): RedactionSeverity {
+  if (value === undefined) return "warning";
+  if (typeof value !== "string" || !SEVERITIES.has(value as RedactionSeverity)) {
+    throw policyError(`${where} must be "warning" or "error".`);
+  }
+  return value as RedactionSeverity;
+}
+
+function assertMinSecretLength(value: unknown, where: string): number {
+  if (value === undefined) return DEFAULT_MIN_SECRET_LENGTH;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw policyError(`${where} must be a positive integer.`);
+  }
+  if (value > MAX_MIN_SECRET_LENGTH) {
+    throw policyError(`${where} must be at most ${MAX_MIN_SECRET_LENGTH}.`);
+  }
+  return value;
+}
+
+function trailingSecretLength(value: string, from: number): number {
+  let index = from;
+  while (index < value.length && isSecretChar(value.charCodeAt(index))) index += 1;
+  return index - from;
+}
+
+/** ASCII case-insensitive `indexOf`; policy keys and prefixes are ASCII-only by validation. */
+function indexOfAscii(haystack: string, needleLower: string, from: number): number {
+  const limit = haystack.length - needleLower.length;
+  for (let start = from; start <= limit; start += 1) {
+    let matched = true;
+    for (let offset = 0; offset < needleLower.length; offset += 1) {
+      let code = haystack.charCodeAt(start + offset);
+      if (code >= 65 && code <= 90) code += 32;
+      if (code !== needleLower.charCodeAt(offset)) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return start;
+  }
+  return -1;
+}
+
+function scanCandidates(
+  value: string,
+  needleLower: string,
+  onMatch: (index: number) => boolean,
+): boolean {
+  const scanned = value.length > MAX_SCAN_LENGTH ? value.slice(0, MAX_SCAN_LENGTH) : value;
+  let from = 0;
+  for (let seen = 0; seen < MAX_SCAN_OCCURRENCES; seen += 1) {
+    const index = indexOfAscii(scanned, needleLower, from);
+    if (index < 0) return false;
+    const before = index === 0 ? undefined : scanned.charCodeAt(index - 1);
+    if (before === undefined || !isTokenChar(before)) {
+      if (onMatch(index)) return true;
+    }
+    from = index + 1;
+  }
+  return false;
+}
+
+function prefixDetector(
+  id: string,
+  prefix: string,
+  minSecretLength: number,
+  severity: RedactionSeverity,
+): RedactionDetector {
+  const needle = prefix.toLowerCase();
+  return {
+    id: `policy.${id}`,
+    severity,
+    matchKind: "value",
+    detect(input) {
+      if (typeof input.value !== "string") return [];
+      const matched = scanCandidates(input.value, needle, (index) => {
+        const scanned = input.value as string;
+        return trailingSecretLength(scanned, index + prefix.length) >= minSecretLength;
+      });
+      return matched ? [{ action: "replace", severity, matchKind: "value" }] : [];
+    },
+  };
+}
+
+function keyValueDetector(
+  id: string,
+  key: string,
+  minSecretLength: number,
+  severity: RedactionSeverity,
+): RedactionDetector {
+  const needle = key.toLowerCase();
+  return {
+    id: `policy.${id}`,
+    severity,
+    matchKind: "value",
+    detect(input) {
+      if (typeof input.value !== "string") return [];
+      const text = input.value;
+      const matched = scanCandidates(text, needle, (index) => {
+        let cursor = index + key.length;
+        while (cursor < text.length && (text[cursor] === " " || text[cursor] === "\t")) cursor += 1;
+        const separator = text[cursor];
+        if (separator !== "=" && separator !== ":") return false;
+        cursor += 1;
+        while (cursor < text.length && (text[cursor] === " " || text[cursor] === "\t")) cursor += 1;
+        if (text[cursor] === '"' || text[cursor] === "'") cursor += 1;
+        return trailingSecretLength(text, cursor) >= minSecretLength;
+      });
+      return matched ? [{ action: "replace", severity, matchKind: "value" }] : [];
+    },
+  };
+}
+
+function compileValuePattern(entry: unknown, position: number, ids: Set<string>): RedactionDetector {
+  const where = `valuePatterns[${position}]`;
+  if (!isRecord(entry)) throw policyError(`${where} must be an object.`);
+
+  const type = entry.type;
+  if (type !== "prefix" && type !== "key-value") {
+    throw policyError(`${where}.type must be "prefix" or "key-value".`);
+  }
+  rejectUnknownKeys(entry, type === "prefix" ? PREFIX_RULE_KEYS : KEY_VALUE_RULE_KEYS, where);
+
+  const id = assertIdentifier(entry.id, `${where}.id`, MAX_POLICY_ID_LENGTH);
+  if (ids.has(id)) throw policyError(`${where}.id "${id}" is duplicated.`);
+  ids.add(id);
+
+  const minSecretLength = assertMinSecretLength(entry.minSecretLength, `${where}.minSecretLength`);
+  const severity = assertSeverity(entry.severity, `${where}.severity`);
+
+  if (type === "prefix") {
+    const prefix = entry.prefix;
+    if (typeof prefix !== "string") throw policyError(`${where}.prefix must be a string.`);
+    if (prefix.length < MIN_POLICY_PREFIX_LENGTH) {
+      throw policyError(`${where}.prefix must be at least ${MIN_POLICY_PREFIX_LENGTH} characters.`);
+    }
+    if (prefix.length > MAX_POLICY_PREFIX_LENGTH) {
+      throw policyError(`${where}.prefix must be at most ${MAX_POLICY_PREFIX_LENGTH} characters.`);
+    }
+    for (let index = 0; index < prefix.length; index += 1) {
+      const code = prefix.charCodeAt(index);
+      if (code < 33 || code > 126) {
+        throw policyError(`${where}.prefix must contain printable ASCII without whitespace.`);
+      }
+    }
+    return prefixDetector(id, prefix, minSecretLength, severity);
+  }
+
+  const key = assertIdentifier(entry.key, `${where}.key`, MAX_POLICY_KEY_LENGTH);
+  return keyValueDetector(id, key, minSecretLength, severity);
+}
+
+/** Validates and compiles an already-parsed policy document. */
+export function compileRedactionPolicy(
+  document: unknown,
+  source: string,
+): CompiledRedactionPolicy {
+  if (!isRecord(document)) throw policyError(`${source} must contain a JSON object.`);
+  rejectUnknownKeys(document, TOP_LEVEL_KEYS, source);
+
+  if (document.policyVersion !== POLICY_VERSION) {
+    throw policyError(`${source} must set "policyVersion": ${POLICY_VERSION}.`);
+  }
+
+  const rawKeys = document.sensitiveKeys ?? [];
+  if (!Array.isArray(rawKeys)) throw policyError(`${source} sensitiveKeys must be an array.`);
+  const rawPatterns = document.valuePatterns ?? [];
+  if (!Array.isArray(rawPatterns)) throw policyError(`${source} valuePatterns must be an array.`);
+
+  const ruleCount = rawKeys.length + rawPatterns.length;
+  if (ruleCount > MAX_POLICY_RULES) {
+    throw policyError(
+      `${source} declares ${ruleCount} rules; the maximum is ${MAX_POLICY_RULES}.`,
+    );
+  }
+
+  const sensitiveKeys: string[] = [];
+  const seenKeys = new Set<string>();
+  rawKeys.forEach((entry, index) => {
+    const key = assertIdentifier(entry, `sensitiveKeys[${index}]`, MAX_POLICY_KEY_LENGTH);
+    const normalized = key.toLowerCase();
+    if (seenKeys.has(normalized)) return;
+    seenKeys.add(normalized);
+    sensitiveKeys.push(key);
+  });
+
+  const ids = new Set<string>();
+  const detectors = rawPatterns.map((entry, index) => compileValuePattern(entry, index, ids));
+
+  return {
+    policyVersion: POLICY_VERSION,
+    source,
+    sensitiveKeys,
+    detectors,
+    ruleCount,
+  };
+}
+
+/** Reads, bounds-checks, and compiles a local policy file. Never fetches remote documents. */
+export async function loadRedactionPolicy(
+  policyPath: string,
+): Promise<CompiledRedactionPolicy> {
+  const trimmed = policyPath.trim();
+  if (trimmed === "") throw policyError("requires a local file path.");
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    throw policyError("only accepts a local file path; remote policy URLs are not supported.");
+  }
+
+  let stats;
+  try {
+    stats = await stat(trimmed);
+  } catch {
+    throw policyError(`file not found: ${trimmed}`);
+  }
+  if (stats.isDirectory()) throw policyError(`must be a JSON file, not a directory: ${trimmed}`);
+  if (stats.size > MAX_POLICY_FILE_BYTES) {
+    throw policyError(
+      `file ${trimmed} is ${stats.size} bytes; the maximum is ${MAX_POLICY_FILE_BYTES} bytes.`,
+    );
+  }
+
+  const raw = await readFile(trimmed, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    throw policyError(`file ${trimmed} is not valid JSON.`);
+  }
+  return compileRedactionPolicy(parsed, trimmed);
+}
+
+/** Deterministic, value-free policy summary for JSON output. */
+export function summarizeRedactionPolicy(
+  policy: CompiledRedactionPolicy,
+): { source: string; policyVersion: number; sensitiveKeys: number; valuePatterns: number } {
+  return {
+    source: policy.source,
+    policyVersion: policy.policyVersion,
+    sensitiveKeys: policy.sensitiveKeys.length,
+    valuePatterns: policy.detectors.length,
+  };
+}

--- a/packages/cli/src/residual-safety.ts
+++ b/packages/cli/src/residual-safety.ts
@@ -1,0 +1,185 @@
+import { openTrace } from "@agent-inspect/core/readers";
+import type { RedactionProfile } from "@agent-inspect/redact";
+
+import { redactValueWithPolicy } from "./redact-content.js";
+import type { CompiledRedactionPolicy } from "./redaction-policy.js";
+import { assessOpenedTrace } from "./safety.js";
+
+/**
+ * Residual safety assessment for a redacted artifact (experimental, 6.18+).
+ *
+ * `redact` produces a derived copy; it never certifies that the copy is safe to share.
+ * This assessment reports what the canonical local safety pipeline still finds in the
+ * redacted output so operators know whether `verify-safe` will flag it.
+ */
+export type ResidualSafetyStatus = "SAFE" | "SAFE_WITH_WARNINGS" | "UNSAFE" | "UNKNOWN";
+
+/**
+ * How the assessment was produced.
+ *
+ * - `supported-trace` — the redacted output re-opened as a trace and ran the full local
+ *   safety pipeline (same rules as `verify-safe`).
+ * - `detector-only` — arbitrary JSON/JSONL that is not a supported trace; only redaction
+ *   detectors could run, so context-sensitive rules (raw content, oversized attributes)
+ *   were not evaluated.
+ * - `unavailable` — the redacted output could not be assessed at all.
+ */
+export type ResidualSafetyBasis = "supported-trace" | "detector-only" | "unavailable";
+
+export interface ResidualSafetyAssessment {
+  status: ResidualSafetyStatus;
+  basis: ResidualSafetyBasis;
+  findingCount: number;
+  highConfidenceFindingCount: number;
+  /** Sorted, de-duplicated rule/detector identifiers. Never contains matched values. */
+  codes: string[];
+  note: string;
+}
+
+export interface ResidualSafetyOptions {
+  profile: RedactionProfile;
+  policy?: CompiledRedactionPolicy;
+}
+
+const SUPPORTED_TRACE_NOTE =
+  "Best-effort local residual assessment of the redacted copy; not a certification that sharing is safe.";
+const DETECTOR_ONLY_NOTE =
+  "Input is not a supported trace; only redaction detectors ran. Context-sensitive rules were not evaluated.";
+const UNAVAILABLE_NOTE = "Redacted output could not be assessed locally.";
+
+function sortedCodes(codes: Iterable<string>): string[] {
+  return [...new Set(codes)].sort((a, b) => a.localeCompare(b));
+}
+
+function assessmentFromSafetyResult(
+  result: ReturnType<typeof assessOpenedTrace>,
+): ResidualSafetyAssessment {
+  const status: ResidualSafetyStatus =
+    result.status === "SAFE WITH WARNINGS" ? "SAFE_WITH_WARNINGS" : result.status;
+  const highConfidence = result.findings.filter((finding) =>
+    finding.confidence === undefined ? finding.severity === "error" : finding.confidence === "high",
+  ).length;
+  return {
+    status,
+    basis: "supported-trace",
+    findingCount: result.findings.length,
+    highConfidenceFindingCount: highConfidence,
+    codes: sortedCodes([
+      ...result.findings.map((finding) => finding.detector ?? finding.ruleId),
+      ...result.diagnostics
+        .filter((diagnostic) => diagnostic.severity !== "info")
+        .map((diagnostic) => diagnostic.code),
+    ]),
+    note: SUPPORTED_TRACE_NOTE,
+  };
+}
+
+function parseDocuments(content: string): unknown[] {
+  const trimmed = content.trim();
+  if (trimmed === "") return [];
+  try {
+    return [JSON.parse(trimmed) as unknown];
+  } catch {
+    // fall through to JSONL
+  }
+  return content
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function detectorOnlyAssessment(
+  content: string,
+  options: ResidualSafetyOptions,
+): ResidualSafetyAssessment {
+  const documents = parseDocuments(content);
+  const codes: string[] = [];
+  let findingCount = 0;
+  let highConfidenceFindingCount = 0;
+  let unsafe = false;
+  let warned = false;
+
+  for (const document of documents) {
+    const pass = redactValueWithPolicy(document, options.profile, options.policy);
+    for (const finding of pass.findings) {
+      // Key rules re-match the already-replaced placeholder; only value-level residue counts.
+      if (finding.action === "keep" || finding.matchKind === "key") continue;
+      findingCount += 1;
+      codes.push(finding.detector);
+      if (finding.severity === "error") {
+        highConfidenceFindingCount += 1;
+        unsafe = true;
+      } else if (finding.severity === "warning") {
+        warned = true;
+      }
+    }
+  }
+
+  return {
+    status: unsafe ? "UNSAFE" : warned ? "SAFE_WITH_WARNINGS" : "SAFE",
+    basis: "detector-only",
+    findingCount,
+    highConfidenceFindingCount,
+    codes: sortedCodes(codes),
+    note: `${SUPPORTED_TRACE_NOTE} ${DETECTOR_ONLY_NOTE}`,
+  };
+}
+
+/** Assesses the redacted copy. Local only; never throws into the redact command. */
+export async function assessResidualSafety(
+  redactedContent: string,
+  options: ResidualSafetyOptions,
+): Promise<ResidualSafetyAssessment> {
+  try {
+    const read = await openTrace(
+      { type: "string", content: redactedContent },
+      { format: "agent-inspect-jsonl" },
+    );
+    const result = assessOpenedTrace(read, {
+      redactionProfile: options.profile,
+      ...(options.policy !== undefined ? { policy: options.policy } : {}),
+    });
+    return assessmentFromSafetyResult(result);
+  } catch {
+    // Not a supported trace (plain JSON, foreign schema, empty output).
+  }
+
+  try {
+    return detectorOnlyAssessment(redactedContent, options);
+  } catch {
+    return {
+      status: "UNKNOWN",
+      basis: "unavailable",
+      findingCount: 0,
+      highConfidenceFindingCount: 0,
+      codes: [],
+      note: `${SUPPORTED_TRACE_NOTE} ${UNAVAILABLE_NOTE}`,
+    };
+  }
+}
+
+/**
+ * Concise, value-free human warning.
+ *
+ * Only `UNSAFE` and `UNKNOWN` warn on stderr: a redacted copy routinely keeps warning-level
+ * findings (a sensitive key name whose value is now a placeholder), and warning on those
+ * would make the default human path noisy. JSON output always carries the full assessment.
+ */
+export function residualWarningLine(
+  assessment: ResidualSafetyAssessment,
+): string | undefined {
+  if (assessment.status !== "UNSAFE" && assessment.status !== "UNKNOWN") return undefined;
+  const codes = assessment.codes.length > 0 ? ` Codes: ${assessment.codes.join(", ")}.` : "";
+  return (
+    `Residual safety: ${assessment.status} (${assessment.basis}) — ` +
+    `${assessment.findingCount} finding(s), ${assessment.highConfidenceFindingCount} high-confidence, ` +
+    `remain in the redacted copy. Run \`agent-inspect verify-safe\` before sharing.${codes}`
+  );
+}
+
+/** Exit code contract for `--fail-on-residual`. Default redact exit codes are unchanged. */
+export function residualExitCode(assessment: ResidualSafetyAssessment): number {
+  if (assessment.status === "UNSAFE") return 1;
+  if (assessment.status === "UNKNOWN") return 2;
+  return 0;
+}

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -15,9 +15,14 @@ import {
   type TraceCheckFinding,
   type TraceCheckRule,
 } from "@agent-inspect/core/checks";
-import { redact, type RedactionFinding, type RedactionProfile } from "@agent-inspect/redact";
+import type { RedactionFinding, RedactionProfile } from "@agent-inspect/redact";
 
-import { redactTraceContent } from "./redact.js";
+import { redactTraceContent, redactValueWithPolicy } from "./redact-content.js";
+import {
+  loadRedactionPolicy,
+  summarizeRedactionPolicy,
+  type CompiledRedactionPolicy,
+} from "./redaction-policy.js";
 import { inputFromTarget } from "./trace-input.js";
 
 export interface SafetyCommandOptions {
@@ -32,6 +37,10 @@ export interface SafetyCommandOptions {
   maxSerializedBytes?: string;
   /** Redaction profile used when deriving the artifact assessment (verify-safe). */
   redactionProfile?: RedactionProfile;
+  /** Local bounded redaction policy file path (parsed by the command entry point). */
+  policyPath?: string;
+  /** Already-compiled local redaction policy (additive; never disables built-ins). */
+  policy?: CompiledRedactionPolicy;
 }
 
 type SafetyStatus = "SAFE" | "SAFE WITH WARNINGS" | "UNSAFE" | "UNKNOWN";
@@ -78,6 +87,8 @@ interface SafetyResult {
   sourceAssessment?: SafetyLayerAssessment;
   artifactAssessment?: SafetyLayerAssessment;
   redactionSummary?: SafetyRedactionSummary;
+  /** Present when a local bounded redaction policy was supplied with `--policy`. */
+  policy?: ReturnType<typeof summarizeRedactionPolicy>;
 }
 
 const BEST_EFFORT_NOTE =
@@ -368,6 +379,7 @@ function classifyRedactionDetector(detector: string): {
 function redactionDetectorFindings(
   read: Awaited<ReturnType<typeof openTrace>>,
   runId: string | undefined,
+  policy: CompiledRedactionPolicy | undefined,
 ): TraceCheckFinding[] {
   const runs = runId === undefined
     ? read.runs
@@ -379,7 +391,7 @@ function redactionDetectorFindings(
       const attrs = node.event.attributes;
       if (attrs === undefined) continue;
 
-      const result = redact(attrs, { profile: "share" });
+      const result = redactValueWithPolicy(attrs, "share", policy);
       for (const finding of result.findings) {
         if (finding.action === "keep") continue;
         const taxonomy = classifyRedactionDetector(finding.detector);
@@ -479,6 +491,11 @@ function printHuman(result: SafetyResult, explain = false): void {
       );
     }
   }
+  if (result.policy !== undefined) {
+    console.log(
+      `Policy: ${result.policy.source} (sensitiveKeys=${result.policy.sensitiveKeys}, valuePatterns=${result.policy.valuePatterns})`,
+    );
+  }
   console.log(
     `Summary: ${result.summary.findings} finding(s), ${result.summary.warnings} warning(s), ${result.summary.errors} error(s)`,
   );
@@ -517,14 +534,20 @@ async function safetyCommand(
   stdin: NodeJS.ReadableStream,
 ): Promise<void> {
   let result: SafetyResult;
+  let policy: CompiledRedactionPolicy | undefined;
 
   try {
+    policy =
+      options.policyPath === undefined
+        ? undefined
+        : await loadRedactionPolicy(options.policyPath);
     const input = await inputFromTarget(target, options, stdin);
     const read = await openTrace(input, {
       ...(options.format !== undefined ? { format: options.format } : {}),
     });
     const source = assessOpenedTrace(read, {
       ...options,
+      ...(policy !== undefined ? { policy } : {}),
       ...(options.run !== undefined ? { runId: options.run } : {}),
     });
     if (command === "scan") {
@@ -546,7 +569,7 @@ async function safetyCommand(
           sourceAssessment: layerFromResult(source),
         };
       } else {
-        const redacted = redactTraceContent(rawContent, profile);
+        const redacted = redactTraceContent(rawContent, profile, policy);
         // Reader labels (e.g. agent-inspect-v0.2-jsonl) are not registered format ids;
         // re-open redacted content with the canonical JSONL reader id.
         const artifactRead = await openTrace(
@@ -555,6 +578,7 @@ async function safetyCommand(
         );
         const artifact = assessOpenedTrace(artifactRead, {
           ...options,
+          ...(policy !== undefined ? { policy } : {}),
           ...(options.run !== undefined ? { runId: options.run } : {}),
         });
         const detectors = [
@@ -584,6 +608,10 @@ async function safetyCommand(
     result = message.startsWith("--")
       ? invalidArgumentResult(command, error)
       : readErrorResult(command, error);
+  }
+
+  if (policy !== undefined) {
+    result = { ...result, policy: summarizeRedactionPolicy(policy) };
   }
 
   process.exitCode = exitCodeFor(result);
@@ -624,7 +652,7 @@ export function assessOpenedTrace(
     );
     const detectorFindings =
       checkResult.diagnostics.length === 0
-        ? redactionDetectorFindings(read, checkResult.runId)
+        ? redactionDetectorFindings(read, checkResult.runId, options.policy)
         : [];
     return resultFromParts({
       command: "verify-safe",

--- a/packages/cli/test/redact-residual.test.ts
+++ b/packages/cli/test/redact-residual.test.ts
@@ -1,0 +1,184 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { redactCommand } from "../src/redact.js";
+
+interface RedactJsonOutput {
+  ok?: boolean;
+  content?: string;
+  findings?: { detector?: string }[];
+  residualAssessment?: {
+    status?: string;
+    basis?: string;
+    findingCount?: number;
+    highConfidenceFindingCount?: number;
+    codes?: string[];
+    note?: string;
+  };
+}
+
+function event(attributes: Record<string, unknown>): string {
+  return `${JSON.stringify({
+    schemaVersion: "0.2",
+    eventId: "event-a",
+    runId: "run-residual",
+    kind: "RUN",
+    name: "residual",
+    status: "ok",
+    timestamp: "2026-06-26T00:00:00.000Z",
+    confidence: "explicit",
+    source: { type: "manual" },
+    attributes,
+  })}\n`;
+}
+
+describe("redact residual safety assessment (#328)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-residual-"));
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  async function writeTrace(name: string, content: string): Promise<string> {
+    const file = path.join(tmp, name);
+    await writeFile(file, content, "utf-8");
+    return file;
+  }
+
+  async function redactJson(
+    target: string,
+    options: Parameters<typeof redactCommand>[1] = {},
+  ): Promise<RedactJsonOutput> {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await redactCommand(target, { json: true, ...options });
+    const output = String(logSpy.mock.calls[0]?.[0] ?? "{}");
+    logSpy.mockRestore();
+    return JSON.parse(output) as RedactJsonOutput;
+  }
+
+  it("keeps default stdout content and exit code unchanged when residue remains", async () => {
+    const file = await writeTrace(
+      "residual.jsonl",
+      event({ prompt: "raw prompt text", apiKey: "sk-fixtureSecretValue123456789" }),
+    );
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await redactCommand(file, { profile: "share" });
+
+    expect(process.exitCode).toBe(0);
+    const printed = String(writeSpy.mock.calls[0]?.[0] ?? "");
+    expect(printed).toContain("[REDACTED]");
+    expect(printed).not.toContain("sk-fixtureSecretValue123456789");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("warns concisely on stderr without printing matched values", async () => {
+    const file = await writeTrace(
+      "warn.jsonl",
+      event({ prompt: "raw prompt text", apiKey: "sk-fixtureSecretValue123456789" }),
+    );
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await redactCommand(file, { profile: "share" });
+
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(stderr).toContain("Residual safety: UNSAFE");
+    expect(stderr).toContain("verify-safe");
+    expect(stderr).not.toContain("sk-fixtureSecretValue123456789");
+    expect(stderr).not.toContain("raw prompt text");
+  });
+
+  it("adds an additive residualAssessment to JSON output", async () => {
+    const file = await writeTrace(
+      "json.jsonl",
+      event({ prompt: "raw prompt text", apiKey: "sk-fixtureSecretValue123456789" }),
+    );
+
+    const result = await redactJson(file, { profile: "share" });
+
+    expect(result.ok).toBe(true);
+    expect(result.residualAssessment?.status).toBe("UNSAFE");
+    expect(result.residualAssessment?.basis).toBe("supported-trace");
+    expect(result.residualAssessment?.codes).toContain("safety.rawPrompt");
+    expect(result.residualAssessment?.highConfidenceFindingCount).toBeGreaterThan(0);
+    expect(result.residualAssessment?.note).toContain("not a certification");
+    expect(JSON.stringify(result.residualAssessment)).not.toContain("raw prompt text");
+    expect(JSON.stringify(result.residualAssessment)).not.toContain(
+      "sk-fixtureSecretValue123456789",
+    );
+  });
+
+  it("reports no residual risk when redaction removes every blocking finding", async () => {
+    const file = await writeTrace(
+      "cleared.jsonl",
+      event({
+        token: "sk-abcdefghijklmnopqrstuvwxyz12",
+        contact: "pilot.user@example.test",
+      }),
+    );
+
+    const result = await redactJson(file, { profile: "share" });
+
+    expect(result.residualAssessment?.basis).toBe("supported-trace");
+    expect(["SAFE", "SAFE_WITH_WARNINGS"]).toContain(result.residualAssessment?.status);
+    expect(result.residualAssessment?.highConfidenceFindingCount).toBe(0);
+  });
+
+  it("exits non-zero only with the explicit --fail-on-residual opt-in", async () => {
+    const file = await writeTrace("fail.jsonl", event({ prompt: "raw prompt text" }));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, profile: "share" });
+    expect(process.exitCode).toBe(0);
+
+    await redactCommand(file, { json: true, profile: "share", failOnResidual: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("keeps --fail-on-residual at zero when nothing residual remains", async () => {
+    const file = await writeTrace("clean.jsonl", event({ note: "nothing sensitive here" }));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await redactCommand(file, { json: true, profile: "share", failOnResidual: true });
+
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("reports detector-only basis for arbitrary JSON that is not a supported trace", async () => {
+    const file = path.join(tmp, "doc.json");
+    await writeFile(
+      file,
+      JSON.stringify({ apiKey: "sk-fixtureSecretValue123456789", note: "ok" }),
+      "utf-8",
+    );
+
+    const result = await redactJson(file, { profile: "share" });
+
+    expect(result.residualAssessment?.basis).toBe("detector-only");
+    expect(result.residualAssessment?.note).toContain("not a supported trace");
+    expect(result.residualAssessment?.status).toBe("SAFE");
+  });
+
+  it("writes a derived copy and never mutates the source", async () => {
+    const original = event({ apiKey: "sk-fixtureSecretValue123456789" });
+    const file = await writeTrace("source.jsonl", original);
+    const output = path.join(tmp, "derived.jsonl");
+
+    await redactCommand(file, { profile: "share", output, failOnResidual: true });
+
+    expect(await readFile(file, "utf-8")).toBe(original);
+    expect(await readFile(output, "utf-8")).toContain("[REDACTED]");
+  });
+});

--- a/packages/cli/test/redaction-policy.test.ts
+++ b/packages/cli/test/redaction-policy.test.ts
@@ -1,0 +1,308 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { redactCommand } from "../src/redact.js";
+import {
+  MAX_POLICY_FILE_BYTES,
+  MAX_POLICY_RULES,
+  compileRedactionPolicy,
+  loadRedactionPolicy,
+} from "../src/redaction-policy.js";
+import { verifySafeCommand } from "../src/safety.js";
+
+const VALID_POLICY = {
+  policyVersion: 1,
+  sensitiveKeys: ["houseSecret"],
+  valuePatterns: [
+    { id: "house-prefix", type: "prefix", prefix: "hsk_", severity: "error" },
+    { id: "house-kv", type: "key-value", key: "house_token", severity: "error" },
+  ],
+};
+
+function event(attributes: Record<string, unknown>): string {
+  return `${JSON.stringify({
+    schemaVersion: "0.2",
+    eventId: "event-a",
+    runId: "run-policy",
+    kind: "RUN",
+    name: "policy",
+    status: "ok",
+    timestamp: "2026-06-26T00:00:00.000Z",
+    confidence: "explicit",
+    source: { type: "manual" },
+    attributes,
+  })}\n`;
+}
+
+describe("bounded local redaction policy (#329)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "agent-inspect-policy-"));
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  async function writePolicy(document: unknown, name = "policy.json"): Promise<string> {
+    const file = path.join(tmp, name);
+    await writeFile(file, JSON.stringify(document), "utf-8");
+    return file;
+  }
+
+  async function writeTrace(name: string, content: string): Promise<string> {
+    const file = path.join(tmp, name);
+    await writeFile(file, content, "utf-8");
+    return file;
+  }
+
+  async function jsonOutput(run: () => Promise<void>): Promise<Record<string, unknown>> {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await run();
+    const output = String(logSpy.mock.calls[0]?.[0] ?? "{}");
+    logSpy.mockRestore();
+    return JSON.parse(output) as Record<string, unknown>;
+  }
+
+  describe("validation", () => {
+    it("compiles a valid policy", () => {
+      const policy = compileRedactionPolicy(VALID_POLICY, "policy.json");
+
+      expect(policy.policyVersion).toBe(1);
+      expect(policy.sensitiveKeys).toEqual(["houseSecret"]);
+      expect(policy.detectors.map((detector) => detector.id)).toEqual([
+        "policy.house-prefix",
+        "policy.house-kv",
+      ]);
+    });
+
+    it.each([
+      [{ policyVersion: 2 }, "policyVersion"],
+      [{ policyVersion: 1, detectors: [] }, "unsupported field"],
+      [{ policyVersion: 1, sensitiveKeys: "token" }, "must be an array"],
+      [{ policyVersion: 1, sensitiveKeys: ["a".repeat(200)] }, "at most 128 characters"],
+      [{ policyVersion: 1, sensitiveKeys: ["bad key"] }, "may only contain"],
+      [
+        { policyVersion: 1, valuePatterns: [{ id: "r", type: "regex", pattern: ".*" }] },
+        'must be "prefix" or "key-value"',
+      ],
+      [
+        { policyVersion: 1, valuePatterns: [{ id: "r", type: "prefix", prefix: "a" }] },
+        "at least 3 characters",
+      ],
+      [
+        {
+          policyVersion: 1,
+          valuePatterns: [{ id: "r", type: "prefix", prefix: "a".repeat(100) }],
+        },
+        "at most 64 characters",
+      ],
+      [
+        {
+          policyVersion: 1,
+          valuePatterns: [{ id: "r", type: "prefix", prefix: "abc", pattern: ".*" }],
+        },
+        "unsupported field",
+      ],
+      [
+        {
+          policyVersion: 1,
+          valuePatterns: [
+            { id: "dup", type: "prefix", prefix: "abc" },
+            { id: "dup", type: "prefix", prefix: "xyz" },
+          ],
+        },
+        "duplicated",
+      ],
+      [
+        {
+          policyVersion: 1,
+          valuePatterns: [{ id: "r", type: "key-value", key: "k", minSecretLength: 0 }],
+        },
+        "positive integer",
+      ],
+      [
+        {
+          policyVersion: 1,
+          valuePatterns: [{ id: "r", type: "key-value", key: "k", severity: "critical" }],
+        },
+        'must be "warning" or "error"',
+      ],
+    ])("rejects %#", (document, expected) => {
+      expect(() => compileRedactionPolicy(document, "policy.json")).toThrow(
+        expect.objectContaining({ message: expect.stringContaining(expected) }),
+      );
+    });
+
+    it("rejects more rules than the bound allows", () => {
+      const sensitiveKeys = Array.from({ length: MAX_POLICY_RULES + 1 }, (_, i) => `key${i}`);
+
+      expect(() => compileRedactionPolicy({ policyVersion: 1, sensitiveKeys }, "p.json")).toThrow(
+        /the maximum is 200/,
+      );
+    });
+
+    it("rejects remote policy locations", async () => {
+      await expect(loadRedactionPolicy("https://example.test/policy.json")).rejects.toThrow(
+        /remote policy URLs are not supported/,
+      );
+    });
+
+    it("rejects an oversized policy file", async () => {
+      const file = path.join(tmp, "big.json");
+      await writeFile(
+        file,
+        JSON.stringify({
+          policyVersion: 1,
+          sensitiveKeys: ["padded"],
+          valuePatterns: [
+            { id: "pad", type: "prefix", prefix: `x${"y".repeat(MAX_POLICY_FILE_BYTES)}` },
+          ],
+        }),
+        "utf-8",
+      );
+
+      await expect(loadRedactionPolicy(file)).rejects.toThrow(/the maximum is 65536 bytes/);
+    });
+
+    it("rejects a missing file and malformed JSON", async () => {
+      await expect(loadRedactionPolicy(path.join(tmp, "nope.json"))).rejects.toThrow(
+        /file not found/,
+      );
+
+      const broken = path.join(tmp, "broken.json");
+      await writeFile(broken, "{ not json", "utf-8");
+      await expect(loadRedactionPolicy(broken)).rejects.toThrow(/is not valid JSON/);
+    });
+
+    it("treats interpolation-looking text as literal and rejects it by charset", () => {
+      expect(() =>
+        compileRedactionPolicy(
+          { policyVersion: 1, sensitiveKeys: ["${HOME}"] },
+          "policy.json",
+        ),
+      ).toThrow(/may only contain/);
+    });
+  });
+
+  describe("redact --policy", () => {
+    it("redacts org-specific keys, prefixes, and key-value forms", async () => {
+      const policyPath = await writePolicy(VALID_POLICY);
+      const file = await writeTrace(
+        "trace.jsonl",
+        event({
+          houseSecret: "house-secret-value-1",
+          prefixed: "hsk_abcdefghijklmno",
+          embedded: "config house_token=abcdefghijklmno end",
+          safe: "nothing sensitive",
+          maxTokens: 4096,
+        }),
+      );
+
+      const result = (await jsonOutput(() =>
+        redactCommand(file, { json: true, profile: "share", policy: policyPath }),
+      )) as { content?: string; findings?: { detector?: string }[]; policy?: unknown };
+
+      expect(result.content).not.toContain("house-secret-value-1");
+      expect(result.content).not.toContain("hsk_abcdefghijklmno");
+      expect(result.content).not.toContain("house_token=abcdefghijklmno");
+      expect(result.content).toContain("nothing sensitive");
+      expect(result.content).toContain("4096");
+      const detectors = result.findings?.map((finding) => finding.detector) ?? [];
+      expect(detectors).toContain("policy.house-prefix");
+      expect(detectors).toContain("policy.house-kv");
+      expect(result.policy).toEqual({
+        policyVersion: 1,
+        sensitiveKeys: 1,
+        valuePatterns: 2,
+        source: policyPath,
+      });
+      expect(JSON.stringify(result.findings)).not.toContain("abcdefghijklmno");
+    });
+
+    it("cannot disable built-in high-confidence protection", async () => {
+      const policyPath = await writePolicy({ policyVersion: 1, sensitiveKeys: ["houseSecret"] });
+      const file = await writeTrace(
+        "builtin.jsonl",
+        event({ note: "Bearer sk-fixtureSecretValue123456789" }),
+      );
+
+      const result = (await jsonOutput(() =>
+        redactCommand(file, { json: true, profile: "share", policy: policyPath }),
+      )) as { content?: string };
+
+      expect(result.content).not.toContain("sk-fixtureSecretValue123456789");
+      expect(result.content).toContain("[REDACTED]");
+    });
+
+    it("does not match a bounded pattern glued inside a longer token", async () => {
+      const policyPath = await writePolicy(VALID_POLICY);
+      const file = await writeTrace(
+        "boundary.jsonl",
+        event({ note: "xhsk_abcdefghijklmno", short: "hsk_abc" }),
+      );
+
+      const result = (await jsonOutput(() =>
+        redactCommand(file, { json: true, profile: "share", policy: policyPath }),
+      )) as { content?: string };
+
+      expect(result.content).toContain("xhsk_abcdefghijklmno");
+      expect(result.content).toContain("hsk_abc");
+    });
+
+    it("reports an actionable error for an invalid policy", async () => {
+      const bad = await writePolicy({ policyVersion: 9 }, "bad.json");
+      const file = await writeTrace("t.jsonl", event({ safe: "ok" }));
+
+      await expect(
+        redactCommand(file, { json: true, profile: "share", policy: bad }),
+      ).rejects.toThrow(/^--policy /);
+    });
+  });
+
+  describe("verify-safe --policy", () => {
+    it("applies the same compiled policy and reports it deterministically", async () => {
+      const policyPath = await writePolicy(VALID_POLICY);
+      const file = await writeTrace(
+        "verify.jsonl",
+        event({ embedded: "config house_token=abcdefghijklmno end" }),
+      );
+
+      const result = (await jsonOutput(() =>
+        verifySafeCommand(file, { json: true, policy: undefined, policyPath }),
+      )) as {
+        policy?: { sensitiveKeys?: number; valuePatterns?: number };
+        redactionSummary?: { detectors?: string[] };
+      };
+
+      expect(result.policy).toEqual({
+        policyVersion: 1,
+        sensitiveKeys: 1,
+        valuePatterns: 2,
+        source: policyPath,
+      });
+      expect(result.redactionSummary?.detectors).toContain("policy.house-kv");
+      expect(JSON.stringify(result)).not.toContain("abcdefghijklmno");
+    });
+
+    it("reports an invalid policy as an argument diagnostic instead of crashing", async () => {
+      const bad = await writePolicy({ policyVersion: 1, valuePatterns: "nope" }, "bad.json");
+      const file = await writeTrace("verify-bad.jsonl", event({ safe: "ok" }));
+
+      const result = (await jsonOutput(() =>
+        verifySafeCommand(file, { json: true, policyPath: bad }),
+      )) as { status?: string; diagnostics?: { code?: string }[] };
+
+      expect(result.status).toBe("UNKNOWN");
+      expect(result.diagnostics?.[0]?.code).toBe("AI_SAFETY_INVALID_ARGUMENTS");
+      expect(process.exitCode).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Implements 6.18.0 chunks D and E: residual safety reporting after standalone `redact` (#328) and a bounded local CLI redaction policy (#329).

> **Note:** this overlaps [#351](https://github.com/rajudandigam/agent-inspect/pull/351), which implements the same two issues with a different policy design. See [Relationship to #351](#relationship-to-351) below. Only one should land.

## Residual safety (#328)

`redact` writes a derived copy and never certifies that the copy is safe to share. Each run now assesses what the canonical local safety pipeline still finds in the redacted output, so operators know whether `verify-safe` will still flag it.

```json
{
  "residualAssessment": {
    "status": "UNSAFE",
    "basis": "supported-trace",
    "findingCount": 2,
    "highConfidenceFindingCount": 1,
    "codes": ["safety.rawPrompt"],
    "note": "Best-effort local residual assessment of the redacted copy; not a certification that sharing is safe."
  }
}
```

- **Backward compatible by default.** stdout/file output and the default exit code are unchanged. `--json` gains an additive `residualAssessment` field; existing fields keep their meaning.
- **`--fail-on-residual`** is the only way to change the exit code: `1` for `UNSAFE`, `2` for `UNKNOWN`, `0` otherwise.
- **Human mode** prints one concise stderr warning, and only for `UNSAFE` / `UNKNOWN`. A redacted copy routinely keeps warning-level findings (a sensitive key name whose value is now a placeholder); warning on those would make the default path noisy, so they stay in JSON only.
- **No matched values are ever printed** — `codes` carries rule/detector identifiers only.
- **Reuses the canonical pipeline.** The assessment re-opens the redacted output and runs `assessOpenedTrace`, the same rule set `verify-safe` uses. No detector lists are copied.
- **`basis`** documents coverage: `supported-trace` for the full rule set, `detector-only` for arbitrary JSON/JSONL that is not a supported trace (redaction detectors only; context-sensitive rules such as raw content and oversized attributes are not evaluated), `unavailable` when nothing could be assessed.
- `redact` still writes a derived copy and never mutates the source.

## Bounded local policy (#329)

`redact --policy ./agent-inspect.redaction.json` and `verify-safe --policy` accept a local JSON file that only **adds** sensitive keys and bounded value patterns on top of the built-in profiles.

```json
{
  "policyVersion": 1,
  "sensitiveKeys": ["houseSecret"],
  "valuePatterns": [
    { "id": "house-prefix", "type": "prefix", "prefix": "hsk_", "severity": "error" },
    { "id": "house-kv", "type": "key-value", "key": "house_token", "minSecretLength": 12 }
  ]
}
```

- **No regex is ever accepted or compiled.** `prefix` matches a token at a word boundary followed by at least `minSecretLength` secret-like characters; `key-value` matches `key=value` / `key: value` inside a string. Both are bounded linear scans (capped scan length and occurrence count), so a policy cannot introduce catastrophic backtracking.
- **Bounds:** 64 KiB file size, 200 total rules, 128-character keys, 3–64-character prefixes, 64-character ids, `minSecretLength` 1–256.
- **Rejects** unknown top-level and per-rule fields, any `policyVersion` other than `1`, duplicate ids, non-ASCII identifier characters, malformed JSON, directories, and oversized files.
- **No JS execution, no remote policy URL, no environment interpolation** — `${HOME}`-style text is literal and fails identifier validation.
- **Additive only.** A policy cannot disable built-in high-confidence protection.
- **Shared compilation.** `redact` and `verify-safe` compile the same policy and apply it to the same detector pipeline. Detectors surface as `policy.<id>` in `redact --json` findings and `verify-safe` `redactionSummary.detectors`.
- Invalid policies fail loudly: `redact` exits `1` with a `--policy …` message; `verify-safe` reports `AI_SAFETY_INVALID_ARGUMENTS` with status `UNKNOWN`.

## Relationship to #351

[#351](https://github.com/rajudandigam/agent-inspect/pull/351) implements the same two issues but accepts a user-supplied regex through a `typed` pattern type, guarded by a character allowlist plus ReDoS heuristics. Those heuristics are bypassable — `(a|aa)+$` passes every guard (no lookaround, no backreference, no nested quantifier inside a group, no `.*`/`.+`, no oversized `{n,m}`) and then backtracks exponentially:

```
ACCEPTED "(a|aa)+$" -> match took 2116 ms   # 35-character input
```

Since policy patterns run against every string in a trace, a policy file could hang `redact` and `verify-safe`. #351 also diverges from the release decision on shape (`version`/`extraKeys`/`patterns` rather than `policyVersion`/`sensitiveKeys`/`valuePatterns`), does not bound the policy file size, does not require `policyVersion`, and does not reject unknown keys. This PR takes the regex-free route the decision specified, which removes the class of bug rather than filtering for it.

## Tests

- `packages/cli/test/redact-residual.test.ts` (8 tests) — default output/exit-code compatibility, stderr warning contents, additive JSON field, cleared-residual path, `--fail-on-residual` opt-in, detector-only basis, source not mutated.
- `packages/cli/test/redaction-policy.test.ts` (24 tests) — compilation, every bound and rejection, remote-URL and interpolation refusal, prefix boundary behavior, built-ins not disableable, and `--policy` wiring on both `redact` and `verify-safe`.

Full `packages/cli` suite: 404 passing. `pnpm typecheck`, `pnpm run docs:links`, `pnpm run docs:commands`, `pnpm run repo:health`, `pnpm run public-truth:check`, and `git diff --check` are clean. Built-CLI smoke covers `--policy` + `--fail-on-residual` end to end.

## Compatibility

No schema change; persisted writes are untouched. No new root exports, no new dependencies, no network I/O. `redactTraceContent` moved to `packages/cli/src/redact-content.ts` so the policy and residual modules can share it without an import cycle; it is CLI-internal and not a published export.

Closes #328
Closes #329