### PR TITLE
feat(adapters): bounded preview capture parity via shared helper (#311)

### DIFF
--- a/.changeset/618-adapter-preview-parity.md
+++ b/.changeset/618-adapter-preview-parity.md
@@ -1,0 +1,28 @@
+---
+"agent-inspect": minor
+"@agent-inspect/adapter-sdk": minor
+"@agent-inspect/ai-sdk": minor
+"@agent-inspect/circuit": minor
+"@agent-inspect/eval": minor
+"@agent-inspect/guardrails": minor
+"@agent-inspect/harness": minor
+"@agent-inspect/index-sqlite": minor
+"@agent-inspect/jest": minor
+"@agent-inspect/langchain": minor
+"@agent-inspect/mcp": minor
+"@agent-inspect/mcp-server": minor
+"@agent-inspect/openai-agents": minor
+"@agent-inspect/redact": minor
+"@agent-inspect/studio": minor
+"@agent-inspect/tui": minor
+"@agent-inspect/viewer": minor
+"@agent-inspect/vitest": minor
+---
+
+Bounded `preview` capture parity across official framework adapters through one shared helper (#311).
+
+`@agent-inspect/ai-sdk` and `@agent-inspect/openai-agents` previously accepted `capture: "preview"` and fell back to metadata-only with an `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` warning. Both now persist bounded `*Preview` attributes, and `@agent-inspect/langchain` resolves its existing preview support through the same helper, so `capture`, `redactionProfile`, `maxPreviewChars`, and `onDiagnostic` mean the same thing in every adapter. A cross-adapter conformance matrix enforces the contract.
+
+Redaction runs on the structured value before a preview string is persisted, `maxPreviewChars` is a hard bound that the `share` and `strict` profiles cap further, and cycles, bigints, and throwing getters are handled without throwing into the traced application. Capture diagnostics are stable: `AI_CAPTURE_FIELD_UNAVAILABLE`, `AI_CAPTURE_PREVIEW_TRUNCATED`, and `AI_CAPTURE_PREVIEW_REDACTED`, reported through `onDiagnostic` and counted in `getDiagnostics().capture`.
+
+`metadata-only` remains the default and stays silent, there is no full-content capture mode, no network I/O is added, and the helper ships on the existing `agent-inspect/advanced` subpath rather than the root API. Preview redaction is key-based and bounded — it is not a sanitization guarantee for secrets embedded in free text.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -16,13 +16,43 @@ v2.3 hardens existing official adapters before adding new ones. Priority is base
 
 Reporters (`@agent-inspect/vitest` and `@agent-inspect/jest`) are public packages as of v2.2, but they are CI/test artifact reporters rather than framework trace adapters. They stay outside the v2.3 adapter-hardening priority order.
 
+## Shared adapter capture contract (preview)
+
+All three official framework adapters — `@agent-inspect/ai-sdk`, `@agent-inspect/openai-agents`, and `@agent-inspect/langchain` — resolve capture through one shared helper, so the same options mean the same thing everywhere. A cross-adapter conformance matrix asserts this contract.
+
+| Option | Type | Default | Behavior |
+| ------ | ---- | ------- | -------- |
+| `capture` | `"metadata-only" \| "preview"` | `"metadata-only"` | `metadata-only` persists no preview attributes at all. `preview` adds bounded `*Preview` attributes. There is no full-content mode. |
+| `redactionProfile` | `"local" \| "share" \| "strict"` | `"local"` | Key-based redaction applied **before** a preview string is persisted. `share` and `strict` also lower the effective `maxPreviewChars` ceiling; `strict` replaces preview values entirely. |
+| `maxPreviewChars` | `number` | adapter default, profile-capped | Hard upper bound on each persisted preview string, including the truncation marker. |
+| `onDiagnostic` | `(diagnostic) => void` | — | Local callback for capture diagnostics. Listener failures are isolated and never reach the traced application. |
+
+Capture diagnostic codes are stable:
+
+| Code | Meaning |
+| ---- | ------- |
+| `AI_CAPTURE_FIELD_UNAVAILABLE` | `capture: "preview"` was requested but the framework did not provide the field, or the value could not be safely serialized. Nothing is persisted for that field. |
+| `AI_CAPTURE_PREVIEW_TRUNCATED` | The preview string hit the `maxPreviewChars` bound and was truncated. |
+| `AI_CAPTURE_PREVIEW_REDACTED` | Redaction replaced at least one value inside the preview before persistence. |
+
+Counters for the same events are available without a listener via each adapter's `getDiagnostics().capture`.
+
+What the contract guarantees:
+
+- **Metadata-only stays the default and stays silent** — no preview attributes, no capture diagnostics.
+- **Redaction runs before persistence** — key-based redaction is applied to the structured value, not to an already-serialized string.
+- **Bounds are hard** — cycles, bigints, and getters that throw are handled without throwing into the traced application, and every persisted preview respects the resolved bound.
+- **No network, no new root/core dependencies** — the helper lives in core and is exported from `agent-inspect/advanced`.
+
+This is bounded preview capture, **not sanitization**: redaction is key-based, so a secret embedded in free text (for example inside a prompt string) can still appear in a preview. Treat preview traces as sensitive and run `agent-inspect redact` before sharing — see [SAFE-TRACE-SHARING.md](./SAFE-TRACE-SHARING.md).
+
 ## Vercel AI SDK (`@agent-inspect/ai-sdk`)
 
 **Full guide:** [AI-SDK-ADOPTION.md](./AI-SDK-ADOPTION.md) · **Capture path:** [CHOOSE-YOUR-CAPTURE-PATH.md](./CHOOSE-YOUR-CAPTURE-PATH.md)
 
 **Status:** experimental adapter — optional package published in the aligned v2.2.0 package set and hardened in the v2.3 adapter train.
 
-The adapter has hardened lifecycle identity and parallel integration isolation. It remains metadata-only: `capture: "preview"` and preview-only redaction options emit diagnostics **and one visible** `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` warning per adapter instance, then fall back to metadata-only capture. Bounded free-text preview capture is planned for a later train; it is not implemented here.
+The adapter has hardened lifecycle identity and parallel integration isolation. Capture is **metadata-only by default**. Opting into `capture: "preview"` persists bounded, redacted preview fields through the [shared adapter capture contract](#shared-adapter-capture-contract-preview); there is no full-content mode.
 
 ### Install
 
@@ -59,7 +89,7 @@ const result = await generateText({
 - **Metadata-only by default** — records model, finish reason, token usage, timing, and safe counts/summaries.
 - **Required safe telemetry settings** — set `recordInputs: false` and `recordOutputs: false` on every AI SDK call using this adapter.
 - **No raw payload capture by default** — prompts, messages, generated text, stream chunks, tool inputs/outputs, headers, request bodies, and response bodies are not persisted.
-- **Preview capture is not enabled yet** — requesting `capture: "preview"` emits one console warning with code `AI_ADAPTER_PREVIEW_NOT_AVAILABLE`, records diagnostics via `getDiagnostics()`, and does not persist raw previews. Effective capture remains metadata-only.
+- **Opt-in bounded previews** — `capture: "preview"` adds `*Preview` attributes for prompt, message, text, tool input, and tool output fields, redacted and truncated by the [shared capture contract](#shared-adapter-capture-contract-preview). Headers, request bodies, response bodies, and `experimental_context` are never previewed.
 
 ### Local no-network recipe
 
@@ -375,7 +405,7 @@ Integration modes:
 - **No upload behavior** — the processor writes only to an explicit local writer or `traceDir`.
 - **Metadata-only by default** — records trace/span IDs, parentage, names, timing, status, errors, safe model/tool names, token counts, and bounded summaries.
 - **No raw payload capture by default** — prompts, messages, generated text, function inputs/outputs, arbitrary custom data, trace exporter credentials, headers, request bodies, response bodies, and hosted tool payloads are not persisted.
-- **Preview capture is not enabled yet** — requesting `capture: "preview"` emits one console warning with code `AI_ADAPTER_PREVIEW_NOT_AVAILABLE`, records diagnostics via `getDiagnostics()`, and does not persist raw previews. Effective capture remains metadata-only.
+- **Opt-in bounded previews** — `capture: "preview"` adds `inputPreview` / `outputPreview` attributes for generation, function, response, custom, transcription, speech, and speech-group spans through the [shared capture contract](#shared-adapter-capture-contract-preview). Span types without a payload concept (handoff, guardrail, agent) stay metadata-only and report no unavailable fields.
 - **Fixture-backed lifecycle coverage** — local tests and the recipe cover agent, generation, function tool, handoff, guardrail, response, MCP tools, custom, transcription, and speech span shapes without provider calls.
 
 Full API: [API.md](./API.md) §14.

--- a/docs/AI-SDK-ADOPTION.md
+++ b/docs/AI-SDK-ADOPTION.md
@@ -84,6 +84,15 @@ See [examples/recipes/ai-sdk-next-route](../../examples/recipes/ai-sdk-next-rout
 | `recordOutputs: false` | yes | Prevents model output capture in telemetry |
 | `capture: "metadata-only"` | yes (adapter) | AgentInspect adapter redacts/bounds persisted fields |
 
+Opting into `capture: "preview"` persists bounded, redacted `*Preview` attributes
+for prompt, message, text, and tool payload fields. Tune it with
+`maxPreviewChars`, raise `redactionProfile` to `share` or `strict` for stricter
+bounds, and observe `AI_CAPTURE_FIELD_UNAVAILABLE` /
+`AI_CAPTURE_PREVIEW_TRUNCATED` / `AI_CAPTURE_PREVIEW_REDACTED` through
+`onDiagnostic` or `getDiagnostics().capture`. Preview traces can still contain
+sensitive free text; redact before sharing. Full contract:
+[ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview).
+
 ## Inspect locally
 
 ```bash

--- a/docs/API.md
+++ b/docs/API.md
@@ -206,12 +206,13 @@ import { agentInspect } from "@agent-inspect/ai-sdk";
   - **`writer`**: optional explicit local `TraceWriter` for tests, recipes, and controlled runtime integration.
   - **`traceDir`**: optional local directory that creates a file writer inside the adapter package.
   - **`runName`**: optional local run name.
-  - **`capture`**: `"metadata-only"` (default) or `"preview"`; `preview` currently emits a diagnostic and falls back to metadata-only.
-  - **`redactionProfile`** and **`maxPreviewChars`**: preview-only knobs; when preview capture is unsupported or not selected, they emit diagnostics instead of silently doing nothing.
-  - **`getDiagnostics()`**: exposes isolated adapter write, lifecycle/configuration, flush, and close failures without throwing into AI SDK callbacks.
+  - **`capture`**: `"metadata-only"` (default) or `"preview"`; `preview` persists bounded, redacted `*Preview` attributes via the shared adapter capture contract.
+  - **`redactionProfile`** and **`maxPreviewChars`**: preview-only knobs; redaction runs before persistence and `maxPreviewChars` is a hard bound (further capped by `share` / `strict` profiles).
+  - **`onDiagnostic`**: optional local listener for capture diagnostics (`AI_CAPTURE_FIELD_UNAVAILABLE`, `AI_CAPTURE_PREVIEW_TRUNCATED`, `AI_CAPTURE_PREVIEW_REDACTED`). Listener failures are isolated.
+  - **`getDiagnostics()`**: exposes isolated adapter write, lifecycle/configuration, flush, and close failures without throwing into AI SDK callbacks, plus a `capture` block with the resolved capture mode and preview counters.
   - **`getWriterStats()`**, **`flush()`**, and **`close()`**: explicit writer lifecycle helpers. Failures are captured in diagnostics.
 
-Every AI SDK call using the adapter must keep telemetry local and metadata-only:
+Every AI SDK call using the adapter must keep telemetry local:
 
 ```ts
 experimental_telemetry: {
@@ -222,7 +223,7 @@ experimental_telemetry: {
 }
 ```
 
-The adapter records local v0.2 persisted events for run, LLM step, and tool lifecycle metadata. It does not persist raw prompts, messages, generated text, stream chunks, tool inputs, tool outputs, headers, request bodies, response bodies, or user `experimental_context`. Unsupported preview capture options are explicit diagnostics and keep this metadata-only behavior.
+The adapter records local v0.2 persisted events for run, LLM step, and tool lifecycle metadata. In the default `metadata-only` mode it does not persist raw prompts, messages, generated text, stream chunks, tool inputs, tool outputs, headers, request bodies, response bodies, or user `experimental_context`. With `capture: "preview"`, prompt, message, text, tool input, and tool output fields are persisted as bounded, redacted previews; headers, request bodies, response bodies, and `experimental_context` are still never previewed. See [ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview).
 
 No network writer, OpenTelemetry exporter, provider wrapper, or global monkey-patch is part of this package.
 
@@ -343,9 +344,10 @@ import { agentInspectProcessor } from "@agent-inspect/openai-agents";
   - **`writer`**: optional explicit local `TraceWriter` for tests, recipes, and controlled runtime integration.
   - **`traceDir`**: optional local directory that creates a file writer inside the adapter package.
   - **`workflowName`**: optional local run name overriding the SDK trace name.
-  - **`capture`**: `"metadata-only"` (default) or `"preview"`; `preview` currently emits a diagnostic and falls back to metadata-only.
-  - **`redactionProfile`** and **`maxPreviewChars`**: preview-only knobs; when preview capture is unsupported or not selected, they emit diagnostics instead of silently doing nothing.
-  - **`getDiagnostics()`**: exposes isolated processor write, lifecycle/configuration, flush, and shutdown failures without throwing into OpenAI Agents callbacks.
+  - **`capture`**: `"metadata-only"` (default) or `"preview"`; `preview` persists bounded, redacted `inputPreview` / `outputPreview` span attributes via the shared adapter capture contract.
+  - **`redactionProfile`** and **`maxPreviewChars`**: preview-only knobs; redaction runs before persistence and `maxPreviewChars` is a hard bound (further capped by `share` / `strict` profiles).
+  - **`onDiagnostic`**: optional local listener for capture diagnostics (`AI_CAPTURE_FIELD_UNAVAILABLE`, `AI_CAPTURE_PREVIEW_TRUNCATED`, `AI_CAPTURE_PREVIEW_REDACTED`). Listener failures are isolated.
+  - **`getDiagnostics()`**: exposes isolated processor write, lifecycle/configuration, flush, and shutdown failures without throwing into OpenAI Agents callbacks, plus a `capture` block with the resolved capture mode and preview counters.
   - **`getWriterStats()`**, **`forceFlush()`**, and **`shutdown()`**: explicit writer lifecycle helpers. Failures are captured in diagnostics.
 
 Safe future usage must replace processors explicitly:
@@ -356,7 +358,7 @@ setTraceProcessors([agentInspectProcessor({ traceDir: "./.agent-inspect" })]);
 
 Do not use `addTraceProcessor()` as the default AgentInspect path; that leaves existing/default processors in place and can preserve backend export behavior in server runtimes.
 
-The processor records local v0.2 persisted events for trace/run, agent, generation/response, function/tool, handoff, guardrail, MCP tools, custom, transcription, and speech span metadata where safely representable. It does not persist raw prompts, messages, generated text, function inputs/outputs, arbitrary custom data, trace exporter credentials, headers, request bodies, response bodies, or hosted tool payloads by default.
+The processor records local v0.2 persisted events for trace/run, agent, generation/response, function/tool, handoff, guardrail, MCP tools, custom, transcription, and speech span metadata where safely representable. It does not persist raw prompts, messages, generated text, function inputs/outputs, arbitrary custom data, trace exporter credentials, headers, request bodies, response bodies, or hosted tool payloads by default. With `capture: "preview"`, span input/output fields are persisted as bounded, redacted previews; trace exporter credentials, headers, and request/response bodies are still never previewed. See [ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview).
 
 ## 15. Experimental persisted-event foundation (v1.2.0)
 

--- a/docs/CHOOSE-YOUR-CAPTURE-PATH.md
+++ b/docs/CHOOSE-YOUR-CAPTURE-PATH.md
@@ -21,6 +21,20 @@ Canonical guide for picking how AgentInspect records TypeScript agent evidence. 
 
 There is **no** official Mastra adapter. Do not invent one from interest alone.
 
+## How much each adapter records
+
+Every official framework adapter resolves `capture` the same way:
+
+| Mode | What lands in the trace |
+| --- | --- |
+| `metadata-only` (**default**) | Names, IDs, parentage, timing, status, model/tool identifiers, token counts, and bounded summaries. No payload text, no capture diagnostics. |
+| `preview` (opt-in) | Everything above plus bounded `*Preview` attributes for the framework's input/output fields, redacted before persistence and truncated at `maxPreviewChars`. |
+
+There is no full-content capture mode. `redactionProfile` is key-based, so it is
+**not** sanitization of free text — run `agent-inspect redact` before sharing a
+preview trace. Contract details and diagnostic codes:
+[ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview).
+
 ## Boundary rule for `observe()`
 
 ```text

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -35,6 +35,7 @@ This document states what AgentInspect **does not** provide today. It complement
 - **OpenAI Agents JS support is experimental.** `@agent-inspect/openai-agents` maps metadata-only runtime spans through the safe `setTraceProcessors()` boundary and does not capture raw payloads by default. The v1.9 package publication retry is a separate maintainer npm automation task, not part of the v2 contract work.
 - **LangGraph support is a boundary decision, not a separate package.** Initial support is expected through `@agent-inspect/langchain` callbacks unless no-network fixtures prove a separate package is needed.
 - **No root/core adapter dependencies.** AI SDK, OpenAI Agents, LangGraph, OpenTelemetry, and LangChain remain outside the root/core runtime dependency graph.
+- **Preview capture is bounded, not sanitized.** `capture: "preview"` persists truncated, key-redacted previews of framework-provided input/output fields. Key-based redaction cannot detect a secret embedded in free text, and there is no full-content capture mode. Fields the framework never exposes are reported as `AI_CAPTURE_FIELD_UNAVAILABLE` rather than reconstructed.
 
 ## LangChain streaming (v1.3.0)
 

--- a/docs/OPENAI-AGENTS-LOCAL.md
+++ b/docs/OPENAI-AGENTS-LOCAL.md
@@ -36,6 +36,7 @@ setTraceProcessors([
 - Default `metadata-only` capture
 - No automatic upload from AgentInspect
 - Replacing processors does not by itself redact OpenAI SDK network traffic — review OpenAI SDK settings separately
+- `capture: "preview"` is opt-in and persists bounded, redacted `inputPreview` / `outputPreview` span attributes; tune with `maxPreviewChars` and `redactionProfile`, and watch `onDiagnostic` / `getDiagnostics().capture` for `AI_CAPTURE_FIELD_UNAVAILABLE`. There is no full-content mode. See [ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview).
 
 ## Recipes
 

--- a/docs/SAFE-TRACE-SHARING.md
+++ b/docs/SAFE-TRACE-SHARING.md
@@ -6,7 +6,7 @@ AgentInspect traces, log-ingest outputs, and exports are local files. They may s
 
 This guide is practical sharing guidance, not a guarantee that any artifact is safe to publish. Redaction profiles are **best-effort transformation**, not compliance-grade DLP or a safety certification. Always finish with `verify-safe` before sharing.
 
-Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and require human review. Org-specific patterns need programmatic custom detectors today; a bounded local CLI policy is proposed separately and is not yet supported.
+Built-in profiles redact high-confidence credential forms (provider keys, JWTs, bearer tokens, and bounded `token=` / `api_key=` / `internal_token=` style key/value secrets). Broad or context-sensitive findings—such as private filesystem paths—may still appear under `verify-safe` and as residual status after `redact`. Org-specific patterns can use a local CLI `--policy` JSON file (`extraKeys` plus bounded literal/prefix/typed patterns) or programmatic custom detectors.
 
 `strict` is a stricter **rule set** (more keys), not a promise that every input produces bytes different from `share`.
 
@@ -63,7 +63,7 @@ Replace sensitive data with clear placeholders such as `example.test`, `user@exa
 - Redacted copies from `agent-inspect redact`: review the output file itself; findings show detector/path/action evidence but do not certify full safety.
 - OpenInference / OTLP JSON exports: check attributes, span names, events, and resource metadata.
 - Structured log ingest configs: confirm mapped keys do not pull in full request bodies, headers, raw prompts, or unbounded output fields.
-- LangChain adapter traces: keep `capture: "metadata-only"` for shareable examples; review `capture: "preview"` traces carefully because previews can include prompt or output fragments.
+- Framework adapter traces (ai-sdk, openai-agents, langchain): keep `capture: "metadata-only"` for shareable examples; review `capture: "preview"` traces carefully because previews can include prompt or output fragments. Preview redaction is key-based and bounded, not a sanitization guarantee.
 - Third-party adapter packages: follow the [Adapter SDK privacy checklist](./ADAPTER-SDK-PRIVACY.md) before sharing adapter traces, examples, or registry submissions.
 
 ## When to use each profile

--- a/docs/SUPPORT-LEVELS.md
+++ b/docs/SUPPORT-LEVELS.md
@@ -75,6 +75,7 @@ See [INSTALL-KITS.md](./INSTALL-KITS.md).
 - Persisted schema **1.0**; v0.1 / v0.2 / 1.0 traces remain readable
 - Optional packages do not add root/core runtime dependencies
 - Network behavior is explicit (see [NETWORK-BEHAVIOR.md](./NETWORK-BEHAVIOR.md))
+- Every Supported official adapter honors the same capture contract — `metadata-only` default, opt-in bounded `preview`, redaction before persistence, shared diagnostic codes — enforced by a cross-adapter conformance matrix (see [ADAPTERS.md](./ADAPTERS.md#shared-adapter-capture-contract-preview))
 
 ## Promotion criteria
 

--- a/docs/implementation/CURRENT-TASK.md
+++ b/docs/implementation/CURRENT-TASK.md
@@ -26,7 +26,8 @@ pendingManualGate: ""
 
 ## Later (authorized after 6.17.8)
 
-- **6.18.0** — differentiation starter, #307/#213, #311 preview, #328/#329, #330, capture-path docs, #295 scope
+- **6.18.0** — differentiation starter, #307/#213, #328/#329, #330, capture-path docs, #295 scope
+  - #311 shared adapter preview capture: implemented (changeset `618-adapter-preview-parity`); close the issue after 6.18.0 publishes
 - **6.19.0** — TraceReader authoring, derived failure roles, architectural-intent interop, prior-context refs
 - **6.20–6.22** — roadmap/labels only in this run
 

--- a/docs/implementation/RELEASE-TRAIN-STATE.md
+++ b/docs/implementation/RELEASE-TRAIN-STATE.md
@@ -26,7 +26,7 @@ githubIssues:
   "222": "candidate close — TraceFacts parity (verify vs #294/#337)"
   "308": "6.20 requiredOrderMode — stay open; PR #315"
   "309": "6.20 alternatives.anyOf — stay open"
-  "311": "6.18 preview parity — stay open"
+  "311": "6.18 preview parity — implemented on feat/618-preview-parity; close after 6.18.0 publish"
   "328": "6.18 residual safety after redact"
   "329": "6.18 bounded CLI redaction policy"
   "330": "6.18 view --errors-only pruned tree"

--- a/packages/adapter-sdk/test/adapter-capture-parity.test.ts
+++ b/packages/adapter-sdk/test/adapter-capture-parity.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Contract: every official framework adapter honors the same shared capture
+ * contract (#311).
+ *
+ * The matrix drives one identical assertion set through all three adapters so
+ * a new adapter — or a regression in an existing one — cannot silently reduce
+ * `capture: "preview"` to metadata-only, ignore `maxPreviewChars` /
+ * `redactionProfile`, or stop reporting `AI_CAPTURE_FIELD_UNAVAILABLE`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { agentInspect } from "@agent-inspect/ai-sdk";
+import { AgentInspectCallback } from "@agent-inspect/langchain";
+import { agentInspectProcessor } from "@agent-inspect/openai-agents";
+import type { AdapterCaptureDiagnostic } from "agent-inspect/advanced";
+import { memoryWriter } from "agent-inspect/writers";
+
+type CaptureRequest = "metadata-only" | "preview";
+
+interface AdapterCaptureOptions {
+  capture: CaptureRequest;
+  maxPreviewChars?: number;
+  redactionProfile?: "local" | "share" | "strict";
+  onDiagnostic?: (diagnostic: AdapterCaptureDiagnostic) => void;
+}
+
+interface CaptureRun {
+  /** Attribute records for every persisted/in-memory lifecycle row. */
+  attributes: Record<string, unknown>[];
+  captureDiagnostics: {
+    capture: string;
+    maxPreviewChars: number;
+    redactionProfile: string;
+    previewFieldsCaptured: number;
+    previewFieldsUnavailable: number;
+  };
+}
+
+interface AdapterCase {
+  name: string;
+  /** Runs a lifecycle where both input and output payloads are available. */
+  withPayloads(options: AdapterCaptureOptions): Promise<CaptureRun>;
+  /** Runs a lifecycle where a requested preview field cannot be sourced. */
+  withMissingInput(options: AdapterCaptureOptions): Promise<CaptureRun>;
+  /** Raw strings that must never reach a metadata-only row. */
+  rawStrings: string[];
+  inputNeedle: string;
+  outputNeedle: string;
+}
+
+const SECRET_KEY_PAYLOAD = { question: "refund policy", apiKey: "sk-must-not-persist" };
+
+function collectStrings(value: unknown, seen = new Set<unknown>()): string[] {
+  if (typeof value === "string") return [value];
+  if (typeof value !== "object" || value === null) return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  return Object.values(value).flatMap((entry) => collectStrings(entry, seen));
+}
+
+// Framework event shapes are built structurally so this cross-adapter matrix
+// does not depend on framework type packages from the adapter-sdk workspace.
+function aiSdkStartEvent(prompt: unknown): never {
+  return {
+    functionId: "parity-function",
+    model: { provider: "fixture-provider", modelId: "fixture-model" },
+    tools: {},
+    prompt,
+    messages: undefined,
+    metadata: {},
+    experimental_context: undefined,
+  } as never;
+}
+
+function aiSdkFinishEvent(text: string): never {
+  return {
+    stepNumber: 0,
+    steps: [],
+    model: { provider: "fixture-provider", modelId: "fixture-model" },
+    content: [],
+    text,
+    reasoning: [],
+    files: [],
+    sources: [],
+    toolCalls: [],
+    toolResults: [],
+    finishReason: { unified: "stop", raw: "stop" },
+    usage: {},
+    totalUsage: {},
+    warnings: [],
+    functionId: "parity-function",
+    metadata: {},
+    experimental_context: undefined,
+  } as never;
+}
+
+function openAiTrace(): never {
+  return {
+    type: "trace",
+    traceId: "trace_parity",
+    name: "parity-workflow",
+    groupId: undefined,
+    metadata: {},
+  } as never;
+}
+
+function openAiGenerationSpan(data: Record<string, unknown> = {}): never {
+  return {
+    type: "trace.span",
+    traceId: "trace_parity",
+    spanId: "span_parity_generation",
+    parentId: null,
+    spanData: { type: "generation", model: "fixture-model", ...data },
+    traceMetadata: {},
+    startedAt: "2026-09-05T00:00:00.000Z",
+    endedAt: "2026-09-05T00:00:00.010Z",
+    error: null,
+  } as never;
+}
+
+const adapterCases: AdapterCase[] = [
+  {
+    name: "@agent-inspect/ai-sdk",
+    inputNeedle: "parity input payload",
+    outputNeedle: "parity output payload",
+    rawStrings: ["parity input payload", "parity output payload", "sk-must-not-persist"],
+    async withPayloads(options) {
+      const writer = memoryWriter();
+      const integration = agentInspect({ writer, runName: "parity", ...options });
+
+      await integration.onStart?.(
+        aiSdkStartEvent({
+          text: "parity input payload",
+          ...SECRET_KEY_PAYLOAD,
+        }),
+      );
+      await integration.onFinish?.(aiSdkFinishEvent("parity output payload"));
+
+      return {
+        attributes: writer.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: integration.getDiagnostics().capture,
+      };
+    },
+    async withMissingInput(options) {
+      const writer = memoryWriter();
+      const integration = agentInspect({ writer, runName: "parity", ...options });
+
+      await integration.onStart?.(aiSdkStartEvent(undefined));
+
+      return {
+        attributes: writer.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: integration.getDiagnostics().capture,
+      };
+    },
+  },
+  {
+    name: "@agent-inspect/openai-agents",
+    inputNeedle: "parity input payload",
+    outputNeedle: "parity output payload",
+    rawStrings: ["parity input payload", "parity output payload", "sk-must-not-persist"],
+    async withPayloads(options) {
+      const writer = memoryWriter();
+      const processor = agentInspectProcessor({ writer, ...options });
+      const span = openAiGenerationSpan({
+        input: { text: "parity input payload", ...SECRET_KEY_PAYLOAD },
+        output: "parity output payload",
+      });
+
+      await processor.onTraceStart(openAiTrace());
+      await processor.onSpanStart(span);
+      await processor.onSpanEnd(span);
+
+      return {
+        attributes: writer.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: processor.getDiagnostics().capture,
+      };
+    },
+    async withMissingInput(options) {
+      const writer = memoryWriter();
+      const processor = agentInspectProcessor({ writer, ...options });
+      const span = openAiGenerationSpan();
+
+      await processor.onTraceStart(openAiTrace());
+      await processor.onSpanStart(span);
+
+      return {
+        attributes: writer.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: processor.getDiagnostics().capture,
+      };
+    },
+  },
+  {
+    name: "@agent-inspect/langchain",
+    inputNeedle: "parity input payload",
+    outputNeedle: "parity output payload",
+    rawStrings: ["parity input payload", "parity output payload", "sk-must-not-persist"],
+    async withPayloads(options) {
+      const callback = new AgentInspectCallback({ runName: "parity", ...options });
+
+      await callback.handleChainStart(
+        { lc: 1, type: "not_implemented", id: ["parityChain"] },
+        { text: "parity input payload", ...SECRET_KEY_PAYLOAD },
+        "chain-1",
+      );
+      await callback.handleChainEnd({ text: "parity output payload" }, "chain-1");
+
+      return {
+        attributes: callback.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: callback.getDiagnostics().capture,
+      };
+    },
+    async withMissingInput(options) {
+      const callback = new AgentInspectCallback({ runName: "parity", ...options });
+
+      await callback.handleChainStart(
+        { lc: 1, type: "not_implemented", id: ["parityChain"] },
+        undefined as unknown as Record<string, unknown>,
+        "chain-1",
+      );
+
+      return {
+        attributes: callback.getEvents().map((event) => event.attributes ?? {}),
+        captureDiagnostics: callback.getDiagnostics().capture,
+      };
+    },
+  },
+];
+
+function previewValues(attributes: Record<string, unknown>[]): string[] {
+  return attributes.flatMap((record) =>
+    Object.entries(record)
+      .filter(([key]) => key.toLowerCase().includes("preview"))
+      .map(([, value]) => value)
+      .filter((value): value is string => typeof value === "string"),
+  );
+}
+
+describe.each(adapterCases)("adapter capture parity — $name", (adapterCase) => {
+  it("defaults to metadata-only and persists no preview attributes", async () => {
+    const run = await adapterCase.withPayloads({ capture: "metadata-only" });
+
+    expect(run.captureDiagnostics.capture).toBe("metadata-only");
+    expect(previewValues(run.attributes)).toEqual([]);
+    for (const raw of adapterCase.rawStrings) {
+      expect(collectStrings(run.attributes)).not.toContain(raw);
+    }
+  });
+
+  it("persists bounded preview attributes when capture is preview", async () => {
+    const run = await adapterCase.withPayloads({
+      capture: "preview",
+      maxPreviewChars: 120,
+    });
+
+    expect(run.captureDiagnostics.capture).toBe("preview");
+    expect(run.captureDiagnostics.maxPreviewChars).toBe(120);
+    expect(run.captureDiagnostics.previewFieldsCaptured).toBeGreaterThan(0);
+
+    const previews = previewValues(run.attributes);
+    expect(previews.length).toBeGreaterThan(0);
+    expect(previews.join("\n")).toContain(adapterCase.inputNeedle);
+    expect(previews.join("\n")).toContain(adapterCase.outputNeedle);
+    for (const preview of previews) {
+      expect(preview.length).toBeLessThanOrEqual(121);
+    }
+  });
+
+  it("honors maxPreviewChars as a hard bound", async () => {
+    const run = await adapterCase.withPayloads({
+      capture: "preview",
+      maxPreviewChars: 8,
+    });
+
+    const previews = previewValues(run.attributes);
+    expect(previews.length).toBeGreaterThan(0);
+    for (const preview of previews) {
+      expect(preview.length).toBeLessThanOrEqual(9);
+    }
+    expect(previews.join("\n")).not.toContain(adapterCase.inputNeedle);
+  });
+
+  it("redacts credential-shaped keys inside previews", async () => {
+    const run = await adapterCase.withPayloads({
+      capture: "preview",
+      maxPreviewChars: 400,
+    });
+
+    expect(previewValues(run.attributes).join("\n")).toContain("[REDACTED]");
+    expect(collectStrings(run.attributes)).not.toContain("sk-must-not-persist");
+  });
+
+  it("caps preview bounds under the strict redaction profile", async () => {
+    const run = await adapterCase.withPayloads({
+      capture: "preview",
+      redactionProfile: "strict",
+      maxPreviewChars: 1000,
+    });
+
+    expect(run.captureDiagnostics.redactionProfile).toBe("strict");
+    expect(run.captureDiagnostics.maxPreviewChars).toBe(80);
+    expect(collectStrings(run.attributes)).not.toContain(adapterCase.inputNeedle);
+  });
+
+  it("emits AI_CAPTURE_FIELD_UNAVAILABLE when a preview field has no source", async () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const run = await adapterCase.withMissingInput({
+      capture: "preview",
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    expect(diagnostics.map((entry) => entry.code)).toContain(
+      "AI_CAPTURE_FIELD_UNAVAILABLE",
+    );
+    expect(diagnostics.every((entry) => entry.capture === "preview")).toBe(true);
+    expect(run.captureDiagnostics.previewFieldsUnavailable).toBeGreaterThan(0);
+  });
+
+  it("keeps metadata-only silent about preview diagnostics", async () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    await adapterCase.withMissingInput({
+      capture: "metadata-only",
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+});
+
+describe("adapter capture parity — matrix coverage", () => {
+  it("covers every official framework adapter", () => {
+    expect(adapterCases.map((entry) => entry.name)).toEqual([
+      "@agent-inspect/ai-sdk",
+      "@agent-inspect/openai-agents",
+      "@agent-inspect/langchain",
+    ]);
+  });
+});

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -52,7 +52,8 @@ const result = await generateText({
 - Writes JSONL under `.agent-inspect/` only
 - No network calls from AgentInspect
 - Default capture: metadata-only
-- `capture: "preview"` is accepted for compatibility but currently falls back to metadata-only and emits one `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` console warning per integration instance
+- `capture: "preview"` is opt-in and persists bounded `*Preview` attributes, redacted before they reach disk and truncated at `maxPreviewChars`; there is no full-content mode
+- Redaction is key-based, so a preview can still contain sensitive free text — run `agent-inspect redact` before sharing
 
 ## API
 
@@ -61,7 +62,7 @@ const result = await generateText({
 | `agentInspect(options)` | Telemetry integration factory |
 | `getTelemetryHandlers()` | Spread into AI SDK call |
 | `getTelemetryMetadata()` | Safe metadata for telemetry block |
-| `getDiagnostics()` | Local warnings (e.g. preview mode) |
+| `getDiagnostics()` | Local warnings plus resolved capture mode and preview counters |
 
 ## CLI
 
@@ -76,7 +77,8 @@ const result = await generateText({
 ## Troubleshooting
 
 - **No trace events:** Ensure `experimental_telemetry.isEnabled: true` and handlers are spread
-- **Preview mode warning:** `capture: "preview"` is not implemented yet; AgentInspect emits `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` once and keeps metadata-only persistence
+- **Empty previews in preview mode:** the AI SDK did not provide the field for that step. AgentInspect reports `AI_CAPTURE_FIELD_UNAVAILABLE` through `onDiagnostic` and `getDiagnostics().capture`
+- **Previews look cut off:** they are bounded by `maxPreviewChars`, which the `share` and `strict` redaction profiles cap further
 
 
 ## Version

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -8,7 +8,11 @@ import type {
   OnToolCallStartEvent,
   TelemetryIntegration,
 } from "ai";
+import { createAdapterPreviewCapture } from "agent-inspect/advanced";
 import type {
+  AdapterCaptureDiagnostics,
+  AdapterDiagnosticListener,
+  AdapterPreviewCapture,
   RedactionProfile,
 } from "agent-inspect/advanced";
 import type {
@@ -21,6 +25,9 @@ import type { TraceWriter, TraceWriterStats } from "agent-inspect/writers";
 
 /**
  * Experimental capture mode for the AI SDK adapter.
+ *
+ * `metadata-only` is the default. `preview` persists bounded, redacted preview
+ * attributes through the shared adapter capture helper.
  *
  * @experimental This package is part of the framework adapter train.
  */
@@ -51,26 +58,33 @@ export interface AgentInspectAiSdkOptions {
   /**
    * Capture policy. Defaults to metadata-only.
    *
-   * @experimental `preview` is currently rejected with diagnostics and falls
-   * back to metadata-only until bounded free-text preview capture is implemented.
+   * @experimental `preview` persists bounded, redacted prompt/message/output
+   * previews. It never persists full content.
    */
   capture?: AgentInspectAiSdkCaptureMode;
 
   /**
-   * Redaction profile for future preview capture.
+   * Redaction profile applied to preview attributes before persistence.
+   * `share` and `strict` also cap `maxPreviewChars`.
    *
-   * @experimental Currently diagnostic-only because the adapter persists
-   * metadata summaries and does not write raw preview content.
+   * @experimental Effective only when `capture: "preview"`.
    */
   redactionProfile?: RedactionProfile;
 
   /**
-   * Bounds future preview capture.
+   * Upper bound for each serialized preview attribute. Defaults to 200.
    *
-   * @experimental Currently diagnostic-only because `preview` falls back to
-   * metadata-only capture.
+   * @experimental Effective only when `capture: "preview"`.
    */
   maxPreviewChars?: number;
+
+  /**
+   * Receives bounded capture diagnostics such as
+   * `AI_CAPTURE_FIELD_UNAVAILABLE`. Listener failures are isolated.
+   *
+   * @experimental
+   */
+  onDiagnostic?: AdapterDiagnosticListener;
 }
 
 export interface AgentInspectAiSdkDiagnostics {
@@ -80,6 +94,8 @@ export interface AgentInspectAiSdkDiagnostics {
   closeFailures: number;
   lastError?: string;
   lastWarning?: string;
+  /** Shared preview-capture counters (`@experimental`). */
+  capture: AdapterCaptureDiagnostics;
 }
 
 export interface AgentInspectAiSdkIntegration extends TelemetryIntegration {
@@ -246,8 +262,9 @@ function summarizeFinishReason(
 class AgentInspectAiSdkTelemetryIntegration {
   private readonly writer: TraceWriter | undefined;
   private readonly requestedCapture: AgentInspectAiSdkCaptureMode;
-  private readonly effectiveCapture: "metadata-only" = "metadata-only";
-  private readonly diagnostics: AgentInspectAiSdkDiagnostics = {
+  private readonly preview: AdapterPreviewCapture;
+  private readonly effectiveCapture: AgentInspectAiSdkCaptureMode;
+  private readonly diagnostics: Omit<AgentInspectAiSdkDiagnostics, "capture"> = {
     writeFailures: 0,
     lifecycleWarnings: 0,
     flushFailures: 0,
@@ -258,12 +275,26 @@ class AgentInspectAiSdkTelemetryIntegration {
 
   constructor(private readonly options: AgentInspectAiSdkOptions) {
     this.requestedCapture = options.capture ?? "metadata-only";
+    this.preview = createAdapterPreviewCapture({
+      capture: this.requestedCapture,
+      redactionProfile: options.redactionProfile,
+      maxPreviewChars: options.maxPreviewChars,
+      onDiagnostic: options.onDiagnostic,
+    });
+    this.effectiveCapture = this.preview.capture;
     this.writer = options.writer ?? (options.traceDir ? fileWriter({ dir: options.traceDir }) : undefined);
     this.recordCaptureOptionWarnings();
   }
 
   getDiagnostics(): AgentInspectAiSdkDiagnostics {
-    return { ...this.diagnostics };
+    return { ...this.diagnostics, capture: this.preview.getDiagnostics() };
+  }
+
+  /** Bounded preview attributes for one lifecycle event (empty unless enabled). */
+  private previewAttributes(
+    fields: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return this.preview.applyPreviewFields({}, fields);
   }
 
   async onStart(event: OnStartEvent): Promise<void> {
@@ -315,16 +346,24 @@ class AgentInspectAiSdkTelemetryIntegration {
             this.requestedCapture === this.effectiveCapture
               ? undefined
               : this.requestedCapture,
-          previewCaptureSupported:
-            this.requestedCapture === "preview" ? false : undefined,
-          redactionProfile: this.options.redactionProfile,
-          maxPreviewChars: normalizeMaxPreviewChars(this.options.maxPreviewChars),
+          previewCaptureSupported: true,
+          // Preview rows report the effective bound/profile, which the
+          // `share` and `strict` profiles can lower below the request.
+          redactionProfile: this.preview.previewEnabled
+            ? this.preview.redactionProfile
+            : this.options.redactionProfile,
+          maxPreviewChars: this.preview.previewEnabled
+            ? this.preview.maxPreviewChars
+            : normalizeMaxPreviewChars(this.options.maxPreviewChars),
           recordInputsRequired: false,
           recordOutputsRequired: false,
           toolCount: countRecordKeys(event.tools),
           hasPrompt: event.prompt !== undefined,
           hasMessages: event.messages !== undefined,
           metadataKeyCount: countRecordKeys(event.metadata),
+          ...this.previewAttributes({
+            input: event.prompt ?? event.messages,
+          }),
         },
       });
     });
@@ -365,6 +404,7 @@ class AgentInspectAiSdkTelemetryIntegration {
           toolCount: countRecordKeys(event.tools),
           messageCount: event.messages.length,
           metadataKeyCount: countRecordKeys(event.metadata),
+          ...this.previewAttributes({ input: event.messages }),
         },
       });
     });
@@ -412,6 +452,7 @@ class AgentInspectAiSdkTelemetryIntegration {
           responseModelId: event.response.modelId,
           responseTimestamp: event.response.timestamp?.toISOString(),
           metadataKeyCount: countRecordKeys(event.metadata),
+          ...this.previewAttributes({ output: event.text }),
         },
         tokenUsage: summarizeUsage(event.usage),
         outputSummary: {
@@ -473,6 +514,7 @@ class AgentInspectAiSdkTelemetryIntegration {
           metadataKeyCount: countRecordKeys(event.metadata),
           providerMetadataKeyCount: countRecordKeys(toolCall.providerMetadata),
           toolMetadataKeyCount: countRecordKeys(toolCall.toolMetadata),
+          ...this.previewAttributes({ input: toolCall.input }),
         },
         inputSummary: summarizeUnknown(toolCall.input),
         error: toolCall.invalid ? summarizeError(toolCall.error) : undefined,
@@ -523,6 +565,10 @@ class AgentInspectAiSdkTelemetryIntegration {
           metadataKeyCount: countRecordKeys(event.metadata),
           providerMetadataKeyCount: countRecordKeys(toolCall.providerMetadata),
           toolMetadataKeyCount: countRecordKeys(toolCall.toolMetadata),
+          ...this.previewAttributes({
+            input: toolCall.input,
+            ...(event.success ? { output: event.output } : {}),
+          }),
         },
         outputSummary: event.success ? summarizeUnknown(event.output) : undefined,
         error: event.success ? undefined : summarizeError(event.error),
@@ -563,6 +609,7 @@ class AgentInspectAiSdkTelemetryIntegration {
           toolCallCount: event.toolCalls.length,
           toolResultCount: event.toolResults.length,
           metadataKeyCount: countRecordKeys(event.metadata),
+          ...this.previewAttributes({ output: event.text }),
         },
         tokenUsage: summarizeUsage(event.totalUsage),
         outputSummary: {
@@ -634,26 +681,12 @@ class AgentInspectAiSdkTelemetryIntegration {
     this.diagnostics.lastWarning = message;
   }
 
-  private previewCapabilityWarned = false;
-
   private recordCaptureOptionWarnings(): void {
+    if (this.effectiveCapture === "preview") return;
+
     const previewOnlyOptions: string[] = [];
-    if (this.requestedCapture === "preview") previewOnlyOptions.push("capture");
     if (this.options.redactionProfile !== undefined) previewOnlyOptions.push("redactionProfile");
     if (this.options.maxPreviewChars !== undefined) previewOnlyOptions.push("maxPreviewChars");
-
-    if (this.requestedCapture === "preview") {
-      const message =
-        `AI_ADAPTER_PREVIEW_NOT_AVAILABLE: capture:"preview" was requested, but this adapter currently persists metadata-only. Effective capture: metadata-only. No preview content was written. See docs/ADAPTERS.md.`;
-      this.recordLifecycleWarning(
-        `AI SDK preview capture is not supported yet; falling back to metadata-only capture. Unsupported options: ${previewOnlyOptions.join(", ")}.`,
-      );
-      if (!this.previewCapabilityWarned) {
-        this.previewCapabilityWarned = true;
-        console.warn(`[agent-inspect:ai-sdk] ${message}`);
-      }
-      return;
-    }
 
     if (previewOnlyOptions.length > 0) {
       this.recordLifecycleWarning(
@@ -677,8 +710,9 @@ class AgentInspectAiSdkTelemetryIntegration {
 /**
  * Create an AgentInspect telemetry integration for the Vercel AI SDK.
  *
- * @experimental The adapter maps metadata-only generation, LLM step, and tool
- * lifecycle events. Keep AI SDK telemetry configured with
+ * @experimental The adapter maps generation, LLM step, and tool lifecycle
+ * events. Capture is metadata-only by default; `capture: "preview"` adds
+ * bounded, redacted preview attributes. Keep AI SDK telemetry configured with
  * `recordInputs: false` and `recordOutputs: false`.
  */
 export function agentInspect(

--- a/packages/ai-sdk/test/api-stability.test.ts
+++ b/packages/ai-sdk/test/api-stability.test.ts
@@ -14,7 +14,10 @@ import { agentInspect } from "@agent-inspect/ai-sdk";
 import {
   buildRunWhatSummary,
 } from "agent-inspect/advanced";
-import type { InspectNode } from "agent-inspect/advanced";
+import type {
+  AdapterCaptureDiagnostic,
+  InspectNode,
+} from "agent-inspect/advanced";
 import {
   persistedInspectEventsToRunTrees,
   persistedInspectEventsToTraceEvents,
@@ -233,6 +236,15 @@ describe("@agent-inspect/ai-sdk scaffold", () => {
       lifecycleWarnings: 0,
       flushFailures: 0,
       closeFailures: 0,
+      capture: {
+        capture: "metadata-only",
+        redactionProfile: "local",
+        maxPreviewChars: 200,
+        previewFieldsCaptured: 0,
+        previewFieldsUnavailable: 0,
+        previewFieldsTruncated: 0,
+        previewFieldsRedacted: 0,
+      },
     });
   });
 
@@ -502,20 +514,20 @@ describe("@agent-inspect/ai-sdk scaffold", () => {
     expectNoRawText(eventsB, "raw parallel answer b");
   });
 
-  it("falls back from preview capture with explicit diagnostics and no raw text", async () => {
+  it("persists bounded preview attributes when capture is preview (#311)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
     const writer = memoryWriter();
     const integration = agentInspect({
       writer,
-      runName: "preview-fallback-fixture",
+      runName: "preview-capture-fixture",
       capture: "preview",
-      redactionProfile: "strict",
-      maxPreviewChars: 8,
+      maxPreviewChars: 32,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
     });
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("AI_ADAPTER_PREVIEW_NOT_AVAILABLE");
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[agent-inspect:ai-sdk]");
+    // Preview is implemented, so the removed capability warning must not fire.
+    expect(warnSpy).not.toHaveBeenCalled();
 
     await generateText({
       model: new MockLanguageModelV3({
@@ -542,8 +554,7 @@ describe("@agent-inspect/ai-sdk scaffold", () => {
       },
     });
 
-    // Lifecycle callbacks must not repeat the capability warning.
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
 
     const events = writer.getEvents();
@@ -555,20 +566,106 @@ describe("@agent-inspect/ai-sdk scaffold", () => {
       ["RUN", "ok"],
     ]);
     expect(events[0]?.attributes).toMatchObject({
-      capture: "metadata-only",
-      requestedCapture: "preview",
-      previewCaptureSupported: false,
-      redactionProfile: "strict",
-      maxPreviewChars: 8,
+      capture: "preview",
+      previewCaptureSupported: true,
+      maxPreviewChars: 32,
     });
+    // The persist path normalizes an absent optional attribute to null.
+    expect(events[0]?.attributes?.requestedCapture).toBeNull();
+    expect(String(events[0]?.attributes?.inputPreview)).toContain(
+      "raw preview prompt",
+    );
+    expect(String(events[3]?.attributes?.outputPreview)).toContain(
+      "raw preview generated answer",
+    );
+
+    for (const event of events) {
+      for (const [key, value] of Object.entries(event.attributes ?? {})) {
+        if (!key.toLowerCase().includes("preview")) continue;
+        if (typeof value !== "string") continue;
+        expect(value.length).toBeLessThanOrEqual(33);
+      }
+    }
+
     expect(integration.getDiagnostics()).toMatchObject({
       writeFailures: 0,
-      lifecycleWarnings: 1,
-      lastWarning:
-        "AI SDK preview capture is not supported yet; falling back to metadata-only capture. Unsupported options: capture, redactionProfile, maxPreviewChars.",
+      lifecycleWarnings: 0,
+      capture: {
+        capture: "preview",
+        redactionProfile: "local",
+        maxPreviewChars: 32,
+      },
     });
-    expectNoRawText(events, "raw preview prompt");
-    expectNoRawText(events, "raw preview generated answer");
+    expect(integration.getDiagnostics().capture.previewFieldsCaptured).toBeGreaterThan(0);
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("reports AI_CAPTURE_FIELD_UNAVAILABLE for unsourceable preview fields (#311)", async () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const writer = memoryWriter();
+    const integration = agentInspect({
+      writer,
+      runName: "preview-unavailable-fixture",
+      capture: "preview",
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    await integration.onStart?.({
+      ...startEvent(),
+      prompt: undefined,
+      messages: undefined,
+    } as unknown as OnStartEvent);
+
+    expect(diagnostics.map((entry) => [entry.code, entry.field])).toEqual([
+      ["AI_CAPTURE_FIELD_UNAVAILABLE", "inputPreview"],
+    ]);
+    expect(writer.getEvents()[0]?.attributes?.inputPreview).toBeUndefined();
+    expect(integration.getDiagnostics().capture).toMatchObject({
+      previewFieldsUnavailable: 1,
+      lastDiagnosticCode: "AI_CAPTURE_FIELD_UNAVAILABLE",
+    });
+  });
+
+  it("redacts credential-shaped keys inside preview attributes (#311)", async () => {
+    const writer = memoryWriter();
+    const integration = agentInspect({
+      writer,
+      runName: "preview-redaction-fixture",
+      capture: "preview",
+      maxPreviewChars: 400,
+    });
+
+    await integration.onStart?.(startEvent());
+    await integration.onStepStart?.(stepStartEvent());
+    await integration.onToolCallStart?.(toolStartEvent());
+
+    const toolStart = writer
+      .getEvents()
+      .find((event) => event.kind === "TOOL");
+
+    expect(String(toolStart?.attributes?.inputPreview)).toContain("[REDACTED]");
+    expectNoRawText(writer.getEvents(), "raw tool input");
+    expect(integration.getDiagnostics().capture.previewFieldsRedacted).toBeGreaterThan(0);
+  });
+
+  it("keeps preview attributes redacted and short under the strict profile (#311)", async () => {
+    const writer = memoryWriter();
+    const integration = agentInspect({
+      writer,
+      runName: "preview-strict-fixture",
+      capture: "preview",
+      redactionProfile: "strict",
+      maxPreviewChars: 500,
+    });
+
+    await integration.onStart?.(startEvent());
+
+    const runStart = writer.getEvents()[0];
+
+    // Strict redacts whole preview fields and caps the bound at 80 characters.
+    expect(runStart?.attributes?.inputPreview).toBe('"[REDACTED]"');
+    expect(integration.getDiagnostics().capture.maxPreviewChars).toBe(80);
+    expectNoRawText(writer.getEvents(), "raw callback prompt");
   });
 
   it("records streamText run and LLM metadata after local stream consumption", async () => {
@@ -806,7 +903,7 @@ describe("@agent-inspect/ai-sdk scaffold", () => {
     await expect(integration.onStart?.(startEvent())).resolves.toBeUndefined();
     await expect(integration.onToolCallStart?.(toolStartEvent())).resolves.toBeUndefined();
 
-    expect(integration.getDiagnostics()).toEqual({
+    expect(integration.getDiagnostics()).toMatchObject({
       writeFailures: 2,
       lifecycleWarnings: 1,
       flushFailures: 0,

--- a/packages/core/src/adapters/preview-capture.ts
+++ b/packages/core/src/adapters/preview-capture.ts
@@ -1,0 +1,328 @@
+/**
+ * Shared bounded-preview capture used by the official framework adapters.
+ *
+ * Adapters own framework field selection; this module owns the parts that must
+ * behave identically everywhere: safe serialization, `maxPreviewChars` bounds,
+ * key/profile redaction before the value reaches an event, and stable
+ * diagnostics when a requested field cannot be sourced.
+ *
+ * Previews are bounded and key-redacted, not sanitized. Review exports before
+ * sharing.
+ *
+ * @experimental Adapter-facing helper; shape may change while the official
+ * adapters remain experimental.
+ */
+import { Redactor } from "../logs/redactor.js";
+import { resolveRedactionProfile } from "../redaction-profiles.js";
+import type { RedactionRule } from "../types/log-config.js";
+import type { RedactionProfile } from "../types.js";
+
+/** Default bound for adapter preview fields (characters). */
+export const DEFAULT_ADAPTER_MAX_PREVIEW_CHARS = 200;
+
+/**
+ * Capture policy shared by the official adapters.
+ *
+ * `metadata-only` is the default everywhere and never persists framework
+ * payload content. `preview` opts into bounded, redacted previews.
+ */
+export type AdapterCaptureMode = "metadata-only" | "preview";
+
+/** Stable diagnostic codes emitted by shared preview capture. */
+export const ADAPTER_CAPTURE_DIAGNOSTIC_CODES = [
+  "AI_CAPTURE_FIELD_UNAVAILABLE",
+  "AI_CAPTURE_PREVIEW_TRUNCATED",
+  "AI_CAPTURE_PREVIEW_REDACTED",
+] as const;
+
+export type AdapterCaptureDiagnosticCode =
+  (typeof ADAPTER_CAPTURE_DIAGNOSTIC_CODES)[number];
+
+/** One bounded diagnostic. Never contains preview content or filesystem paths. */
+export interface AdapterCaptureDiagnostic {
+  readonly code: AdapterCaptureDiagnosticCode;
+  readonly message: string;
+  /** Persisted attribute name the diagnostic refers to (e.g. `inputPreview`). */
+  readonly field: string;
+  readonly capture: AdapterCaptureMode;
+}
+
+/** Optional consumer hook for adapter capture diagnostics. */
+export type AdapterDiagnosticListener = (
+  diagnostic: AdapterCaptureDiagnostic,
+) => void;
+
+/** Preview capture options accepted by every official adapter. */
+export interface AdapterPreviewCaptureOptions {
+  /** Defaults to `metadata-only`. */
+  capture?: AdapterCaptureMode;
+  /** Redaction profile applied to preview values before they reach an event. */
+  redactionProfile?: RedactionProfile;
+  /** Upper bound for each serialized preview field. */
+  maxPreviewChars?: number;
+  /** Extra adapter-supplied redaction rules. */
+  redact?: RedactionRule[];
+  /** Receives bounded capture diagnostics. Listener failures are swallowed. */
+  onDiagnostic?: AdapterDiagnosticListener;
+}
+
+/** Bounded capture counters for adapter `getDiagnostics()` surfaces. */
+export interface AdapterCaptureDiagnostics {
+  readonly capture: AdapterCaptureMode;
+  readonly redactionProfile: RedactionProfile;
+  readonly maxPreviewChars: number;
+  readonly previewFieldsCaptured: number;
+  readonly previewFieldsUnavailable: number;
+  readonly previewFieldsTruncated: number;
+  readonly previewFieldsRedacted: number;
+  readonly lastDiagnosticCode?: AdapterCaptureDiagnosticCode;
+  readonly lastDiagnosticMessage?: string;
+}
+
+/** Shared preview capture handle owned by one adapter instance. */
+export interface AdapterPreviewCapture {
+  /** Effective capture mode (adapters no longer downgrade `preview`). */
+  readonly capture: AdapterCaptureMode;
+  readonly previewEnabled: boolean;
+  readonly maxPreviewChars: number;
+  readonly redactionProfile: RedactionProfile;
+  /** Normalizes a logical field to a persisted `*Preview` attribute name. */
+  previewFieldName(field: string): string;
+  /**
+   * Returns a bounded, redacted preview string, or `undefined` when capture is
+   * metadata-only or the field could not be sourced.
+   */
+  capturePreviewField(field: string, value: unknown): string | undefined;
+  /** Writes every available preview onto `target` and returns it. */
+  applyPreviewFields(
+    target: Record<string, unknown>,
+    fields: Record<string, unknown>,
+  ): Record<string, unknown>;
+  getDiagnostics(): AdapterCaptureDiagnostics;
+}
+
+/**
+ * JSON-ish serialization that tolerates cycles, bigints, and throwing getters,
+ * bounded to `maxChars`. Returns `undefined` for a non-positive bound or a
+ * value JSON cannot represent.
+ */
+export function serializeAdapterPreview(
+  value: unknown,
+  maxChars: number,
+): string | undefined {
+  if (!Number.isFinite(maxChars) || maxChars <= 0) return undefined;
+  const serialized = serializePreviewValue(value);
+  if (serialized === undefined) return undefined;
+  return boundPreviewString(serialized, Math.floor(maxChars)).text;
+}
+
+/**
+ * Resolves the effective preview bound. Profile caps apply so a `share` or
+ * `strict` profile cannot be widened by a larger adapter option.
+ */
+export function resolveAdapterMaxPreviewChars(
+  value: unknown,
+  profile: RedactionProfile = "local",
+): number {
+  const requested =
+    typeof value === "number" && Number.isFinite(value) && value >= 0
+      ? Math.floor(value)
+      : DEFAULT_ADAPTER_MAX_PREVIEW_CHARS;
+  const cap = resolveRedactionProfile(profile).maxPreviewLengthCap;
+  return cap === undefined ? requested : Math.min(requested, cap);
+}
+
+/** Creates the shared preview capture handle for one adapter instance. */
+export function createAdapterPreviewCapture(
+  options: AdapterPreviewCaptureOptions = {},
+): AdapterPreviewCapture {
+  const capture: AdapterCaptureMode =
+    options.capture === "preview" ? "preview" : "metadata-only";
+  const redactionProfile: RedactionProfile = options.redactionProfile ?? "local";
+  const maxPreviewChars = resolveAdapterMaxPreviewChars(
+    options.maxPreviewChars,
+    redactionProfile,
+  );
+  const redactor = new Redactor({
+    rules: options.redact,
+    extraKeys: resolveRedactionProfile(redactionProfile).extraKeys,
+  });
+
+  const counters = {
+    previewFieldsCaptured: 0,
+    previewFieldsUnavailable: 0,
+    previewFieldsTruncated: 0,
+    previewFieldsRedacted: 0,
+  };
+  let lastDiagnosticCode: AdapterCaptureDiagnosticCode | undefined;
+  let lastDiagnosticMessage: string | undefined;
+
+  const emit = (
+    code: AdapterCaptureDiagnosticCode,
+    field: string,
+    message: string,
+  ): void => {
+    lastDiagnosticCode = code;
+    lastDiagnosticMessage = `${code}: ${message}`;
+    try {
+      options.onDiagnostic?.({ code, message, field, capture });
+    } catch {
+      // Consumer diagnostics must never throw into instrumented code.
+    }
+  };
+
+  const previewFieldName = (field: string): string =>
+    /preview$/i.test(field) ? field : `${field}Preview`;
+
+  const capturePreviewField = (
+    field: string,
+    value: unknown,
+  ): string | undefined => {
+    if (capture !== "preview" || maxPreviewChars <= 0) return undefined;
+    const name = previewFieldName(field);
+
+    try {
+      if (value === undefined) {
+        counters.previewFieldsUnavailable += 1;
+        emit(
+          "AI_CAPTURE_FIELD_UNAVAILABLE",
+          name,
+          `${name} was requested but this framework callback did not expose the field`,
+        );
+        return undefined;
+      }
+
+      // Normalize before redaction so cycles and hostile getters cannot reach
+      // the key-based redactor, which walks plain structures only.
+      const plain = toPlainPreviewValue(value);
+      if (plain === UNSERIALIZABLE) {
+        counters.previewFieldsUnavailable += 1;
+        emit(
+          "AI_CAPTURE_FIELD_UNAVAILABLE",
+          name,
+          `${name} could not be serialized into a bounded preview`,
+        );
+        return undefined;
+      }
+
+      const serialized = serializePreviewValue(redactor.redactValue(name, plain));
+      if (serialized === undefined) {
+        counters.previewFieldsUnavailable += 1;
+        emit(
+          "AI_CAPTURE_FIELD_UNAVAILABLE",
+          name,
+          `${name} could not be serialized into a bounded preview`,
+        );
+        return undefined;
+      }
+
+      if (containsRedactionMarker(serialized)) {
+        counters.previewFieldsRedacted += 1;
+        emit(
+          "AI_CAPTURE_PREVIEW_REDACTED",
+          name,
+          `${name} matched the ${redactionProfile} redaction profile before persistence`,
+        );
+      }
+
+      const bounded = boundPreviewString(serialized, maxPreviewChars);
+      if (bounded.truncated) {
+        counters.previewFieldsTruncated += 1;
+        emit(
+          "AI_CAPTURE_PREVIEW_TRUNCATED",
+          name,
+          `${name} was truncated to maxPreviewChars=${maxPreviewChars}`,
+        );
+      }
+
+      counters.previewFieldsCaptured += 1;
+      return bounded.text;
+    } catch {
+      counters.previewFieldsUnavailable += 1;
+      emit(
+        "AI_CAPTURE_FIELD_UNAVAILABLE",
+        name,
+        `${name} could not be read from this framework callback`,
+      );
+      return undefined;
+    }
+  };
+
+  return {
+    capture,
+    previewEnabled: capture === "preview",
+    maxPreviewChars,
+    redactionProfile,
+    previewFieldName,
+    capturePreviewField,
+    applyPreviewFields(target, fields) {
+      if (capture !== "preview") return target;
+      for (const [field, value] of Object.entries(fields)) {
+        const preview = capturePreviewField(field, value);
+        if (preview !== undefined) target[previewFieldName(field)] = preview;
+      }
+      return target;
+    },
+    getDiagnostics() {
+      return {
+        capture,
+        redactionProfile,
+        maxPreviewChars,
+        ...counters,
+        ...(lastDiagnosticCode === undefined ? {} : { lastDiagnosticCode }),
+        ...(lastDiagnosticMessage === undefined
+          ? {}
+          : { lastDiagnosticMessage }),
+      };
+    },
+  };
+}
+
+/** Sentinel for a value JSON cannot represent at all. */
+const UNSERIALIZABLE = Symbol("agent-inspect.preview.unserializable");
+
+function toPlainPreviewValue(value: unknown): unknown {
+  const json = serializePreviewValue(value);
+  if (json === undefined) return UNSERIALIZABLE;
+  try {
+    return JSON.parse(json) as unknown;
+  } catch {
+    // `serializePreviewValue` fell back to `String(value)`.
+    return json;
+  }
+}
+
+function containsRedactionMarker(serialized: string): boolean {
+  return serialized.includes("[REDACTED]") || serialized.includes("[HASH:");
+}
+
+function serializePreviewValue(value: unknown): string | undefined {
+  try {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (_key, entry) => {
+      if (typeof entry === "bigint") return entry.toString();
+      if (typeof entry === "function" || typeof entry === "symbol") {
+        return undefined;
+      }
+      if (typeof entry === "object" && entry !== null) {
+        if (seen.has(entry)) return "[Circular]";
+        seen.add(entry);
+      }
+      return entry;
+    });
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function boundPreviewString(
+  value: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) return { text: value, truncated: false };
+  return { text: `${value.slice(0, maxChars)}…`, truncated: true };
+}

--- a/packages/core/src/entries/advanced.ts
+++ b/packages/core/src/entries/advanced.ts
@@ -49,6 +49,24 @@ export {
   resolveTraceSafetyOptions,
 } from "../trace-event-safety.js";
 
+export type {
+  AdapterCaptureDiagnostic,
+  AdapterCaptureDiagnosticCode,
+  AdapterCaptureDiagnostics,
+  AdapterCaptureMode,
+  AdapterDiagnosticListener,
+  AdapterPreviewCapture,
+  AdapterPreviewCaptureOptions,
+} from "../adapters/preview-capture.js";
+
+export {
+  ADAPTER_CAPTURE_DIAGNOSTIC_CODES,
+  DEFAULT_ADAPTER_MAX_PREVIEW_CHARS,
+  createAdapterPreviewCapture,
+  resolveAdapterMaxPreviewChars,
+  serializeAdapterPreview,
+} from "../adapters/preview-capture.js";
+
 export {
   TERMINAL_INDENT,
   MAX_TERMINAL_NAME_LENGTH,

--- a/packages/core/test/adapters/preview-capture.test.ts
+++ b/packages/core/test/adapters/preview-capture.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ADAPTER_CAPTURE_DIAGNOSTIC_CODES,
+  DEFAULT_ADAPTER_MAX_PREVIEW_CHARS,
+  createAdapterPreviewCapture,
+  resolveAdapterMaxPreviewChars,
+  serializeAdapterPreview,
+  type AdapterCaptureDiagnostic,
+} from "../../src/adapters/preview-capture.js";
+
+describe("shared adapter preview capture (#311)", () => {
+  it("captures nothing in the default metadata-only mode", () => {
+    const capture = createAdapterPreviewCapture();
+
+    expect(capture.capture).toBe("metadata-only");
+    expect(capture.previewEnabled).toBe(false);
+    expect(capture.capturePreviewField("input", "raw prompt")).toBeUndefined();
+    expect(
+      capture.applyPreviewFields({}, { input: "raw prompt" }),
+    ).toEqual({});
+    expect(capture.getDiagnostics()).toMatchObject({
+      capture: "metadata-only",
+      maxPreviewChars: DEFAULT_ADAPTER_MAX_PREVIEW_CHARS,
+      previewFieldsCaptured: 0,
+      previewFieldsUnavailable: 0,
+    });
+  });
+
+  it("bounds preview fields by maxPreviewChars and reports truncation", () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      maxPreviewChars: 12,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    const preview = capture.capturePreviewField("input", "y".repeat(400));
+
+    expect(preview).toHaveLength(13);
+    expect(preview?.endsWith("…")).toBe(true);
+    expect(diagnostics.map((entry) => entry.code)).toEqual([
+      "AI_CAPTURE_PREVIEW_TRUNCATED",
+    ]);
+    expect(diagnostics[0]?.field).toBe("inputPreview");
+    expect(capture.getDiagnostics()).toMatchObject({
+      previewFieldsCaptured: 1,
+      previewFieldsTruncated: 1,
+    });
+  });
+
+  it("emits AI_CAPTURE_FIELD_UNAVAILABLE when a requested field has no source", () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    expect(capture.capturePreviewField("output", undefined)).toBeUndefined();
+    expect(diagnostics).toEqual([
+      {
+        code: "AI_CAPTURE_FIELD_UNAVAILABLE",
+        field: "outputPreview",
+        capture: "preview",
+        message: expect.stringContaining("outputPreview"),
+      },
+    ]);
+    expect(capture.getDiagnostics()).toMatchObject({
+      previewFieldsUnavailable: 1,
+      lastDiagnosticCode: "AI_CAPTURE_FIELD_UNAVAILABLE",
+    });
+  });
+
+  it("redacts sensitive keys before the preview string exists", () => {
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      maxPreviewChars: 400,
+    });
+
+    const preview = capture.capturePreviewField("input", {
+      question: "refund policy",
+      apiKey: "sk-live-should-not-persist",
+    });
+
+    expect(preview).toContain("refund policy");
+    expect(preview).toContain("[REDACTED]");
+    expect(preview).not.toContain("sk-live-should-not-persist");
+    expect(capture.getDiagnostics()).toMatchObject({
+      previewFieldsRedacted: 1,
+      lastDiagnosticCode: "AI_CAPTURE_PREVIEW_REDACTED",
+    });
+  });
+
+  it("honors adapter redaction rules in addition to profile keys", () => {
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      maxPreviewChars: 400,
+      redact: [{ key: "accountRef", strategy: "full" }],
+    });
+
+    const preview = capture.capturePreviewField("input", {
+      accountRef: "acct-42",
+    });
+
+    expect(preview).not.toContain("acct-42");
+    expect(preview).toContain("[REDACTED]");
+  });
+
+  it("caps maxPreviewChars using share and strict profile limits", () => {
+    expect(resolveAdapterMaxPreviewChars(5000, "local")).toBe(5000);
+    expect(resolveAdapterMaxPreviewChars(5000, "share")).toBe(200);
+    expect(resolveAdapterMaxPreviewChars(5000, "strict")).toBe(80);
+    expect(resolveAdapterMaxPreviewChars(40, "strict")).toBe(40);
+    expect(resolveAdapterMaxPreviewChars(undefined)).toBe(
+      DEFAULT_ADAPTER_MAX_PREVIEW_CHARS,
+    );
+    expect(resolveAdapterMaxPreviewChars(-3)).toBe(
+      DEFAULT_ADAPTER_MAX_PREVIEW_CHARS,
+    );
+  });
+
+  it("replaces whole preview fields under the strict profile", () => {
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      redactionProfile: "strict",
+    });
+
+    expect(capture.capturePreviewField("input", "customer transcript")).toBe(
+      '"[REDACTED]"',
+    );
+    expect(capture.maxPreviewChars).toBe(80);
+  });
+
+  it("keeps already-suffixed preview names stable", () => {
+    const capture = createAdapterPreviewCapture({ capture: "preview" });
+
+    expect(capture.previewFieldName("streamPreview")).toBe("streamPreview");
+    expect(capture.previewFieldName("input")).toBe("inputPreview");
+    expect(
+      capture.applyPreviewFields({}, { streamPreview: "abc", output: "def" }),
+    ).toEqual({ streamPreview: '"abc"', outputPreview: '"def"' });
+  });
+
+  it("survives cycles, bigints, and throwing getters without throwing", () => {
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      maxPreviewChars: 400,
+    });
+
+    const cyclic: Record<string, unknown> = { name: "root" };
+    cyclic.self = cyclic;
+    expect(capture.capturePreviewField("input", cyclic)).toContain("[Circular]");
+    expect(capture.capturePreviewField("input", { total: 7n })).toContain("7");
+
+    const hostile = {
+      get boom(): string {
+        throw new Error("hostile getter");
+      },
+    };
+    expect(() => capture.capturePreviewField("input", hostile)).not.toThrow();
+    expect(capture.capturePreviewField("input", hostile)).not.toContain("boom");
+
+    // A value JSON cannot represent at all is reported as unavailable.
+    expect(
+      capture.capturePreviewField("output", () => "opaque"),
+    ).toBeUndefined();
+    expect(capture.getDiagnostics()).toMatchObject({
+      previewFieldsUnavailable: 1,
+      lastDiagnosticCode: "AI_CAPTURE_FIELD_UNAVAILABLE",
+    });
+  });
+
+  it("isolates consumer diagnostic listener failures", () => {
+    const onDiagnostic = vi.fn(() => {
+      throw new Error("listener exploded");
+    });
+    const capture = createAdapterPreviewCapture({
+      capture: "preview",
+      onDiagnostic,
+    });
+
+    expect(() => capture.capturePreviewField("input", undefined)).not.toThrow();
+    expect(onDiagnostic).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes stable diagnostic codes and bounded serialization", () => {
+    expect([...ADAPTER_CAPTURE_DIAGNOSTIC_CODES]).toEqual([
+      "AI_CAPTURE_FIELD_UNAVAILABLE",
+      "AI_CAPTURE_PREVIEW_TRUNCATED",
+      "AI_CAPTURE_PREVIEW_REDACTED",
+    ]);
+    expect(serializeAdapterPreview("hello", 0)).toBeUndefined();
+    expect(serializeAdapterPreview("hello", -1)).toBeUndefined();
+    expect(serializeAdapterPreview(undefined, 20)).toBeUndefined();
+    expect(serializeAdapterPreview({ a: 1 }, 20)).toBe('{"a":1}');
+    expect(serializeAdapterPreview("abcdef", 3)).toBe('"ab…');
+  });
+});

--- a/packages/core/test/fixtures/api-surface.snapshot.json
+++ b/packages/core/test/fixtures/api-surface.snapshot.json
@@ -149,7 +149,9 @@
   "experimentalSubpaths": [],
   "subpaths": {
     "advanced": [
+      "ADAPTER_CAPTURE_DIAGNOSTIC_CODES",
       "COHORT_METRIC_IDS",
+      "DEFAULT_ADAPTER_MAX_PREVIEW_CHARS",
       "DEFAULT_MAX_EVENT_BYTES",
       "DEFAULT_MAX_METADATA_VALUE_LENGTH",
       "DEFAULT_MAX_PREVIEW_LENGTH",
@@ -206,6 +208,7 @@
       "bundleRunAssetRelativePath",
       "collectTraceSchemaVersions",
       "compareCohortAggregates",
+      "createAdapterPreviewCapture",
       "createInspector",
       "createInspectorRuntime",
       "createRunId",
@@ -296,6 +299,7 @@
       "renderSuiteReportMarkdown",
       "renderTimeline",
       "renderTraceStats",
+      "resolveAdapterMaxPreviewChars",
       "resolveBundleRunIds",
       "resolveRedactionProfile",
       "resolveSuiteCaseTrace",
@@ -309,6 +313,7 @@
       "runWithStepContext",
       "sanitizeBundleRunId",
       "searchTraces",
+      "serializeAdapterPreview",
       "serializeEvent",
       "serializeEvidenceManifest",
       "sessionKeyForRun",

--- a/packages/langchain/src/agent-inspect-callback.ts
+++ b/packages/langchain/src/agent-inspect-callback.ts
@@ -14,7 +14,10 @@ type RetrieverDocuments = Parameters<
   NonNullable<BaseCallbackHandler["handleRetrieverEnd"]>
 >[0];
 import {
+  createAdapterPreviewCapture,
   getCurrentCorrelationMetadata,
+  type AdapterCaptureDiagnostics,
+  type AdapterPreviewCapture,
   type InspectEvent,
   type InspectKind,
 } from "agent-inspect/advanced";
@@ -24,7 +27,6 @@ import {
   extractLangGraphMetadata,
   extractModelName,
   extractTokenUsage,
-  safePreview,
   toPlainMetadata,
 } from "./metadata.js";
 import {
@@ -71,6 +73,7 @@ export class AgentInspectCallback extends BaseCallbackHandler {
     AgentInspectCallbackOptions;
 
   readonly #redactor: Redactor;
+  readonly #capture: AdapterPreviewCapture;
   readonly #persistence?: LangChainTracePersistence;
   #events: InspectEvent[] = [];
   readonly #starts = new Map<string, StartEntry>();
@@ -99,6 +102,13 @@ export class AgentInspectCallback extends BaseCallbackHandler {
       persist: intent.persist,
     };
     this.#redactor = new Redactor({ rules: this.#opts.redact });
+    this.#capture = createAdapterPreviewCapture({
+      capture: this.#opts.capture === "preview" ? "preview" : "metadata-only",
+      redactionProfile: this.#opts.redactionProfile,
+      maxPreviewChars: this.#opts.maxPreviewChars,
+      redact: this.#opts.redact,
+      onDiagnostic: this.#opts.onDiagnostic,
+    });
     if (intent.contradictory && !this.#opts.silent) {
       console.error(
         "[agent-inspect:langchain] persist:false with traceDir set — traces stay in-memory; remove traceDir or set persist:true",
@@ -111,7 +121,8 @@ export class AgentInspectCallback extends BaseCallbackHandler {
         runId: this.#opts.runId,
         redact: this.#opts.redact,
         silent: this.#opts.silent,
-        maxPreviewChars: this.#opts.maxPreviewChars,
+        maxPreviewChars: this.#capture.maxPreviewChars,
+        redactionProfile: this.#opts.redactionProfile,
       });
     }
   }
@@ -154,6 +165,7 @@ export class AgentInspectCallback extends BaseCallbackHandler {
     hasTerminalError: boolean;
     inMemoryEventCount: number;
     deferredPersistStartCount: number;
+    capture: AdapterCaptureDiagnostics;
   } {
     const base = this.#persistence?.getDiagnostics() ?? {
       lateEventCount: 0,
@@ -173,6 +185,7 @@ export class AgentInspectCallback extends BaseCallbackHandler {
       ...base,
       inMemoryEventCount: this.#events.length,
       deferredPersistStartCount: this.#deferredPersistStart.size,
+      capture: this.#capture.getDiagnostics(),
     };
   }
 
@@ -244,8 +257,8 @@ export class AgentInspectCallback extends BaseCallbackHandler {
   }
 
   #streamPreviewLimit(): number {
-    if (this.#opts.capture !== "preview") return 0;
-    return this.#opts.maxStreamPreviewChars ?? this.#opts.maxPreviewChars ?? 200;
+    if (!this.#capture.previewEnabled) return 0;
+    return this.#opts.maxStreamPreviewChars ?? this.#capture.maxPreviewChars;
   }
 
   #attachStreamMetadata(attrs: Record<string, unknown>, lcRunId: string): void {
@@ -392,12 +405,7 @@ export class AgentInspectCallback extends BaseCallbackHandler {
   }
 
   #applyPreview(attrs: Record<string, unknown>, previews: Record<string, unknown>): void {
-    if (this.#opts.capture !== "preview") return;
-    const max = this.#opts.maxPreviewChars;
-    for (const [k, v] of Object.entries(previews)) {
-      const p = safePreview(v, max);
-      if (p !== undefined) attrs[k] = p;
-    }
+    this.#capture.applyPreviewFields(attrs, previews);
   }
 
   #pushEvent(ev: InspectEvent): void {

--- a/packages/langchain/src/metadata.ts
+++ b/packages/langchain/src/metadata.ts
@@ -1,3 +1,5 @@
+import { serializeAdapterPreview } from "agent-inspect/advanced";
+
 export interface TokenUsage {
   input?: number;
   output?: number;
@@ -114,32 +116,14 @@ export function extractModelName(serializedOrOutput: unknown): string | undefine
   }
 }
 
-/** Safe truncated string preview for logging-style fields. */
+/**
+ * Safe truncated string preview for logging-style fields.
+ *
+ * Delegates to the shared adapter preview serializer so every official adapter
+ * bounds and escapes preview values identically.
+ */
 export function safePreview(value: unknown, maxChars: number): string | undefined {
-  try {
-    if (maxChars <= 0) return undefined;
-    const seen = new WeakSet<object>();
-    const json = JSON.stringify(value, (_k, v) => {
-      if (typeof v === "bigint") return v.toString();
-      if (typeof v === "function" || typeof v === "symbol") return undefined;
-      if (typeof v === "object" && v !== null) {
-        if (seen.has(v)) return "[Circular]";
-        seen.add(v);
-      }
-      return v;
-    });
-    if (json === undefined) return undefined;
-    if (json.length <= maxChars) return json;
-    return `${json.slice(0, maxChars)}…`;
-  } catch {
-    try {
-      const s = String(value);
-      if (s.length <= maxChars) return s;
-      return `${s.slice(0, maxChars)}…`;
-    } catch {
-      return undefined;
-    }
-  }
+  return serializeAdapterPreview(value, maxChars);
 }
 
 const MAX_METADATA_KEYS = 40;

--- a/packages/langchain/src/trace-persistence.ts
+++ b/packages/langchain/src/trace-persistence.ts
@@ -10,6 +10,7 @@ import {
   resolveTraceSafetyOptions,
   writeTraceEvent,
   type InspectKind,
+  type RedactionProfile,
   type StepMetadata,
   type StepType,
   type TraceEvent,
@@ -43,6 +44,8 @@ export interface LangChainTracePersistenceOptions {
   redact?: RedactionRule[];
   silent?: boolean;
   maxPreviewChars?: number;
+  /** Named redaction profile applied to persisted metadata and previews. */
+  redactionProfile?: RedactionProfile;
 }
 
 /** Options for explicit envelope finalization (serverless / unusual callback shapes). */
@@ -133,6 +136,9 @@ export class LangChainTracePersistence {
     this.#safety = resolveTraceSafetyOptions({
       redact: options.redact ? { rules: options.redact } : true,
       maxPreviewLength: options.maxPreviewChars,
+      ...(options.redactionProfile
+        ? { redactionProfile: options.redactionProfile }
+        : {}),
     });
     this.#lifecycle = createInvocationState(this.#runId);
   }

--- a/packages/langchain/src/types.ts
+++ b/packages/langchain/src/types.ts
@@ -1,3 +1,4 @@
+import type { AdapterDiagnosticListener, RedactionProfile } from "agent-inspect/advanced";
 import type { RedactionRule } from "agent-inspect/logs";
 
 export type CaptureMode = "none" | "metadata-only" | "preview";
@@ -23,6 +24,20 @@ export interface AgentInspectCallbackOptions extends LangChainStreamingOptions {
   capture?: CaptureMode;
   redact?: RedactionRule[];
   maxPreviewChars?: number;
+  /**
+   * Redaction profile applied to preview attributes before persistence.
+   * `share` and `strict` also cap `maxPreviewChars`.
+   *
+   * @experimental Effective only when `capture: "preview"`.
+   */
+  redactionProfile?: RedactionProfile;
+  /**
+   * Receives bounded capture diagnostics such as
+   * `AI_CAPTURE_FIELD_UNAVAILABLE`. Listener failures are isolated.
+   *
+   * @experimental
+   */
+  onDiagnostic?: AdapterDiagnosticListener;
   /**
    * Persist callback lifecycle as schemaVersion "0.1" JSONL.
    * When omitted: enabled if `traceDir` is set, otherwise in-memory only.

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -44,14 +44,15 @@ Use **`setTraceProcessors` replacement** for local-only mode. Avoid `addTracePro
 - Local JSONL files only
 - AgentInspect does not upload traces to OpenAI
 - Metadata-only by default
-- `capture: "preview"` is accepted for compatibility but currently falls back to metadata-only and emits one `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` console warning per processor instance
+- `capture: "preview"` is opt-in and persists bounded `inputPreview` / `outputPreview` span attributes, redacted before they reach disk and truncated at `maxPreviewChars`; there is no full-content mode
+- Redaction is key-based, so a preview can still contain sensitive free text — run `agent-inspect redact` before sharing
 
 ## API
 
 | Export | Purpose |
 | ------ | ------- |
 | `agentInspectOpenAiAgents(options)` | `TracingProcessor` for local persistence |
-| `getDiagnostics()` | Warnings for misconfiguration |
+| `getDiagnostics()` | Warnings for misconfiguration plus resolved capture mode and preview counters |
 
 ## CLI
 
@@ -66,7 +67,8 @@ Use **`setTraceProcessors` replacement** for local-only mode. Avoid `addTracePro
 
 - **Duplicate export:** Using `addTraceProcessor` keeps SDK default exporter — use replacement mode for local-only
 - **Handoffs/sessions:** Mapped to run metadata; see docs for session IDs
-- **Preview mode warning:** `capture: "preview"` is not implemented yet; AgentInspect emits `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` once and keeps metadata-only persistence
+- **Empty previews in preview mode:** the span type carries no payload field (handoff, guardrail, agent), or the SDK omitted it. Payload-bearing spans report `AI_CAPTURE_FIELD_UNAVAILABLE` through `onDiagnostic` and `getDiagnostics().capture`
+- **Previews look cut off:** they are bounded by `maxPreviewChars`, which the `share` and `strict` redaction profiles cap further
 
 
 ## Version

--- a/packages/openai-agents/src/index.ts
+++ b/packages/openai-agents/src/index.ts
@@ -5,7 +5,11 @@ import type {
   Trace,
   TracingProcessor,
 } from "@openai/agents";
+import { createAdapterPreviewCapture } from "agent-inspect/advanced";
 import type {
+  AdapterCaptureDiagnostics,
+  AdapterDiagnosticListener,
+  AdapterPreviewCapture,
   RedactionProfile,
 } from "agent-inspect/advanced";
 import type {
@@ -19,8 +23,10 @@ import type { TraceWriter, TraceWriterStats } from "agent-inspect/writers";
 /**
  * Experimental capture mode for the OpenAI Agents JS adapter.
  *
- * @experimental This package is part of the framework adapter train. `preview` is
- * currently rejected with diagnostics and falls back to metadata-only capture.
+ * `metadata-only` is the default. `preview` persists bounded, redacted span
+ * input/output preview attributes through the shared adapter capture helper.
+ *
+ * @experimental This package is part of the framework adapter train.
  */
 export type AgentInspectOpenAiAgentsCaptureMode = "metadata-only" | "preview";
 
@@ -50,26 +56,33 @@ export interface AgentInspectOpenAiAgentsOptions {
   /**
    * Capture policy. Defaults to metadata-only.
    *
-   * @experimental `preview` is not implemented yet; requesting it records a
-   * diagnostic warning and keeps metadata-only persistence.
+   * @experimental `preview` persists bounded, redacted span input/output
+   * previews. It never persists full span content.
    */
   capture?: AgentInspectOpenAiAgentsCaptureMode;
 
   /**
-   * Redaction profile for future preview capture.
+   * Redaction profile applied to preview attributes before persistence.
+   * `share` and `strict` also cap `maxPreviewChars`.
    *
-   * @experimental Currently diagnostic-only because the processor persists
-   * metadata summaries and never writes raw span content by default.
+   * @experimental Effective only when `capture: "preview"`.
    */
   redactionProfile?: RedactionProfile;
 
   /**
-   * Bounds future preview capture.
+   * Upper bound for each serialized preview attribute. Defaults to 200.
    *
-   * @experimental Currently diagnostic-only because `preview` falls back to
-   * metadata-only capture.
+   * @experimental Effective only when `capture: "preview"`.
    */
   maxPreviewChars?: number;
+
+  /**
+   * Receives bounded capture diagnostics such as
+   * `AI_CAPTURE_FIELD_UNAVAILABLE`. Listener failures are isolated.
+   *
+   * @experimental
+   */
+  onDiagnostic?: AdapterDiagnosticListener;
 }
 
 export interface AgentInspectOpenAiAgentsDiagnostics {
@@ -80,6 +93,8 @@ export interface AgentInspectOpenAiAgentsDiagnostics {
   lastError?: string;
   lastWarning?: string;
   runtimeMappingImplemented: true;
+  /** Shared preview-capture counters (`@experimental`). */
+  capture: AdapterCaptureDiagnostics;
 }
 
 export interface AgentInspectOpenAiAgentsProcessor extends TracingProcessor {
@@ -420,6 +435,41 @@ function spanOutputSummary(data: SpanData): unknown {
   }
 }
 
+/**
+ * Raw span fields eligible for bounded preview capture, keyed by the logical
+ * preview name. Span types without a payload concept return `{}` so preview
+ * mode does not report false "field unavailable" diagnostics for them.
+ */
+function spanPreviewSources(
+  data: SpanData,
+  phase: "start" | "end",
+): Record<string, unknown> {
+  const withPhase = (
+    input: unknown,
+    output: unknown,
+  ): Record<string, unknown> =>
+    phase === "start" ? { input } : { input, output };
+
+  switch (data.type) {
+    case "generation":
+      return withPhase(data.input, data.output);
+    case "function":
+      return withPhase(data.input, data.output);
+    case "response":
+      return withPhase(data._input, data._response);
+    case "transcription":
+      return withPhase(data.input.data, data.output);
+    case "speech":
+      return withPhase(data.input, data.output.data);
+    case "custom":
+      return { input: data.data };
+    case "speech_group":
+      return { input: data.input };
+    default:
+      return {};
+  }
+}
+
 function traceEventId(traceId: string): string {
   return `openai_agents_trace:${traceId}`;
 }
@@ -434,8 +484,12 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
 
   private readonly writer: TraceWriter | undefined;
   private readonly requestedCapture: AgentInspectOpenAiAgentsCaptureMode;
-  private readonly effectiveCapture: "metadata-only" = "metadata-only";
-  private readonly diagnostics: AgentInspectOpenAiAgentsDiagnostics = {
+  private readonly preview: AdapterPreviewCapture;
+  private readonly effectiveCapture: AgentInspectOpenAiAgentsCaptureMode;
+  private readonly diagnostics: Omit<
+    AgentInspectOpenAiAgentsDiagnostics,
+    "capture"
+  > = {
     writeFailures: 0,
     lifecycleWarnings: 0,
     flushFailures: 0,
@@ -448,17 +502,24 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
 
   constructor(private readonly options: AgentInspectOpenAiAgentsOptions) {
     this.requestedCapture = options.capture ?? "metadata-only";
+    this.preview = createAdapterPreviewCapture({
+      capture: this.requestedCapture,
+      redactionProfile: options.redactionProfile,
+      maxPreviewChars: options.maxPreviewChars,
+      onDiagnostic: options.onDiagnostic,
+    });
+    this.effectiveCapture = this.preview.capture;
     this.writer = options.writer ?? (options.traceDir ? fileWriter({ dir: options.traceDir }) : undefined);
     for (const key of [
       "options",
       "writer",
       "requestedCapture",
+      "preview",
       "effectiveCapture",
       "diagnostics",
       "activeTraces",
       "activeSpans",
       "closed",
-      "previewCapabilityWarned",
     ] as const) {
       Object.defineProperty(this, key, { enumerable: false });
     }
@@ -500,10 +561,15 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
             this.requestedCapture === this.effectiveCapture
               ? undefined
               : this.requestedCapture,
-          previewCaptureSupported:
-            this.requestedCapture === "preview" ? false : undefined,
-          redactionProfile: this.options.redactionProfile,
-          maxPreviewChars: normalizeMaxPreviewChars(this.options.maxPreviewChars),
+          previewCaptureSupported: true,
+          // Preview rows report the effective bound/profile, which the
+          // `share` and `strict` profiles can lower below the request.
+          redactionProfile: this.preview.previewEnabled
+            ? this.preview.redactionProfile
+            : this.options.redactionProfile,
+          maxPreviewChars: this.preview.previewEnabled
+            ? this.preview.maxPreviewChars
+            : normalizeMaxPreviewChars(this.options.maxPreviewChars),
           groupId: trace.groupId ?? undefined,
           metadataKeyCount: countRecordKeys(trace.metadata),
         },
@@ -593,6 +659,7 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
         attributes: {
           ...commonSpanAttributes(span),
           ...specificSpanAttributes(span.spanData),
+          ...this.previewAttributes(span, "start"),
         },
         inputSummary: spanInputSummary(span.spanData),
         tokenUsage: summarizeUsage(
@@ -643,6 +710,7 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
           ...specificSpanAttributes(span.spanData),
           legacyEvent: "step_completed",
           errorDataSummary: summarizeOptionalUnknown(span.error?.data),
+          ...this.previewAttributes(span, "end"),
         },
         inputSummary: spanInputSummary(span.spanData),
         outputSummary: spanOutputSummary(span.spanData),
@@ -684,7 +752,19 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
   }
 
   getDiagnostics(): AgentInspectOpenAiAgentsDiagnostics {
-    return { ...this.diagnostics };
+    return { ...this.diagnostics, capture: this.preview.getDiagnostics() };
+  }
+
+  /** Bounded preview attributes for one span phase (empty unless enabled). */
+  private previewAttributes(
+    span: Span<SpanData>,
+    phase: "start" | "end",
+  ): Record<string, unknown> {
+    if (!this.preview.previewEnabled) return {};
+    return this.preview.applyPreviewFields(
+      {},
+      spanPreviewSources(span.spanData, phase),
+    );
   }
 
   getWriterStats(): TraceWriterStats | undefined {
@@ -712,26 +792,12 @@ class AgentInspectOpenAiAgentsTracingProcessor implements AgentInspectOpenAiAgen
     this.diagnostics.lastWarning = message;
   }
 
-  private previewCapabilityWarned = false;
-
   private recordCaptureOptionWarnings(): void {
+    if (this.effectiveCapture === "preview") return;
+
     const previewOnlyOptions: string[] = [];
-    if (this.requestedCapture === "preview") previewOnlyOptions.push("capture");
     if (this.options.redactionProfile !== undefined) previewOnlyOptions.push("redactionProfile");
     if (this.options.maxPreviewChars !== undefined) previewOnlyOptions.push("maxPreviewChars");
-
-    if (this.requestedCapture === "preview") {
-      const message =
-        `AI_ADAPTER_PREVIEW_NOT_AVAILABLE: capture:"preview" was requested, but this adapter currently persists metadata-only. Effective capture: metadata-only. No preview content was written. See docs/ADAPTERS.md.`;
-      this.recordLifecycleWarning(
-        `OpenAI Agents preview capture is not supported yet; falling back to metadata-only capture. Unsupported options: ${previewOnlyOptions.join(", ")}.`,
-      );
-      if (!this.previewCapabilityWarned) {
-        this.previewCapabilityWarned = true;
-        console.warn(`[agent-inspect:openai-agents] ${message}`);
-      }
-      return;
-    }
 
     if (previewOnlyOptions.length > 0) {
       this.recordLifecycleWarning(

--- a/packages/openai-agents/test/api-stability.test.ts
+++ b/packages/openai-agents/test/api-stability.test.ts
@@ -6,6 +6,7 @@ import {
   type AgentInspectOpenAiAgentsOptions,
   type AgentInspectOpenAiAgentsProcessor,
 } from "@agent-inspect/openai-agents";
+import type { AdapterCaptureDiagnostic } from "agent-inspect/advanced";
 import {
   persistedInspectEventsToRunTrees,
   persistedInspectEventsToTraceEvents,
@@ -93,6 +94,15 @@ describe("@agent-inspect/openai-agents processor", () => {
       flushFailures: 0,
       shutdownFailures: 0,
       runtimeMappingImplemented: true,
+      capture: {
+        capture: "metadata-only",
+        redactionProfile: "local",
+        maxPreviewChars: 200,
+        previewFieldsCaptured: 0,
+        previewFieldsUnavailable: 0,
+        previewFieldsTruncated: 0,
+        previewFieldsRedacted: 0,
+      },
     });
   });
 
@@ -288,7 +298,7 @@ describe("@agent-inspect/openai-agents processor", () => {
     expectNoRawText(events, "raw speech output");
   });
 
-  it("diagnoses preview-only options and out-of-order callbacks without throwing", async () => {
+  it("diagnoses out-of-order callbacks in preview mode without throwing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const writer = memoryWriter();
     const processor = agentInspectProcessor({
@@ -298,25 +308,154 @@ describe("@agent-inspect/openai-agents processor", () => {
       maxPreviewChars: 8,
     });
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("AI_ADAPTER_PREVIEW_NOT_AVAILABLE");
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[agent-inspect:openai-agents]");
+    // Preview is implemented, so the removed capability warning must not fire.
+    expect(warnSpy).not.toHaveBeenCalled();
 
     await processor.onSpanEnd(
       spanFixture({ type: "generation", model: "gpt-fixture" }),
     );
     await processor.onTraceEnd(traceFixture({ traceId: "missing-trace" }));
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
 
     expect(writer.getEvents()).toEqual([]);
     expect(processor.getDiagnostics()).toMatchObject({
-      lifecycleWarnings: 3,
+      lifecycleWarnings: 2,
       writeFailures: 0,
       runtimeMappingImplemented: true,
+      capture: {
+        capture: "preview",
+        redactionProfile: "strict",
+        maxPreviewChars: 8,
+      },
     });
     expect(processor.getDiagnostics().lastWarning).toContain("matching start");
+  });
+
+  it("persists bounded, redacted span previews when capture is preview (#311)", async () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const writer = memoryWriter();
+    const processor = agentInspectProcessor({
+      writer,
+      capture: "preview",
+      maxPreviewChars: 64,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+    const trace = traceFixture();
+    const generationSpan = spanFixture(
+      {
+        type: "generation",
+        model: "gpt-fixture",
+        input: [{ role: "user", content: "raw prompt secret" }],
+        output: [{ role: "assistant", content: "raw output secret" }],
+        model_config: { temperature: 0 },
+      },
+      { spanId: "span_generation" },
+    );
+    const functionSpan = spanFixture(
+      {
+        type: "function",
+        name: "lookupTool",
+        input: "refund policy",
+        output: "z".repeat(400),
+      },
+      { spanId: "span_function" },
+    );
+    const customSpan = spanFixture(
+      {
+        type: "custom",
+        name: "credentialCarrier",
+        data: { apiKey: "sk-must-not-persist" },
+      },
+      { spanId: "span_custom" },
+    );
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(generationSpan);
+    await processor.onSpanEnd(generationSpan);
+    await processor.onSpanStart(functionSpan);
+    await processor.onSpanEnd(functionSpan);
+    await processor.onSpanStart(customSpan);
+    await processor.onSpanEnd(customSpan);
+    await processor.onTraceEnd(trace);
+
+    const events = writer.getEvents();
+    const runStart = events[0];
+    expect(runStart?.attributes).toMatchObject({
+      capture: "preview",
+      previewCaptureSupported: true,
+      maxPreviewChars: 64,
+    });
+
+    const generationEnd = events.find(
+      (event) => event.name === "generation:gpt-fixture" && event.status === "ok",
+    );
+    expect(String(generationEnd?.attributes?.inputPreview)).toContain(
+      "raw prompt secret",
+    );
+    expect(String(generationEnd?.attributes?.outputPreview)).toContain(
+      "raw output secret",
+    );
+
+    const functionEnd = events.find(
+      (event) => event.name === "lookupTool" && event.status === "ok",
+    );
+    const credentialPreviews = events
+      .flatMap((event) => Object.entries(event.attributes ?? {}))
+      .filter(([key]) => key.endsWith("Preview"))
+      .map(([, value]) => String(value));
+    expect(credentialPreviews.join("\n")).toContain("[REDACTED]");
+    expectNoRawText(events, "sk-must-not-persist");
+    expect(String(functionEnd?.attributes?.outputPreview)).toHaveLength(65);
+    expect(String(functionEnd?.attributes?.outputPreview).endsWith("…")).toBe(true);
+
+    // Span types without a payload concept must not report unavailable fields.
+    const handoffSpan = spanFixture(
+      { type: "handoff", from_agent: "A", to_agent: "B" },
+      { spanId: "span_handoff" },
+    );
+    await processor.onSpanStart(handoffSpan);
+    expect(
+      diagnostics.filter((entry) => entry.code === "AI_CAPTURE_FIELD_UNAVAILABLE"),
+    ).toEqual([]);
+    expect(
+      diagnostics.some((entry) => entry.code === "AI_CAPTURE_PREVIEW_TRUNCATED"),
+    ).toBe(true);
+    expect(
+      diagnostics.some((entry) => entry.code === "AI_CAPTURE_PREVIEW_REDACTED"),
+    ).toBe(true);
+    expect(processor.getDiagnostics().capture.previewFieldsCaptured).toBeGreaterThan(0);
+  });
+
+  it("reports AI_CAPTURE_FIELD_UNAVAILABLE for spans missing payload fields (#311)", async () => {
+    const diagnostics: AdapterCaptureDiagnostic[] = [];
+    const writer = memoryWriter();
+    const processor = agentInspectProcessor({
+      writer,
+      capture: "preview",
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+    const trace = traceFixture();
+    const bareGeneration = spanFixture(
+      { type: "generation", model: "gpt-fixture" },
+      { spanId: "span_bare_generation" },
+    );
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(bareGeneration);
+    await processor.onSpanEnd(bareGeneration);
+
+    expect(
+      diagnostics
+        .filter((entry) => entry.code === "AI_CAPTURE_FIELD_UNAVAILABLE")
+        .map((entry) => entry.field),
+    ).toEqual(["inputPreview", "inputPreview", "outputPreview"]);
+    expect(processor.getDiagnostics().capture).toMatchObject({
+      previewFieldsCaptured: 0,
+      previewFieldsUnavailable: 3,
+      lastDiagnosticCode: "AI_CAPTURE_FIELD_UNAVAILABLE",
+    });
   });
 
   it("isolates writer, flush, and shutdown failures", async () => {


### PR DESCRIPTION
Closes #311 once 6.18.0 publishes.

## Problem

`@agent-inspect/ai-sdk` and `@agent-inspect/openai-agents` accepted `capture: "preview"`, then persisted metadata-only behind a visible `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` warning. `@agent-inspect/langchain` had real preview support, but through its own code path. The same option meant three different things.

## What changed

One shared helper (`packages/core/src/adapters/preview-capture.ts`, exported from the existing `agent-inspect/advanced` subpath) now owns field selection, safe serialization, `maxPreviewChars` bounds, redaction, and diagnostics. All three adapters resolve capture through it:

- `capture?: "metadata-only" | "preview"` — metadata-only stays the default and persists no preview attributes and no capture diagnostics.
- `redactionProfile?` — key-based redaction applied to the structured value **before** any preview string exists; `share` / `strict` also lower the effective bound, and `strict` replaces preview values.
- `maxPreviewChars?` — hard upper bound on every persisted preview string, including the truncation marker.
- `onDiagnostic?` — local listener; listener failures are isolated and never reach the traced application.

Stable diagnostic codes, also counted in `getDiagnostics().capture`:

| Code | Meaning |
| --- | --- |
| `AI_CAPTURE_FIELD_UNAVAILABLE` | Preview requested but the framework did not expose the field, or it could not be safely serialized |
| `AI_CAPTURE_PREVIEW_TRUNCATED` | Preview hit the `maxPreviewChars` bound |
| `AI_CAPTURE_PREVIEW_REDACTED` | Redaction replaced a value before persistence |

The removed `AI_ADAPTER_PREVIEW_NOT_AVAILABLE` warning no longer fires; preview-only options still warn when they are set in metadata-only mode.

## Safety

- Redaction runs before persistence, not on an already-serialized string.
- Cycles, bigints, and getters that throw are normalized without throwing into instrumented code.
- No full-content capture mode, no network I/O, no new root API surface, no new root/core dependency, no schema/protocol change.
- Docs state plainly that this is **bounded preview capture, not sanitization**: key-based redaction cannot find a secret embedded in free text, so preview traces still need `agent-inspect redact` before sharing.

## Tests

- `packages/core/test/adapters/preview-capture.test.ts` — helper unit coverage (bounds, profiles, unserializable values, listener isolation).
- `packages/adapter-sdk/test/adapter-capture-parity.test.ts` — cross-adapter conformance matrix driving one identical assertion set through ai-sdk, openai-agents, and langchain.
- Adapter `api-stability` suites extended for real preview capture, redaction, and unavailable fields.

Commands run locally: `pnpm typecheck`, `pnpm test` (282 files / 2065 tests), `pnpm docs:check`, `pnpm repo:health`, `git diff --check`.

## Release

Minor changeset `618-adapter-preview-parity` for the fixed 6.18 group.