### PR TITLE
docs: confirm 6.19.0 published on npm

### DIFF
--- a/docs/implementation/CURRENT-TASK.md
+++ b/docs/implementation/CURRENT-TASK.md
@@ -5,8 +5,8 @@ executionMode: maintainer-reviewed
 namedTrain: agentinspect-feedback-integrity-v6.17.5-to-v6.22
 currentTrain: v6.20.0-flexible-contracts
 trainStatus: ready
-currentChunk: phase4-620-622-roadmap-label-hygiene
-nextAction: "After Phase 4 PR merges: implement 6.20.0 (#308/#315 requiredOrderMode; #309 alternatives.anyOf) when authorized — no premature coding"
+currentChunk: authorize-620-implementation
+nextAction: "Authorize and implement 6.20.0 (#308/#315 requiredOrderMode; #309 alternatives.anyOf) — no premature coding without maintainer go-ahead"
 canonicalRoadmap: docs/implementation/ROADMAP.md
 activePlan: docs/implementation/active/NEXT-RELEASES.md
 pendingManualGate: ""
@@ -14,15 +14,15 @@ pendingManualGate: ""
 
 ## Published baseline
 
-**6.19.0** manifests on `main` via Version Packages `#357` (`4e0d794`); Trusted Publish in flight from that merge (confirm npm). Prior published: **6.17.8**, **6.18.0**. Persisted schema **1.0**.
+**6.19.0** published on npm (`agent-inspect@6.19.0`, Trusted Publish run `34013658849`). Version Packages `#357` (`4e0d794`). Prior published: **6.17.8**, **6.18.0**. Persisted schema **1.0**.
 
 ## Active train — v6.20.0 flexible deterministic contracts
 
 | Chunk | Status |
 | --- | --- |
-| Phase 4 roadmap/label hygiene | in progress (this PR) |
-| `requiredOrderMode` (#308 / PR #315) | scheduled 6.20 — not implemented in this chunk |
-| `alternatives.anyOf` (#309) | scheduled 6.20 — not implemented in this chunk |
+| Phase 4 roadmap/label hygiene | done (`#358`) |
+| `requiredOrderMode` (#308 / PR #315) | scheduled 6.20 — await authorization |
+| `alternatives.anyOf` (#309) | scheduled 6.20 — await authorization |
 
 ## Later
 
@@ -35,4 +35,4 @@ pendingManualGate: ""
 - **#308 / #315 / #309** — scheduled **6.20**; labels → `roadmap-now`
 - **#320 / #321** — scheduled **6.21**; labels → `roadmap-next`
 - **#331** — design confirmed; conditional **6.22**; existing APIs only; not implemented; stays `roadmap-future`
-- **#355** — close after 6.19.0 is confirmed on npm (derived failure roles shipped in `#354`)
+- **#355** — closed (6.19.0 derived failure roles shipped in `#354`, published on npm)

--- a/docs/implementation/RELEASE-TRAIN-STATE.md
+++ b/docs/implementation/RELEASE-TRAIN-STATE.md
@@ -6,16 +6,16 @@
 
 ```yaml
 baselineVersion: "6.19.0"
-publishedVersion: "6.18.0"  # 6.19.0 Version Packages merged; confirm npm
+publishedVersion: "6.19.0"
 currentTrain: "v6.20.0-flexible-contracts"
 trainStatus: "ready"
 executionMode: "maintainer-reviewed"
 namedTrain: "agentinspect-feedback-integrity-v6.17.5-to-v6.22"
 branch: "main"
-currentChunk: "phase4-620-622-roadmap-label-hygiene"
-lastConfirmedCommit: "4e0d794"
-lastValidationLevel: "version-packages-357-merged-publish-pending"
-nextAction: "Merge Phase 4 docs/labels PR; then authorize 6.20.0 implementation (#308/#315/#309)"
+currentChunk: "authorize-620-implementation"
+lastConfirmedCommit: "5a4dd5b"
+lastValidationLevel: "npm-6.19.0-trusted-publish-34013658849"
+nextAction: "Authorize 6.20.0 implementation (#308/#315/#309)"
 pendingManualGate: ""
 githubIssues:
   "209": "keep open — cross-platform packed-consumer matrix"
@@ -29,13 +29,14 @@ githubIssues:
   "321": "6.21 outcome provenance — roadmap-next; stay open"
   "331": "6.22 — design confirmed; existing APIs only; not implemented; roadmap-future"
   "354": "6.19 PR — merged"
-  "355": "6.19 derived failure design note — close after npm confirms 6.19.0"
+  "355": "closed — 6.19.0 published on npm"
 canonicalRoadmap: "docs/implementation/ROADMAP.md"
 activePlan: "docs/implementation/active/NEXT-RELEASES.md"
 completedChunks:
   - "6.17.8 published (Version Packages #343)"
   - "6.18.0 A–H code + Version Packages #350 + Trusted Publish"
-  - "6.19.0 A–D (#354) + Version Packages #357"
+  - "6.19.0 A–D (#354) + Version Packages #357 + Trusted Publish"
+  - "Phase 4 roadmap/label hygiene (#358)"
 remainingTrains:
   - "v6.19.1 reserved patch"
   - "v6.20.0 flexible deterministic contracts"

--- a/docs/implementation/active/NEXT-RELEASES.md
+++ b/docs/implementation/active/NEXT-RELEASES.md
@@ -1,8 +1,8 @@
 # Active execution plan — next releases (post-6.19.0)
 
 **Authority:** [../ROADMAP.md](../ROADMAP.md) · final release decision (2026-09-05)  
-**Baseline:** Version Packages `#357` on `main` (`4e0d794`) · manifests `6.19.0` · schema `1.0`
-**Exclusions:** Gmail/outreach; local `npm publish`; schema 1.1; premature 6.20–6.22 implementation in Phase 4
+**Baseline:** **published** `agent-inspect@6.19.0` on npm · Version Packages `#357` (`4e0d794`) · schema `1.0`
+**Exclusions:** Gmail/outreach; local `npm publish`; schema 1.1; premature 6.20–6.22 implementation without authorization
 
 ## Release table
 
@@ -12,7 +12,7 @@
 | 6.17.9 | Conditional corrective patch | Only verified security/compatibility defects |
 | 6.18.0 | Safe adoption and differentiation | **published** (`#350`) |
 | 6.18.1 | Reserved patch | Adapter/CLI/security corrections only |
-| 6.19.0 | External evidence and failure semantics | **on main** (`#354` + Version Packages `#357`); Trusted Publish (confirm npm) |
+| 6.19.0 | External evidence and failure semantics | **published** (`#354` + `#357` + Trusted Publish `34013658849`) |
 | 6.19.1 | Reserved patch | Reader/failure-fact compatibility corrections only |
 | 6.20.0 | Flexible deterministic contracts | #308/#315 ordering modes; #309 alternate valid paths |
 | 6.21.0 | Multi-agent evidence precision | #320 actor scope; #321 outcome provenance |
@@ -25,8 +25,8 @@
 | `phase0-roadmap-truth` | done |
 | `6.17.8 A–E` | done (published) |
 | `6.18.0 A–H` | done (published) |
-| `6.19.0 A–D` | done (`#354` merged; Version Packages `#357`) |
-| `6.20–6.22 labels only` | **Phase 4** — docs + GitHub label/comment hygiene (no implementation) |
+| `6.19.0 A–D` | done (published on npm) |
+| `6.20–6.22 labels only` | done (`#358`) |
 
 ## Issue → train labels (Phase 4)
 


### PR DESCRIPTION
## Summary
- Mark `agent-inspect@6.19.0` as published (Trusted Publish run 34013658849).
- Refresh CURRENT-TASK / RELEASE-TRAIN-STATE / NEXT-RELEASES after `#354` / `#357` / `#358`.
- Note `#355` closed; next action is authorize 6.20.0.

## Test plan
- [x] `npm view agent-inspect version` → 6.19.0
- [x] Publish workflow success
- Docs-only; no package code changes