### PR TITLE
fix(cli): fail closed on corrupt index snapshots

### DIFF
--- a/packages/cli/src/index-cmd.ts
+++ b/packages/cli/src/index-cmd.ts
@@ -30,8 +30,17 @@ async function readSnapshot(indexPath: string): Promise<TraceIndexSnapshot | und
   try {
     const raw = await readFile(indexPath, "utf8");
     return JSON.parse(raw) as TraceIndexSnapshot;
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return undefined;
+    }
+
+    throw error;
   }
 }
 

--- a/packages/cli/test/index-cmd.test.ts
+++ b/packages/cli/test/index-cmd.test.ts
@@ -18,6 +18,8 @@ describe("index CLI", () => {
     if (tmpDir) {
       await indexCleanCommand({ dir: tmpDir, json: true });
     }
+    process.exitCode = 0;
+    vi.restoreAllMocks();
   });
 
   it("builds and reports index status", async () => {
@@ -60,6 +62,33 @@ describe("index CLI", () => {
 
     await indexCleanCommand({ dir: tmpDir });
     expect(traceIndexPath(tmpDir)).toContain(".agent-inspect-index.json");
-    logSpy.mockRestore();
+  });
+
+  it("reports a missing index as an available rebuild", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "ai-index-"));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await indexStatusCommand({ dir: tmpDir, json: true });
+
+    const statusPayload = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+    expect(statusPayload).toMatchObject({ ok: true, exists: false, stale: true });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("fails closed when the index snapshot contains malformed JSON", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "ai-index-"));
+    await writeFile(traceIndexPath(tmpDir), "{broken", "utf8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await indexStatusCommand({ dir: tmpDir, json: true });
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[AgentInspect] index status failed:"),
+    );
+    expect(process.exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Treat only `ENOENT` as a missing JSON index when reading `.agent-inspect-index.json`.
- Propagate malformed JSON and other read failures so `index status` fails closed instead of reporting `ok: true, exists: false`.
- Add regression coverage for valid, missing, and malformed index states while preserving the existing missing-index behavior.

<!-- What does this PR change and why? -->

**Linked issue:** #360 

**Close:** #360 

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Documentation only
- [ ] Example / recipe / fixture
- [x] Test / regression coverage
- [ ] Feature or enhancement (scoped)
- [ ] Breaking change (requires major version plan, maintainer approval required)

## Reproduction / evidence

Before this change, `readSnapshot()` returned `undefined` for every read or parse failure. As a result, a malformed `.agent-inspect-index.json` was indistinguishable from a genuinely missing index.

A synthetic malformed index such as:

```text
{broken
```

could make:

```powershell
node packages/cli/dist/index.cjs index status --dir $TraceDir --json
```

report a successful missing-index state with exit code `0`.

**Before screenshot**
<img width="608" height="217" alt="2026-09-06-204251" src="https://github.com/user-attachments/assets/4f990fec-a7b3-43f1-a829-3b0e1546f71f" />

The fix now defensively checks the caught value and only converts `error.code === "ENOENT"` to the existing missing-index state. Malformed JSON and all other failures are rethrown to the existing `index status` command error boundary.

After the change, the same malformed synthetic index produces an error such as:

```text
[AgentInspect] index status failed: Expected property name or '}' in JSON at position 1 (line 1 column 2)
Exit code = 1
```

**After screenshot**

<img width="681" height="121" alt="2026-09-06-204304" src="https://github.com/user-attachments/assets/3560aca4-cf89-46e6-8ac8-efbdbad6f0eb" />

Focused coverage now locks in the three relevant states:

```text
valid index      -> exists=true
missing index    -> ok=true, exists=false, stale=true
malformed index  -> command failure, exit code 1
```

The scope intentionally does not add runtime validation for structurally invalid but syntactically valid snapshots, atomic index writes, a new JSON error envelope, or new exit codes.

## Product boundaries (check all that apply)

- [x] Local-first only, no network upload added
- [x] No new vendor sinks
- [x] No SaaS / dashboard scope added
- [x] Persisted schema compatibility preserved (`schemaVersion` 0.1/0.2/1.0 traces stay readable)
- [x] No `step_failed` event introduced
- [x] `inspectRun` default tracing behavior unchanged
- [x] Redaction, size bounds, and privacy defaults not weakened

## Packages touched

- [x] `agent-inspect` (root: core + CLI, published)
- [ ] Framework adapters: `@agent-inspect/ai-sdk` / `openai-agents` / `langchain` / `mcp` / `adapter-sdk`
- [ ] Test reporters and gates: `@agent-inspect/vitest` / `jest` / `eval` / `guardrails` / `circuit` / `harness`
- [ ] Inspection surfaces: `@agent-inspect/viewer` / `tui` / `studio` / `mcp-server` / `index-sqlite` / `redact`
- [x] Private workspace internals (`packages/core`, `packages/cli`, ships via root `agent-inspect`)
- [ ] Docs / fixtures / recipes / community only

## Validation

```text
pnpm exec vitest run packages/cli/test/index-cmd.test.ts
PASS, 3/3 tests

pnpm build
PASS

pnpm typecheck
PASS

pnpm size
PASS, 12.02 kB / 120 kB

pnpm fixtures:check
PASS

pnpm repo:health
PASS

pnpm pack:smoke
PASS after rerunning with elevated permissions

git diff --check
PASS

pnpm test
2050/2055 tests passed
```

The five remaining full-suite failures match the existing Windows baseline and are unrelated to these two modified files:

```text
4 symlink tests fail with Windows EPERM
1 Windows drive path is misclassified by the redaction URL regex
```

Rerunning with elevated permissions produced the same five failures.

I did not rerun `test:coverage` or `test:all` because they are blocked by the same known Windows baseline failures. The focused regression suite and the relevant build, typecheck, size, fixture, repository health, and package smoke validations all pass.

## Data safety

- [x] Synthetic data only, no real prompts, logs, tokens, or PII (fixture tokens use `sk_test_fake` / `Bearer fake-token` shapes)
- [x] Trace/log samples in the PR were redacted or generated from fixtures

The manual reproduction uses only this synthetic malformed content:

```text
{broken
```

## Release hygiene

- [x] No version bumps and **no Changesets**, maintainers own Changesets and releases
- [x] No new runtime dependencies without prior maintainer approval (root stays `chalk`, `commander`, `nanoid` only)
- [x] No publish, tag, or workflow changes

## Checklist

- [x] Linked issue explains the why (comment on the issue before large PRs)
- [x] Tests added or updated for behavior changes
- [ ] Docs updated when behavior or public API changes (`docs/API.md`, `docs/CLI.md`, `README.md`)
- [x] `git diff --check` clean

Docs were not changed because this patch does not introduce a new public API, persisted schema, JSON failure schema, or exit-code contract. It restores malformed index reads to the existing command-error path.